### PR TITLE
Fix typo in SyntaxTreeVisitor class name

### DIFF
--- a/Sources/Apodini/Components/AnyComponent.swift
+++ b/Sources/Apodini/Components/AnyComponent.swift
@@ -9,7 +9,7 @@ import Vapor
 
 
 public struct AnyComponent: Component {
-    private let _visit: (_ visitor: SynaxTreeVisitor) -> Void
+    private let _visit: (_ visitor: SyntaxTreeVisitor) -> Void
     
     
     init<C: Component>(_ component: C) {
@@ -19,7 +19,7 @@ public struct AnyComponent: Component {
 
 
 extension AnyComponent: Visitable {
-    func visit(_ visitor: SynaxTreeVisitor) {
+    func visit(_ visitor: SyntaxTreeVisitor) {
         _visit(visitor)
     }
 }

--- a/Sources/Apodini/Components/Component.swift
+++ b/Sources/Apodini/Components/Component.swift
@@ -12,11 +12,11 @@ import Runtime
 
 /// A `Component` is the central building block of  Apodini. Each component handles a specific functionality of the Apodini web service.
 ///
-/// A `Component` either has a `handle` function that is called when a request reaches the `Component` or consists of different other components as descriibed by the `content` property.
+/// A `Component` either has a `handle` function that is called when a request reaches the `Component` or consists of different other components as described by the `content` property.
 public protocol Component {
-    /// The type of `Component` this `Component` is made out of if the compoent is a composition of multiple subcomponents.
+    /// The type of `Component` this `Component` is made out of if the component is a composition of multiple subcomponents.
     associatedtype Content: Component = Never
-    /// The type that is returned from the `handle` method when the component handles a request. The returntyp of the `handle` method is encoded into the response send out to the client.
+    /// The type that is returned from the `handle` method when the component handles a request. The return type of the `handle` method is encoded into the response send out to the client.
     associatedtype Response: ResponseEncodable = Never
     
     
@@ -30,7 +30,7 @@ public protocol Component {
 
 
 extension Component {
-    func visit(_ visitor: SynaxTreeVisitor) {
+    func visit(_ visitor: SyntaxTreeVisitor) {
         precondition(((try? typeInfo(of: Self.self).kind) ?? .none) == .struct, "Component \((try? typeInfo(of: Self.self).name) ?? "unknown") must be a struct")
         
         if let visitable = self as? Visitable {

--- a/Sources/Apodini/Components/EmptyComponent.swift
+++ b/Sources/Apodini/Components/EmptyComponent.swift
@@ -55,5 +55,5 @@ public struct EmptyComponent: Component {
 
 
 extension EmptyComponent: Visitable {
-    func visit(_ visitor: SynaxTreeVisitor) {}
+    func visit(_ visitor: SyntaxTreeVisitor) {}
 }

--- a/Sources/Apodini/Components/Group.swift
+++ b/Sources/Apodini/Components/Group.swift
@@ -27,7 +27,7 @@ public struct Group<Content: Component>: Component {
 
 
 extension Group: Visitable {
-    func visit(_ visitor: SynaxTreeVisitor) {
+    func visit(_ visitor: SyntaxTreeVisitor) {
         visitor.enterCollectionItem()
         visitor.addContext(PathComponentContextKey.self, value: pathComponents, scope: .environment)
         content.visit(visitor)

--- a/Sources/Apodini/Components/TupleComponent.swift
+++ b/Sources/Apodini/Components/TupleComponent.swift
@@ -21,7 +21,7 @@ public struct TupleComponent<T>: Component {
 }
 
 extension TupleComponent: Visitable {
-    func visit(_ visitor: SynaxTreeVisitor) {
+    func visit(_ visitor: SyntaxTreeVisitor) {
         let mirror = Mirror(reflecting: storage)
         for (_, value) in mirror.children {
             visitor.enterCollectionItem()
@@ -31,7 +31,7 @@ extension TupleComponent: Visitable {
                 // Since init is internal & we only create Tuple Components in the Component Builder
                 // We know for a fact that unsafeVisit won't fail.
                 #if DEBUG
-                fatalError("Attemted to visit value that was not a component. It was instantiated from \(file):\(function): \(error)")
+                fatalError("Attempted to visit value that was not a component. It was instantiated from \(file):\(function): \(error)")
                 #else
                 fatalError(error)
                 #endif

--- a/Sources/Apodini/Modifier/GuardModifier.swift
+++ b/Sources/Apodini/Modifier/GuardModifier.swift
@@ -56,7 +56,7 @@ public struct GuardModifier<C: Component>: Modifier {
 }
 
 extension GuardModifier: Visitable {
-    func visit(_ visitor: SynaxTreeVisitor) {
+    func visit(_ visitor: SyntaxTreeVisitor) {
         visitor.addContext(GuardContextKey.self, value: [`guard`], scope: .environment)
         component.visit(visitor)
     }
@@ -64,21 +64,21 @@ extension GuardModifier: Visitable {
 
 
 extension Component {
-    /// Use an asyncronousn`Guard` to guard `Component`s by inspecting incoming requests
+    /// Use an asynchronous `Guard` to guard `Component`s by inspecting incoming requests
     /// - Parameter guard: The `Guard` used to inspecting incoming requests
-    /// - Returns: Returns a modified `Component` protected by the asyncronous `Guard`
+    /// - Returns: Returns a modified `Component` protected by the asynchronous `Guard`
     public func `guard`<G: Guard>(_ guard: @escaping @autoclosure () -> (G)) -> GuardModifier<Self> {
         GuardModifier(self, guard: `guard`)
     }
     
-    /// Use a syncronous `SyncGuard` to guard `Component`s by inspecting incoming requests
+    /// Use a synchronous `SyncGuard` to guard `Component`s by inspecting incoming requests
     /// - Parameter guard: The `Guard` used to inspecting incoming requests
-    /// - Returns: Returns a modified `Component` protected by the syncronous `SyncGuard`
+    /// - Returns: Returns a modified `Component` protected by the synchronous `SyncGuard`
     public func `guard`<G: SyncGuard>(_ guard: @escaping @autoclosure () -> (G)) -> GuardModifier<Self> {
         GuardModifier(self, guard: `guard`)
     }
     
-    /// Reselts all guards for the modified `Component`
+    /// Resets all guards for the modified `Component`
     public func resetGuards() -> GuardModifier<Self> {
         GuardModifier(self, guard: { ResetGuard() })
     }

--- a/Sources/Apodini/Modifier/OperationModifier.swift
+++ b/Sources/Apodini/Modifier/OperationModifier.swift
@@ -40,7 +40,7 @@ public struct OperationModifier<ModifiedComponent: Component>: Modifier {
 
 
 extension OperationModifier: Visitable {
-    func visit(_ visitor: SynaxTreeVisitor) {
+    func visit(_ visitor: SyntaxTreeVisitor) {
         visitor.addContext(OperationContextKey.self, value: operation, scope: .nextComponent)
         component.visit(visitor)
     }

--- a/Sources/Apodini/Modifier/ResponseModifer.swift
+++ b/Sources/Apodini/Modifier/ResponseModifer.swift
@@ -49,7 +49,7 @@ extension ResponseTransformer {
     /// - Returns: The output as a type erasured `ResponseEncodable`
     public func transform(response: ResponseEncodable) -> ResponseEncodable {
         guard let response = response as? Self.Response else {
-            fatalError("Coult not cast the `ResponseEncodable` passed to the `AnyResponseTransformer` to the expected \(Response.self) type")
+            fatalError("Could not cast the `ResponseEncodable` passed to the `AnyResponseTransformer` to the expected \(Response.self) type")
         }
         return self.transform(response: response)
     }
@@ -65,7 +65,7 @@ struct ResponseContextKey: ContextKey {
 }
 
 
-/// A `ResponseModifier` can be used to transfrom the output of `Component`'s response to a differnt type using a `ResponseTransformer`
+/// A `ResponseModifier` can be used to transform the output of `Component`'s response to a different type using a `ResponseTransformer`
 public struct ResponseModifier<C: Component, T: ResponseTransformer>: Modifier where T.Response == C.Response {
     public typealias Response = T.TransformedResponse
     
@@ -89,7 +89,7 @@ public struct ResponseModifier<C: Component, T: ResponseTransformer>: Modifier w
 
 
 extension ResponseModifier: Visitable {
-    func visit(_ visitor: SynaxTreeVisitor) {
+    func visit(_ visitor: SyntaxTreeVisitor) {
         visitor.addContext(ResponseContextKey.self, value: [responseTransformer], scope: .nextComponent)
         component.visit(visitor)
     }
@@ -97,7 +97,7 @@ extension ResponseModifier: Visitable {
 
 
 extension Component {
-    /// A `response` modifier can be used to transfrom the output of `Component`'s response to a differnt type using a `ResponseTransformer`
+    /// A `response` modifier can be used to transform the output of `Component`'s response to a different type using a `ResponseTransformer`
     /// - Parameter responseTransformer: The `ResponseTransformer` used to transform the response of a `Component`
     /// - Returns: The modified `Component` with a new `Response` type
     public func response<T: ResponseTransformer>(

--- a/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor+unsafeVisit.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor+unsafeVisit.swift
@@ -1,9 +1,9 @@
 import Foundation
 import AssociatedTypeRequirementsVisitor
 
-extension SynaxTreeVisitor {
+extension SyntaxTreeVisitor {
     enum Error: Swift.Error {
-        case attemptedToVisitNoneComponent(Any, visitor: SynaxTreeVisitor)
+        case attemptedToVisitNoneComponent(Any, visitor: SyntaxTreeVisitor)
     }
 
     /**
@@ -26,7 +26,7 @@ private protocol ComponentAssociatedTypeRequirementsVisitor: AssociatedTypeRequi
 }
 
 private struct StandardComponentVisitor: ComponentAssociatedTypeRequirementsVisitor {
-    let visitor: SynaxTreeVisitor
+    let visitor: SyntaxTreeVisitor
 
     func callAsFunction<T: Component>(_ value: T) {
         value.visit(visitor)

--- a/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
@@ -1,5 +1,5 @@
 //
-//  SynaxTreeVisitor.swift
+//  SyntaxTreeVisitor.swift
 //  Apodini
 //
 //  Created by Paul Schmiedmayer on 6/26/20.
@@ -15,11 +15,12 @@ enum Scope {
 
 
 protocol Visitable {
-    func visit(_ visitor: SynaxTreeVisitor)
+    func visit(_ visitor: SyntaxTreeVisitor)
 }
 
 
-class SynaxTreeVisitor {
+class SyntaxTreeVisitor {
+    private var asf: String = ""
     private let semanticModelBuilders: [SemanticModelBuilder]
     private(set) var currentNode = ContextNode()
     
@@ -40,8 +41,8 @@ class SynaxTreeVisitor {
     }
     
     func register<C: Component>(component: C) {
-        // We capture the currentContextNode and make a copy that will be used when execuring the request as
-        // direcly capturing the currentNode would be influenced by the `resetContextNode()` call and using the
+        // We capture the currentContextNode and make a copy that will be used when executing the request as
+        // directly capturing the currentNode would be influenced by the `resetContextNode()` call and using the
         // currentNode would always result in the last currentNode that was used when visiting the component tree.
         let context = Context(contextNode: currentNode.copy())
         

--- a/Sources/Apodini/WebService.swift
+++ b/Sources/Apodini/WebService.swift
@@ -9,9 +9,9 @@ import Vapor
 import Fluent
 import FluentMongoDriver
 
-/// Each Apodini program conists of a `WebService`component that is used to describe the Web API of the Web Service
+/// Each Apodini program consists of a `WebService`component that is used to describe the Web API of the Web Service
 public protocol WebService: Component, ConfigurationCollection {
-    /// The currennt version of the `WebService`
+    /// The current version of the `WebService`
     var version: Version { get }
     
     /// An empty initializer used to create an Apodini `WebService`
@@ -20,7 +20,7 @@ public protocol WebService: Component, ConfigurationCollection {
 
 
 extension WebService {
-    /// This function is exectured to start up an Apodini `WebService`
+    /// This function is executed to start up an Apodini `WebService`
     public static func main() {
         do {
             let environmentName = try Environment.detect().name
@@ -64,11 +64,11 @@ extension WebService {
 
 extension WebService {
     func register(_ semanticModelBuilders: SemanticModelBuilder...) {
-        let visitor = SynaxTreeVisitor(semanticModelBuilders: semanticModelBuilders)
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: semanticModelBuilders)
         self.visit(visitor)
     }
     
-    private func visit(_ visitor: SynaxTreeVisitor) {
+    private func visit(_ visitor: SyntaxTreeVisitor) {
         visitor.addContext(APIVersionContextKey.self, value: version, scope: .environment)
         visitor.addContext(PathComponentContextKey.self, value: [version], scope: .environment)
         Group {

--- a/Tests/ApodiniTests/ContextNodeTests.swift
+++ b/Tests/ApodiniTests/ContextNodeTests.swift
@@ -45,7 +45,7 @@ struct IntModifier<ModifiedComponent: Component>: Modifier, Visitable {
         self.value = value
     }
 
-    func visit(_ visitor: SynaxTreeVisitor) {
+    func visit(_ visitor: SyntaxTreeVisitor) {
         switch scope {
         case .environment:
             visitor.addContext(IntEnvironmentContextKey.self, value: value, scope: .environment)
@@ -109,7 +109,7 @@ final class ContextNodeTests: XCTestCase {
             }
         }
 
-        let visitor = SynaxTreeVisitor(semanticModelBuilders: [TestSemanticModelBuilder(app)])
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [TestSemanticModelBuilder(app)])
         groupWithSingleComponent.visit(visitor)
     }
     
@@ -147,7 +147,7 @@ final class ContextNodeTests: XCTestCase {
             }
         }
 
-        let visitor = SynaxTreeVisitor(semanticModelBuilders: [TestSemanticModelBuilder(app)])
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [TestSemanticModelBuilder(app)])
         groupWithComponentAndGroup.visit(visitor)
     }
     
@@ -184,7 +184,7 @@ final class ContextNodeTests: XCTestCase {
             }
         }
 
-        let visitor = SynaxTreeVisitor(semanticModelBuilders: [TestSemanticModelBuilder(app)])
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [TestSemanticModelBuilder(app)])
         groupWithGroupAndComponent.visit(visitor)
     }
 }

--- a/Tests/ApodiniTests/PrintVisitor.swift
+++ b/Tests/ApodiniTests/PrintVisitor.swift
@@ -7,47 +7,47 @@
 
 @testable import Apodini
 
-class PrintVisitor: SynaxTreeVisitor {
-    private var intendationLevel: UInt = 0
+class PrintVisitor: SyntaxTreeVisitor {
+    private var indentationLevel: UInt = 0
     
     
-    private var intendation: String {
-        String(repeating: "  ", count: Int(intendationLevel))
+    private var indentation: String {
+        String(repeating: "  ", count: Int(indentationLevel))
     }
     
     
     override func enterCollectionItem() {
         super.enterCollectionItem()
-        print("\(intendation){")
-        intendationLevel += 1
+        print("\(indentation){")
+        indentationLevel += 1
     }
     
     override func addContext<C>(_ contextKey: C.Type = C.self, value: C.Value, scope: Scope) where C: ContextKey {
         super.addContext(contextKey, value: value, scope: scope)
-        print("\(intendation) + \(contextKey.self) = \(value)")
+        print("\(indentation) + \(contextKey.self) = \(value)")
     }
     
     override func register<C>(component: C) where C: Component {
-        print("\(intendation)\(component)")
+        print("\(indentation)\(component)")
         printContext()
         
         currentNode.resetContextNode()
     }
     
     func printContext() {
-        print("\(intendation) -> \(className(OperationContextKey.self)) = \(currentNode.getContextValue(for: OperationContextKey.self))")
-        print("\(intendation) -> \(className(APIVersionContextKey.self)) = \(currentNode.getContextValue(for: APIVersionContextKey.self))")
-        print("\(intendation) -> \(className(PathComponentContextKey.self)) = \(currentNode.getContextValue(for: PathComponentContextKey.self))")
-        print("\(intendation) -> \(className(GuardContextKey.self)) = \(currentNode.getContextValue(for: GuardContextKey.self))")
+        print("\(indentation) -> \(className(OperationContextKey.self)) = \(currentNode.getContextValue(for: OperationContextKey.self))")
+        print("\(indentation) -> \(className(APIVersionContextKey.self)) = \(currentNode.getContextValue(for: APIVersionContextKey.self))")
+        print("\(indentation) -> \(className(PathComponentContextKey.self)) = \(currentNode.getContextValue(for: PathComponentContextKey.self))")
+        print("\(indentation) -> \(className(GuardContextKey.self)) = \(currentNode.getContextValue(for: GuardContextKey.self))")
         if !currentNode.getContextValue(for: ResponseContextKey.self).isEmpty {
-            print("\(intendation) -> \(className(ResponseContextKey.self)) = \(currentNode.getContextValue(for: ResponseContextKey.self))")
+            print("\(indentation) -> \(className(ResponseContextKey.self)) = \(currentNode.getContextValue(for: ResponseContextKey.self))")
         }
     }
     
     override func exitCollectionItem() {
         super.exitCollectionItem()
-        intendationLevel = max(0, intendationLevel - 1)
-        print("\(intendation)}")
+        indentationLevel = max(0, indentationLevel - 1)
+        print("\(indentation)}")
     }
     
     private func className<T>(_ type: T.Type = T.self) -> String {

--- a/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
+++ b/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
@@ -72,7 +72,7 @@ final class SharedSemanticModelBuilderTests: XCTestCase {
     func testEndpointsTreeNodes() {
         // swiftlint:disable force_unwrapping
         let modelBuilder = SharedSemanticModelBuilder(app)
-        let visitor = SynaxTreeVisitor(semanticModelBuilders: [modelBuilder])
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [modelBuilder])
         let testComponent = TestComponent()
         Group {
             testComponent.content
@@ -82,15 +82,15 @@ final class SharedSemanticModelBuilderTests: XCTestCase {
         let treeNodeA: EndpointsTreeNode = modelBuilder.endpointsTreeRoot!.children.first!
         let treeNodeB: EndpointsTreeNode = treeNodeA.children.first { $0.path.description == "b" }!
         let treeNodeNameParameter: EndpointsTreeNode = treeNodeB.children.first!
-        let treeNodeSomeOtherIdParamter: EndpointsTreeNode = treeNodeA.children.first { $0.path.description != "b" }!
-        var endpointGroupLevel: Endpoint = treeNodeSomeOtherIdParamter.endpoints.first!.value
+        let treeNodeSomeOtherIdParameter: EndpointsTreeNode = treeNodeA.children.first { $0.path.description != "b" }!
+        var endpointGroupLevel: Endpoint = treeNodeSomeOtherIdParameter.endpoints.first!.value
         let someOtherIdParameterId: UUID = endpointGroupLevel.parameters.first { $0.name == "someOtherId" }!.id
         var endpoint: Endpoint = treeNodeNameParameter.endpoints.first!.value
         
         XCTAssertEqual(treeNodeA.endpoints.count, 0)
         XCTAssertEqual(treeNodeB.endpoints.count, 0)
         XCTAssertEqual(treeNodeNameParameter.endpoints.count, 1)
-        XCTAssertEqual(treeNodeSomeOtherIdParamter.endpoints.count, 1)
+        XCTAssertEqual(treeNodeSomeOtherIdParameter.endpoints.count, 1)
         XCTAssertEqual(endpointGroupLevel.absolutePath[0].description, "a")
         XCTAssertEqual(endpointGroupLevel.absolutePath[1].description, ":\(someOtherIdParameterId.uuidString)")
         XCTAssertEqual(endpoint.absolutePath[0].description, "a")

--- a/Tests/ApodiniTests/VisitorTests.swift
+++ b/Tests/ApodiniTests/VisitorTests.swift
@@ -57,27 +57,27 @@ final class VisitorTests: XCTestCase {
     }
     
     func testRESTVisitor() {
-        let visitor = SynaxTreeVisitor(semanticModelBuilders: [SharedSemanticModelBuilder(app, interfaceExporters: RESTInterfaceExporter.self)])
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [SharedSemanticModelBuilder(app, interfaceExporters: RESTInterfaceExporter.self)])
         TestWebService().visit(visitor)
     }
     
     func testGraphQLVisitor() {
-        let visitor = SynaxTreeVisitor(semanticModelBuilders: [GraphQLSemanticModelBuilder(app)])
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [GraphQLSemanticModelBuilder(app)])
         TestWebService().visit(visitor)
     }
     
     func testGRPCVisitor() {
-        let visitor = SynaxTreeVisitor(semanticModelBuilders: [GRPCSemanticModelBuilder(app)])
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [GRPCSemanticModelBuilder(app)])
         TestWebService().visit(visitor)
     }
     
     func testWebSocketVisitor() {
-        let visitor = SynaxTreeVisitor(semanticModelBuilders: [WebSocketSemanticModelBuilder(app)])
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [WebSocketSemanticModelBuilder(app)])
         TestWebService().visit(visitor)
     }
     
     func testOpenAPIVisitor() {
-        let visitor = SynaxTreeVisitor(semanticModelBuilders: [OpenAPISemanticModelBuilder(app)])
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [OpenAPISemanticModelBuilder(app)])
         TestWebService().visit(visitor)
     }
 }


### PR DESCRIPTION
This PR fixes a typo in the `SyntaxTreeVisitor` class name which was there from the beginning (and drove me crazy since then 🙃). 

Additionally I took the opportunity to fix general typos in docs etc in files which got touched in the refactoring process.