### PR TITLE
Resolve Package.resolved

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -65,6 +65,15 @@
         }
       },
       {
+        "package": "Runtime",
+        "repositoryURL": "https://github.com/wickwirew/Runtime.git",
+        "state": {
+          "branch": null,
+          "revision": "a848b81e1a0100801f572e5273ffe4352fd54088",
+          "version": "2.2.2"
+        }
+      },
+      {
         "package": "sql-kit",
         "repositoryURL": "https://github.com/vapor/sql-kit.git",
         "state": {


### PR DESCRIPTION
The PR https://github.com/Apodini/Apodini/pull/22 added the new dependency `Runtime`. The PR was based on a version of Apodini where the build cache wasn't yet in place and `Package.resolved` wasn't yet checked in.
https://github.com/Apodini/Apodini/pull/25 was then merged not properly considering the changes made in #22 (my fault), thus Package.resolve was not properly update to include `Runtime` dependency.

**Impact:** Latest action runs would still use a build cache which didn't include an already fetched `Runtime` dependency, thus every run would need to go the extra step of resolving that dependency resulting in slightly longer run times.

This PR restores the consistency between Package.resolved and Package.swift.