### PR TITLE
Moving Parameter Options to be defined at Exporter Level

### DIFF
--- a/Sources/Apodini/Request/Options/AnyPropertyOption.swift
+++ b/Sources/Apodini/Request/Options/AnyPropertyOption.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct AnyPropertyOption<Property> {
+    let key: AnyPropertyOptionKey
+    let value: Any
+
+    public init<Option>(key: PropertyOptionKey<Property, Option>, value: Option) {
+        self.key = key
+        self.value = value
+    }
+}

--- a/Sources/Apodini/Request/Options/PropertyOption.swift
+++ b/Sources/Apodini/Request/Options/PropertyOption.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public protocol PropertyOption {
+    /**
+        Combines two instances of the same type of option into a single one.
+        This can include any logic on how to combine these options.
+
+        Defaults to returning the left hand side
+     */
+    static func & (lhs: Self, rhs: Self) -> Self
+}
+
+extension PropertyOption where Self: OptionSet {
+
+    public static func & (lhs: Self, rhs: Self) -> Self {
+        return lhs.union(rhs)
+    }
+
+}
+
+extension PropertyOption {
+
+    public static func & (lhs: Self, rhs: Self) -> Self {
+        return lhs
+    }
+
+}

--- a/Sources/Apodini/Request/Options/PropertyOptionKey.swift
+++ b/Sources/Apodini/Request/Options/PropertyOptionKey.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public class AnyPropertyOptionKey : NSObject {
+    func combine(lhs: Any, rhs: Any) -> Any {
+        fatalError("AnyPropertyOptionKey.combine should be overridden!")
+    }
+}
+public class PropertyOptionKey<Property, Option: PropertyOption> : AnyPropertyOptionKey {
+    override func combine(lhs: Any, rhs: Any) -> Any {
+        // swiftlint:disable next
+        return (lhs as! Option) & (rhs as! Option)
+    }
+}

--- a/Sources/Apodini/Request/Options/PropertyOptionSet.swift
+++ b/Sources/Apodini/Request/Options/PropertyOptionSet.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public struct PropertyOptionSet<Property> {
+    private let options: [AnyPropertyOptionKey: Any]
+
+    public init() {
+        options = [:]
+    }
+
+    public init(_ options: [AnyPropertyOption<Property>]) {
+        var combined: [AnyPropertyOptionKey: Any] = [:]
+        for option in options {
+            if let lhs = combined[option.key] {
+                combined[option.key] = option.key.combine(lhs: lhs, rhs: option.value)
+            } else {
+                combined[option.key] = option.value
+            }
+        }
+
+        self.options = combined
+    }
+
+    public func option<Option>(for key: PropertyOptionKey<Property, Option>) -> Option? {
+        guard let option = options[key] else { return nil }
+        // swiftlint:disable next
+        return (option as! Option)
+    }
+}

--- a/Sources/Apodini/Semantic Model Builder/REST/HTTPParameterMode.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/HTTPParameterMode.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum HTTPParameterMode: PropertyOption {
+    case body
+    case path
+    case query
+}
+
+extension PropertyOptionKey where Property == ParameterOptionNameSpace, Option == HTTPParameterMode {
+    static let http = PropertyOptionKey<ParameterOptionNameSpace, HTTPParameterMode>()
+}
+
+extension AnyPropertyOption where Property == ParameterOptionNameSpace {
+    public static func http(_ mode: HTTPParameterMode) -> AnyPropertyOption<ParameterOptionNameSpace> {
+        return AnyPropertyOption(key: .http, value: mode)
+    }
+}

--- a/Sources/Apodini/Semantic Model Builder/WebSocket/WebSocketParameterMode.swift
+++ b/Sources/Apodini/Semantic Model Builder/WebSocket/WebSocketParameterMode.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public enum WebSocketParameterMode: PropertyOption {
+    case constant
+    case stream
+}
+
+extension PropertyOptionKey where Property == ParameterOptionNameSpace, Option == WebSocketParameterMode {
+    static let webSocket = PropertyOptionKey<ParameterOptionNameSpace, WebSocketParameterMode>()
+}
+
+extension AnyPropertyOption where Property == ParameterOptionNameSpace {
+    public static func webSocket(_ mode: WebSocketParameterMode) -> AnyPropertyOption<ParameterOptionNameSpace> {
+        return AnyPropertyOption(key: .webSocket, value: mode)
+    }
+}


### PR DESCRIPTION
This PR changes the manifesto and Parameter property wrapper to use an option set defined at the exporter level.
Basically acting as a key store for each exporter.

This has the benefit that we don't have to use abstract concepts such as lightweight, and can be more explicit without coupling the Property Wrapper with HTTP specific knowledge.

This has the downside of making some options less easy to discover, but I think that autocomplete might be good enough for it