### PR TITLE
Disable conditional_returns_on_newline rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -31,8 +31,6 @@ only_rules:
     # The initializers declared in compiler protocols such as ExpressibleByArrayLiteral shouldn't be called directly.
   - computed_accessors_order
     # Getter and setters in computed properties and subscripts should be in a consistent order.
-  - conditional_returns_on_newline
-    # Conditional statements should always return on the next line
   - contains_over_filter_count
     # Prefer contains over comparing filter(where:).count to 0.
   - contains_over_filter_is_empty


### PR DESCRIPTION
I'd like to disable the conditional_returns_on_newline SwiftLint rule.
When I am dealing with a simple error, I want to get it out of the way as fast as possible. I don't want to spent another 2 lines of code returning nil.

```
guard let x = x else { return nil }
```