### PR TITLE
Move decoding of request to SemanticModelBuilder implementation

### DIFF
--- a/Sources/Apodini/Request/Body.swift
+++ b/Sources/Apodini/Request/Body.swift
@@ -27,12 +27,10 @@ public class Body<Element: Codable>: RequestInjectable {
     public init() { }
     
     
-    func inject(using request: Vapor.Request) throws {
-        guard let byteBuffer = request.body.data, let data = byteBuffer.getData(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes) else {
-            throw Vapor.Abort(.internalServerError, reason: "Could not read the HTTP request's body")
+    func inject(using request: Vapor.Request, with decoder: SemanticModelBuilder?) throws {
+        if let decoder = decoder {
+            element = try decoder.decode(Element.self, from: request)
         }
-        
-        element = try JSONDecoder().decode(Element.self, from: data)
     }
     
     func disconnect() {

--- a/Sources/Apodini/Request/Database.swift
+++ b/Sources/Apodini/Request/Database.swift
@@ -27,7 +27,7 @@ public class Database: RequestInjectable {
     public init() { }
     
     
-    func inject(using request: Vapor.Request) throws {
+    func inject(using request: Vapor.Request, with decoder: SemanticModelBuilder? = nil) throws {
         self.database = request.db
     }
     

--- a/Sources/Apodini/Request/Request.swift
+++ b/Sources/Apodini/Request/Request.swift
@@ -25,7 +25,7 @@ public class Request: RequestInjectable {
     public init() { }
     
     
-    func inject(using request: Vapor.Request) throws {
+    func inject(using request: Vapor.Request, with decoder: SemanticModelBuilder? = nil) throws {
         self.request = request
     }
     

--- a/Sources/Apodini/Request/RequestInjectable.swift
+++ b/Sources/Apodini/Request/RequestInjectable.swift
@@ -10,14 +10,15 @@ import Vapor
 
 
 protocol RequestInjectable {
-    func inject(using request: Vapor.Request) throws
+    func inject(using request: Vapor.Request, with decoder: SemanticModelBuilder?) throws
     func disconnect()
 }
 
 
 extension Vapor.Request {
-    func enterRequestContext<E, R>(with element: E, executing method: (E) -> EventLoopFuture<R>) -> EventLoopFuture<R> {
-        inject(in: element)
+    func enterRequestContext<E, R>(with element: E, using decoder: SemanticModelBuilder? = nil, executing method: (E) -> EventLoopFuture<R>)
+    -> EventLoopFuture<R> {
+        inject(in: element, using: decoder)
         
         return method(element)
             .map { response in
@@ -26,19 +27,19 @@ extension Vapor.Request {
             }
     }
     
-    func enterRequestContext<E, R>(with element: E, executing method: (E) -> R) -> R {
-        inject(in: element)
+    func enterRequestContext<E, R>(with element: E, using decoder: SemanticModelBuilder? = nil, executing method: (E) -> R) -> R {
+        inject(in: element, using: decoder)
         let response = method(element)
         disconnect(from: element)
         return response
     }
     
-    private func inject<E>(in element: E) {
+    private func inject<E>(in element: E, using decoder: SemanticModelBuilder? = nil) {
         // Inject all properties that can be injected using RequestInjectable
         for child in Mirror(reflecting: element).children {
             if let requestInjectable = child.value as? RequestInjectable {
                 do {
-                    try requestInjectable.inject(using: self)
+                    try requestInjectable.inject(using: self, with: decoder)
                 } catch {
                     fatalError("Could not inject a value into a \(child.label ?? "UNKNOWN") property wrapper.")
                 }

--- a/Sources/Apodini/Semantic Model Builder/Context.swift
+++ b/Sources/Apodini/Semantic Model Builder/Context.swift
@@ -21,7 +21,7 @@ class Context {
         contextNode.getContextValue(for: contextKey)
     }
     
-    func createRequestHandler<C: Component>(withComponent component: C)
+    func createRequestHandler<C: Component>(withComponent component: C, using decoder: SemanticModelBuilder)
     -> (Vapor.Request) -> EventLoopFuture<Vapor.Response> {
         return { (request: Vapor.Request) in
             let guardEventLoopFutures = self.contextNode.getContextValue(for: GuardContextKey.self)
@@ -33,7 +33,7 @@ class Context {
             return EventLoopFuture<Void>
                 .whenAllSucceed(guardEventLoopFutures, on: request.eventLoop)
                 .flatMap { _ in
-                    request.enterRequestContext(with: component) { component in
+                    request.enterRequestContext(with: component, using: decoder) { component in
                         var response: ResponseEncodable = component.handle()
                         for responseTransformer in self.contextNode.getContextValue(for: ResponseContextKey.self) {
                             response = request.enterRequestContext(with: responseTransformer()) { responseTransformer in

--- a/Sources/Apodini/Semantic Model Builder/REST/RESTSemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/RESTSemanticModelBuilder.swift
@@ -61,10 +61,18 @@ class RESTSemanticModelBuilder: SemanticModelBuilder {
         // We currently just register the component here using the functionality based of Vapor.
         // The next step would be to create a sophisticated semantic model based on the Context and Components and use this to register the components in a structured way and e.g. provide HATEOS information.
         
-        let requestHandler = context.createRequestHandler(withComponent: component)
+        let requestHandler = context.createRequestHandler(withComponent: component, using: self)
         RESTPathBuilder(context.get(valueFor: PathComponentContextKey.self))
             .routesBuilder(app)
             .on(context.get(valueFor: HTTPMethodContextKey.self), [], use: requestHandler)
+    }
+
+    override func decode<T: Decodable>(_ type: T.Type, from request: Vapor.Request) throws -> T? {
+        guard let byteBuffer = request.body.data, let data = byteBuffer.getData(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes) else {
+            throw Vapor.Abort(.internalServerError, reason: "Could not read the HTTP request's body")
+        }
+
+        return try JSONDecoder().decode(type, from: data)
     }
     
     

--- a/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
@@ -18,4 +18,7 @@ class SemanticModelBuilder {
     
     
     func register<C: Component>(component: C, withContext context: Context) { }
+    func decode<T: Decodable>(_ type: T.Type, from request: Vapor.Request) throws -> T? {
+        fatalError("decode must be overridden")
+    }
 }


### PR DESCRIPTION
**Note**: this is based on the work @hendesi already did in branch [database-access](https://github.com/Apodini/Apodini/commits/experimental/database-access).

I would like to move forward with this topic, as it will facilitate plugin in the gRPC decoding functionality (among others) in upcoming PRs.

As #14 was decided not to be the way to handle the decoding of `RequestInjectable`s, I want to propose another PR.
In this approach, the `SemanticModelBuilder`s would implement a `decode` method, and the `RequestInjectable`s forward the request to this method. This allows the `SemanticModelBuilder` to decide how to decode.

I would also ask @hendesi and @tgymnich to please take a look at this PR.

In particular, I would like to discuss (maybe in todays meeting) 
- whether we need multiple decoders handed over to the `RequestInjectable` (as implemented in [RequestInjectable in database-access](https://github.com/Apodini/Apodini/blob/75ec0401e2548faa0261da20daad5fd2e982cd9c/Sources/Apodini/Request/RequestInjectable.swift#L13)), or not. My version only hands over one decoder to the `RequestInjectable` at the moment (see [here](https://github.com/Apodini/Apodini/blob/b5499f54b36cd4a3035563d9bcdeb18f39bc2145/Sources/Apodini/Request/RequestInjectable.swift#L13)).
- whether we could also simply hand over the `TopLevelDecoder`s (such as `JSONDecoder` and my `ProtoDecoder`) directly, instead of adding the `decode` method to the `SemanticModelBuilder`s.