### PR TITLE
Add decoder to @Body property wrapper

### DIFF
--- a/Tests/ApodiniTests/CustomCompoentTest.swift
+++ b/Tests/ApodiniTests/CustomCompoentTest.swift
@@ -17,7 +17,7 @@ final class CustomComponentTests: ApodiniTests {
         @Apodini.Database
         var database: Fluent.Database
         
-        @Body
+        @Body(decoder: JSONDecoder())
         var bird: Bird
         
         


### PR DESCRIPTION
I've added a decoder property conforming to the new protocol `DataDecoder` to  `Body`. This enables us to express the expected format / encoding of the `Body`.