### PR TITLE
Shared Semantic Model R2

### DIFF
--- a/Sources/Apodini/Request/Parameter.swift
+++ b/Sources/Apodini/Request/Parameter.swift
@@ -12,18 +12,6 @@ import Foundation
 /// Generic Parameter that can be used to mark that the options are meant for `@Parameter`s
 public enum ParameterOptionNameSpace { }
 
-/// This enum defines the properties of `Parameter` as string constants.
-/// When refactoring `Parameter` please ensure to keep them up to date.
-/// Those can be used for any kind of runtime reflection.
-enum ParameterProperties {
-    static let id = "id"
-    static let name = "name"
-    static let element = "element"
-    static let options = "options"
-    static let defaultValue = "defaultValue"
-    static let wrappedValue = "wrappedValue"
-}
-
 /// The `@Parameter` property wrapper can be used to express input in `Components`
 @propertyWrapper
 public struct Parameter<Element: Codable> {
@@ -36,7 +24,7 @@ public struct Parameter<Element: Codable> {
     var id = UUID()
     var name: String?
     private var element: Element?
-    private var options: PropertyOptionSet<ParameterOptionNameSpace>
+    internal var options: PropertyOptionSet<ParameterOptionNameSpace>
     private var defaultValue: Element?
     
     
@@ -99,6 +87,10 @@ extension Parameter: RequestInjectable {
             element = try decoder.decode(Element.self, from: request)
         }
     }
+
+    func visit(_ visitor: RequestInjectableVisitor) {
+        visitor.register(self)
+    }
 }
 
 
@@ -108,6 +100,6 @@ extension Parameter: _PathComponent {
     }
     
     func append<P>(to pathBuilder: inout P) where P: PathBuilder {
-        pathBuilder.append(":\(self.id)")
+        pathBuilder.append(self)
     }
 }

--- a/Sources/Apodini/Request/Parameter.swift
+++ b/Sources/Apodini/Request/Parameter.swift
@@ -88,8 +88,8 @@ extension Parameter: RequestInjectable {
         }
     }
 
-    func visit(_ visitor: RequestInjectableVisitor) {
-        visitor.register(self)
+    func accept(_ visitor: RequestInjectableVisitor) {
+        visitor.visit(self)
     }
 }
 

--- a/Sources/Apodini/Request/RequestInjectable.swift
+++ b/Sources/Apodini/Request/RequestInjectable.swift
@@ -12,11 +12,29 @@ import Runtime
 
 protocol RequestInjectable {
     mutating func inject(using request: Vapor.Request, with decoder: RequestInjectableDecoder?) throws
+    func visit(_ visitor: RequestInjectableVisitor)
+}
+
+extension RequestInjectable {
+    func visit(_ visitor: RequestInjectableVisitor) {
+        visitor.register(self)
+    }
 }
 
 protocol RequestInjectableDecoder {
     func decode<T: Decodable>(_ type: T.Type, from request: Vapor.Request) throws -> T?
 }
