### PR TITLE
Fix SPM Warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,8 @@ let package = Package(
                 .product(name: "Fluent", package: "fluent"),
                 .product(name: "AssociatedTypeRequirementsKit", package: "AssociatedTypeRequirementsKit"),
                 .product(name: "Runtime", package: "Runtime")
-            ]
+            ],
+            exclude: ["Components/ComponentBuilder.swift.gyb"]
         ),
         .testTarget(
             name: "ApodiniTests",


### PR DESCRIPTION
I fixed a spm warning by excluding Components/ComponentBuilder.swift.gyb