+
+protocol RequestInjectableVisitor {
+    func register<Injectable: RequestInjectable>(_ requestInjectable: Injectable)
+
+    func register<Element>(_ parameter: Parameter<Element>)
+}
+extension RequestInjectableVisitor {
+    func register<Injectable: RequestInjectable>(_ requestInjectable: Injectable) {}
+    func register<Element>(_ parameter: Parameter<Element>) {}
+}
+
 
 private func extractRequestInjectables(from subject: Any) -> [String: RequestInjectable] {
     Mirror(reflecting: subject).children.reduce(into: [String: RequestInjectable]()) { result, child in

--- a/Sources/Apodini/Request/RequestInjectable.swift
+++ b/Sources/Apodini/Request/RequestInjectable.swift
@@ -12,12 +12,12 @@ import Runtime
 
 protocol RequestInjectable {
     mutating func inject(using request: Vapor.Request, with decoder: RequestInjectableDecoder?) throws
-    func visit(_ visitor: RequestInjectableVisitor)
+    func accept(_ visitor: RequestInjectableVisitor)
 }
 
 extension RequestInjectable {
-    func visit(_ visitor: RequestInjectableVisitor) {
-        visitor.register(self)
+    func accept(_ visitor: RequestInjectableVisitor) {
+        visitor.visit(self)
     }
 }
 
@@ -26,13 +26,13 @@ protocol RequestInjectableDecoder {
 }
 
 protocol RequestInjectableVisitor {
-    func register<Injectable: RequestInjectable>(_ requestInjectable: Injectable)
+    func visit<Injectable: RequestInjectable>(_ requestInjectable: Injectable)
 
-    func register<Element>(_ parameter: Parameter<Element>)
+    func visit<Element>(_ parameter: Parameter<Element>)
 }
 extension RequestInjectableVisitor {
-    func register<Injectable: RequestInjectable>(_ requestInjectable: Injectable) {}
-    func register<Element>(_ parameter: Parameter<Element>) {}
+    func visit<Injectable: RequestInjectable>(_ requestInjectable: Injectable) {}
+    func visit<Element>(_ parameter: Parameter<Element>) {}
 }
 
 

--- a/Sources/Apodini/Semantic Model Builder/EndpointParameter.swift
+++ b/Sources/Apodini/Semantic Model Builder/EndpointParameter.swift
@@ -5,7 +5,6 @@
 //  Created by Lorena Schlesinger on 06.12.20.
 //
 
-import Runtime
 import Foundation
 
 struct EndpointParameter {
@@ -23,57 +22,86 @@ struct EndpointParameter {
         case path
     }
 
-    static func create(from requestInjectables: [String: RequestInjectable]) -> [EndpointParameter] {
-        requestInjectables
-            .compactMap {
-                create(from: $0.value, label: $0.key)
-            }
+    init(id: UUID, name: String?, label: String, contentType: Any.Type, options: PropertyOptionSet<ParameterOptionNameSpace>) {
+        self.id = id
+        self.name = name
+        self.label = label
+        self.contentType = contentType
+        self.options = options
+
+        let httpOption = options.option(for: PropertyOptionKey.http)
+        switch httpOption {
+        case .path:
+            precondition(contentType is LosslessStringConvertible.Type, "Invalid explicit option .path for parameter \(name ?? label). Option is only available for wrapped properties conforming to \(LosslessStringConvertible.self).")
+            parameterType = .path
+        case .query:
+            precondition(contentType is LosslessStringConvertible.Type, "Invalid explicit option .query for parameter \(name ?? label). Option is only available for wrapped properties conforming to \(LosslessStringConvertible.self).")
+            parameterType = .lightweight
+        case .body:
+            parameterType = .content
+        default:
+            parameterType = contentType is LosslessStringConvertible.Type ? .lightweight : .content
+        }
     }
-    
-    static func create(from requestInjectable: RequestInjectable, label: String) -> EndpointParameter? {
-        guard let info: TypeInfo = try? typeInfo(of: type(of: requestInjectable)) else {
-            return nil
+}
+
+class ParameterBuilder: RequestInjectableVisitor {
+    let requestInjectables: [String: RequestInjectable]
+    var currentLabel: String?
+
+    var parameters: [EndpointParameter] = []
+
+    init(from requestInjectables: [String: RequestInjectable]) {
+        self.requestInjectables = requestInjectables
+    }
+
+    func build() {
+        for (label, requestInjectable) in requestInjectables {
+            currentLabel = label
+            requestInjectable.visit(self)
         }
-        /// Parameter<String> serves as representative `parameterType` of any Parameter<T> as  `mangeldName` of all Parameter<T> is `Parameter`
-        let parameterType = try? typeInfo(of: Parameter<String>.self)
-        if info.mangledName == parameterType?.mangledName {
-            let mirror = Mirror(reflecting: requestInjectable)
-            // swiftlint:disable:next force_cast
-            let id = mirror.children.first { $0.label == ParameterProperties.id }!.value as! UUID
-            let name = mirror.children.first { $0.label == ParameterProperties.name }?.value as? String
-            let contentType = info.genericTypes[0]
-            // swiftlint:disable:next force_cast
-            let options = mirror.children.first { $0.label == ParameterProperties.options }!.value as! PropertyOptionSet<ParameterOptionNameSpace>
-            
-            let parameterType: EndpointParameter.EndpointParameterType = {
-                var result: EndpointParameter.EndpointParameterType = .lightweight
-                let isLosslessStringConvertible = contentType is LosslessStringConvertible.Type
-                let option = options.option(for: PropertyOptionKey.http)
-                switch option {
-                case .path:
-                    precondition(isLosslessStringConvertible, "Invalid explicit option .path for parameter \(name ?? label). Option is only available for wrapped properties conforming to \(LosslessStringConvertible.self).")
-                    result = .path
-                case .query:
-                    precondition(isLosslessStringConvertible, "Invalid explicit option .query for parameter \(name ?? label). Option is only available for wrapped properties conforming to \(LosslessStringConvertible.self).")
-                    result = .lightweight
-                case .body:
-                    result = .content
-                default:
-                    if !isLosslessStringConvertible {
-                        result = .content
-                    }
-                }
-                return result
-            }()
-            
-            return EndpointParameter(
-                id: id,
-                name: name,
+        currentLabel = nil
+    }
+
+    func register<Element>(_ parameter: Parameter<Element>) {
+        guard let label = currentLabel else {
+            preconditionFailure("EndpointParameter visited a Parameter where current label wasn't set. Something must have been called out of order!")
+        }
+
+        let endpointParameter = EndpointParameter(
+                id: parameter.id,
+                name: parameter.name,
                 label: label,
-                contentType: contentType,
-                options: options,
-                parameterType: parameterType)
-        }
-        return nil
+                contentType: Element.self,
+                options: parameter.options
+        )
+
+        parameters.append(endpointParameter)
+    }
+}
+
+struct PathComponentAnalyzer: PathBuilder {
+    struct PathParameterAnalyzingResult {
+        var parameterMode: HTTPParameterMode?
+    }
+
+    var result: PathParameterAnalyzingResult?
+
+    mutating func append<T>(_ parameter: Parameter<T>) {
+        result = PathParameterAnalyzingResult(
+                parameterMode: parameter.option(for: .http)
+        )
+    }
+
+    mutating func append(_ string: String) {}
+
+    /// This function does two things:
+    ///   * First it checks if the given `_PathComponent` is if type Parameter. If it is it returns
+    ///     a `PathParameterAnalyzingResult` otherwise it returns nil.
+    ///   * Secondly it retrieves the .http ParameterOption for the Parameter which is stored in the `PathParameterAnalyzingResult`
+    static func analyzePathComponentForParameter(_ pathComponent: _PathComponent) -> PathParameterAnalyzingResult? {
+        var analyzer = PathComponentAnalyzer()
+        pathComponent.append(to: &analyzer)
+        return analyzer.result
     }
 }

--- a/Sources/Apodini/Semantic Model Builder/EndpointParameter.swift
+++ b/Sources/Apodini/Semantic Model Builder/EndpointParameter.swift
@@ -58,12 +58,12 @@ class ParameterBuilder: RequestInjectableVisitor {
     func build() {
         for (label, requestInjectable) in requestInjectables {
             currentLabel = label
-            requestInjectable.visit(self)
+            requestInjectable.accept(self)
         }
         currentLabel = nil
     }
 
-    func register<Element>(_ parameter: Parameter<Element>) {
+    func visit<Element>(_ parameter: Parameter<Element>) {
         guard let label = currentLabel else {
             preconditionFailure("EndpointParameter visited a Parameter where current label wasn't set. Something must have been called out of order!")
         }

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter.swift
@@ -9,11 +9,11 @@ protocol InterfaceExporter: RequestInjectableDecoder {
 
     func export(_ endpoint: Endpoint)
 
-    func finishedExporting(_ root: EndpointsTreeNode)
+    func finishedExporting(_ webService: WebServiceModel)
 
     func decode<T: Decodable>(_ type: T.Type, from request: Vapor.Request) throws -> T?
 }
 
 extension InterfaceExporter {
-    func finishedExporting(_ root: EndpointsTreeNode) {}
+    func finishedExporting(_ webService: WebServiceModel) {}
 }

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter.swift
@@ -7,7 +7,13 @@ import Vapor
 protocol InterfaceExporter: RequestInjectableDecoder {
     init(_ app: Application)
 
-    func export(_ node: EndpointsTreeNode)
+    func export(_ endpoint: Endpoint)
+
+    func finishedExporting(_ root: EndpointsTreeNode)
 
     func decode<T: Decodable>(_ type: T.Type, from request: Vapor.Request) throws -> T?
+}
+
+extension InterfaceExporter {
+    func finishedExporting(_ root: EndpointsTreeNode) {}
 }

--- a/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
@@ -66,27 +66,31 @@ class RESTInterfaceExporter: InterfaceExporter {
         self.app = app
     }
 
-    func export(_ node: EndpointsTreeNode) {
-        exportEndpoints(node)
+    func export(_ endpoint: Endpoint) {
+        let pathBuilder = RESTPathBuilder(endpoint.absolutePath)
+        let routesBuilder = pathBuilder.routesBuilder(app)
 
-        for child in node.children {
-            export(child)
+        let operation = endpoint.operation
+        let requestHandler = createRequestHandler(for: endpoint)
+
+        routesBuilder.on(operation.httpMethod, [], use: requestHandler)
+
+        app.logger.info("\(pathBuilder.pathDescription) + \(operation.httpMethod.rawValue) with \(endpoint.guards.count) guards.")
+
+        for relationship in endpoint.relationships {
+            let path = relationship.destinationPath
+            app.logger.info("  - links to: \(StringPathBuilder(path).build())")
         }
     }
 
-    func exportEndpoints(_ node: EndpointsTreeNode) {
-        let pathBuilder = RESTPathBuilder(node.absolutePath)
-        let routesBuilder = pathBuilder.routesBuilder(app)
+    func finishedExporting(_ root: EndpointsTreeNode) {
+        if root.endpoints.count == 0 {
+            // if the root path doesn't have endpoints we need to create a custom one to deliver linking entry points.
 
-        for (operation, endpoint) in node.endpoints {
-            let requestHandler = createRequestHandler(for: endpoint)
-            routesBuilder.on(operation.httpMethod, [], use: requestHandler)
-
-            app.logger.info("\(pathBuilder.pathDescription) + \(operation.httpMethod.rawValue) with \(endpoint.guards.count) guards.")
-
-            for linkedNode in node.children {
-                let pathComponents = linkedNode.absolutePath
-                app.logger.info("  - links to: \(StringPathBuilder(pathComponents).build())")
+            for relationship in root.relationships {
+                app.logger.info("/ + \(HTTPMethod.GET.rawValue)")
+                let path = relationship.destinationPath
+                app.logger.info("  - links to: \(StringPathBuilder(path).build())")
             }
         }
     }

--- a/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
@@ -83,11 +83,11 @@ class RESTInterfaceExporter: InterfaceExporter {
         }
     }
 
-    func finishedExporting(_ root: EndpointsTreeNode) {
-        if root.endpoints.count == 0 {
+    func finishedExporting(_ webService: WebServiceModel) {
+        if webService.rootEndpoints.count == 0 {
             // if the root path doesn't have endpoints we need to create a custom one to deliver linking entry points.
 
-            for relationship in root.relationships {
+            for relationship in webService.relationships {
                 app.logger.info("/ + \(HTTPMethod.GET.rawValue)")
                 let path = relationship.destinationPath
                 app.logger.info("  - links to: \(StringPathBuilder(path).build())")

--- a/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
@@ -19,7 +19,7 @@ class SemanticModelBuilder: RequestInjectableDecoder {
         // Overwritten by subclasses of the SemanticModelBuilder
     }
 
-    func finishedProcessing() {
+    func finishedRegistration() {
         // Can be overwritten to run action once the component tree was parsed
     }
     

--- a/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
@@ -23,6 +23,9 @@ class SharedSemanticModelBuilder: SemanticModelBuilder {
 
         let requestInjectables = component.extractRequestInjectables()
 
+        let parameterBuilder = ParameterBuilder(from: requestInjectables)
+        parameterBuilder.build()
+
         var endpoint = Endpoint(
                 description: String(describing: component),
                 context: context,
@@ -31,7 +34,8 @@ class SharedSemanticModelBuilder: SemanticModelBuilder {
                 requestInjectables: requestInjectables,
                 handleMethod: component.handle,
                 responseTransformers: responseModifiers,
-                handleReturnType: C.Response.self
+                handleReturnType: C.Response.self,
+                parameters: parameterBuilder.parameters
         )
 
         if endpointsTreeRoot == nil {

--- a/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
@@ -4,12 +4,34 @@
 
 import Vapor
 
+class WebServiceModel {
+    fileprivate let root: EndpointsTreeNode = EndpointsTreeNode(path: RootPath())
+    fileprivate var finishedParsing = false
+
+    lazy var rootEndpoints: [Endpoint] = {
+        if !finishedParsing {
+            fatalError("rootEndpoints of the WebServiceModel was accessed before parsing was finished!")
+        }
+        return root.endpoints.map { _, endpoint -> Endpoint in endpoint }
+    }()
+    var relationships: [EndpointRelationship] {
+        root.relationships
+    }
+
+    fileprivate func addEndpoint(_ endpoint: inout Endpoint, at paths: [PathComponent]) {
+        root.addEndpoint(&endpoint, at: paths)
+    }
+}
+
 class SharedSemanticModelBuilder: SemanticModelBuilder {
     private var interfaceExporters: [InterfaceExporter]
-    var endpointsTreeRoot: EndpointsTreeNode?
+
+    var webService: WebServiceModel
 
     init(_ app: Application, interfaceExporters: InterfaceExporter.Type...) {
         self.interfaceExporters = interfaceExporters.map { exporterType in exporterType.init(app) }
+        webService = WebServiceModel()
+
         super.init(app)
     }
 
@@ -38,32 +60,26 @@ class SharedSemanticModelBuilder: SemanticModelBuilder {
                 parameters: parameterBuilder.parameters
         )
 
-        if endpointsTreeRoot == nil {
-            endpointsTreeRoot = EndpointsTreeNode(path: RootPath())
-        }
-
         for parameter in endpoint.parameters {
             let pathDescription = ":\(parameter.id)"
             if parameter.parameterType == .path && !paths.contains(where: { ($0 as? _PathComponent)?.description == pathDescription }) {
                 paths.append(pathDescription)
             }
         }
-        // swiftlint:disable:next force_unwrapping
-        endpointsTreeRoot!.addEndpoint(&endpoint, at: paths)
+
+        webService.addEndpoint(&endpoint, at: paths)
     }
 
     override func finishedRegistration() {
         super.finishedRegistration()
 
-        guard let node = endpointsTreeRoot else {
-            return
-        }
+        webService.finishedParsing = true
 
-        node.printTree() // currently only for debugging purposes
+        webService.root.printTree() // currently only for debugging purposes
 
         for exporter in interfaceExporters {
-            call(exporter: exporter, for: node)
-            exporter.finishedExporting(node)
+            call(exporter: exporter, for: webService.root)
+            exporter.finishedExporting(webService)
         }
     }
 

--- a/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
@@ -52,8 +52,8 @@ class SharedSemanticModelBuilder: SemanticModelBuilder {
         endpointsTreeRoot!.addEndpoint(&endpoint, at: paths)
     }
 
-    override func finishedProcessing() {
-        super.finishedProcessing()
+    override func finishedRegistration() {
+        super.finishedRegistration()
 
         guard let node = endpointsTreeRoot else {
             return
@@ -62,7 +62,18 @@ class SharedSemanticModelBuilder: SemanticModelBuilder {
         node.printTree() // currently only for debugging purposes
 
         for exporter in interfaceExporters {
-            exporter.export(node)
+            call(exporter: exporter, for: node)
+            exporter.finishedExporting(node)
+        }
+    }
+
+    private func call(exporter: InterfaceExporter, for node: EndpointsTreeNode) {
+        for (_, endpoint) in node.endpoints {
+            exporter.export(endpoint)
+        }
+
+        for child in node.children {
+            call(exporter: exporter, for: child)
         }
     }
 

--- a/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
@@ -27,10 +27,12 @@ class SharedSemanticModelBuilder: SemanticModelBuilder {
     private var interfaceExporters: [InterfaceExporter]
 
     var webService: WebServiceModel
+    var rootNode: EndpointsTreeNode
 
     init(_ app: Application, interfaceExporters: InterfaceExporter.Type...) {
         self.interfaceExporters = interfaceExporters.map { exporterType in exporterType.init(app) }
         webService = WebServiceModel()
+        rootNode = webService.root // used to provide the unit test a reference to the root of the tree
 
         super.init(app)
     }

--- a/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
@@ -63,7 +63,7 @@ class SyntaxTreeVisitor {
 
             if currentNode.parentContextNode == nil { // we exited to the top level node, thus we can call postProcessing
                 for builder in semanticModelBuilders {
-                    builder.finishedProcessing()
+                    builder.finishedRegistration()
                 }
             }
         } else {

--- a/Sources/TestWebService/main.swift
+++ b/Sources/TestWebService/main.swift
@@ -64,7 +64,7 @@ struct TestWebService: Apodini.WebService {
             Text("Hello Swift! 💻")
                 .response(EmojiMediator())
                 .guard(PrintGuard())
-            Group("5") {
+            Group("5", "3") {
                 Text("Hello Swift 5! 💻")
             }
         }.guard(PrintGuard("Someone is accessing Swift 😎!!"))

--- a/Tests/ApodiniTests/EndpointsTreeTests.swift
+++ b/Tests/ApodiniTests/EndpointsTreeTests.swift
@@ -52,6 +52,9 @@ final class EndpointsTreeTests: XCTestCase {
         let testHandler = try XCTUnwrap(testComponent.content.content as? TestHandler)
         
         let requestInjectables: [String: RequestInjectable] = testHandler.extractRequestInjectables()
+        let parameterBuilder = ParameterBuilder(from: requestInjectables)
+        parameterBuilder.build()
+
         var endpoint = Endpoint(
                 description: String(describing: testHandler),
                 context: Context(contextNode: ContextNode()),
@@ -60,7 +63,8 @@ final class EndpointsTreeTests: XCTestCase {
                 requestInjectables: requestInjectables,
                 handleMethod: testHandler.handle,
                 responseTransformers: [],
-                handleReturnType: TestHandler.Response.self
+                handleReturnType: TestHandler.Response.self,
+                parameters: parameterBuilder.parameters
         )
         
         let parameters: [EndpointParameter] = endpoint.parameters

--- a/Tests/ApodiniTests/EndpointsTreeTests.swift
+++ b/Tests/ApodiniTests/EndpointsTreeTests.swift
@@ -55,7 +55,7 @@ final class EndpointsTreeTests: XCTestCase {
         let parameterBuilder = ParameterBuilder(from: requestInjectables)
         parameterBuilder.build()
 
-        var endpoint = Endpoint(
+        let endpoint = Endpoint(
                 description: String(describing: testHandler),
                 context: Context(contextNode: ContextNode()),
                 operation: Operation.automatic,

--- a/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
+++ b/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
@@ -79,13 +79,13 @@ final class SharedSemanticModelBuilderTests: XCTestCase {
         }.visit(visitor)
         
         let nameParameterId: UUID = testComponent.$name.id
-        let treeNodeA: EndpointsTreeNode = modelBuilder.endpointsTreeRoot!.children.first!
+        let treeNodeA: EndpointsTreeNode = modelBuilder.rootNode.children.first!
         let treeNodeB: EndpointsTreeNode = treeNodeA.children.first { $0.path.description == "b" }!
         let treeNodeNameParameter: EndpointsTreeNode = treeNodeB.children.first!
         let treeNodeSomeOtherIdParameter: EndpointsTreeNode = treeNodeA.children.first { $0.path.description != "b" }!
-        var endpointGroupLevel: Endpoint = treeNodeSomeOtherIdParameter.endpoints.first!.value
+        let endpointGroupLevel: Endpoint = treeNodeSomeOtherIdParameter.endpoints.first!.value
         let someOtherIdParameterId: UUID = endpointGroupLevel.parameters.first { $0.name == "someOtherId" }!.id
-        var endpoint: Endpoint = treeNodeNameParameter.endpoints.first!.value
+        let endpoint: Endpoint = treeNodeNameParameter.endpoints.first!.value
         
         XCTAssertEqual(treeNodeA.endpoints.count, 0)
         XCTAssertEqual(treeNodeB.endpoints.count, 0)
@@ -101,7 +101,7 @@ final class SharedSemanticModelBuilderTests: XCTestCase {
         
         // test nested use of path parameter that is only set inside `Handler` (i.e. `TestHandler2`)
         let treeNodeSomeIdParameter: EndpointsTreeNode = treeNodeNameParameter.children.first!
-        var nestedEndpoint: Endpoint = treeNodeSomeIdParameter.endpoints.first!.value
+        let nestedEndpoint: Endpoint = treeNodeSomeIdParameter.endpoints.first!.value
         let someIdParameterId: UUID = nestedEndpoint.parameters.first { $0.name == "someId" }!.id
         
         XCTAssertEqual(nestedEndpoint.parameters.count, 2)


### PR DESCRIPTION
This is a minor revision to the shared semantic model.

This PR contains two changes:

* d24c571: I found a way to completely eliminate the use of the Runtime framework, the idea really just came randomly to my mind 😅. It uses a basic Visitor pattern to get to the type information. As you @lschlesinger are the code owner of that part of the shared model, would be great if you could leave a code review.  
This commit also fixes an issue where a PathParameter would always be passed as a string representation to the PathBuilder.

* 6a6dc97 improves on the `InterfaceExporter` interface. When discussing the needs of other exporters like gRPC with @moritzschuell, we found that the exporter doesn't really need to get a reference to the individual nodes of the EndpointsTree. Thus the `InterfaceExporter.export`  was changed to be called for every endpoint in the tree.