### PR TITLE
Fix in Endpoint for "external" `.path` Parameters

### DIFF
--- a/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
@@ -38,6 +38,7 @@ class SharedSemanticModelBuilder: SemanticModelBuilder {
             endpointsTreeRoot = EndpointsTreeNode(path: RootPath())
         }
 
+        // "manually" add path components that are only defined as path parameters inside `Handler`s
         for parameter in endpoint.parameters {
             let pathDescription = ":\(parameter.id)"
             if parameter.parameterType == .path && !paths.contains(where: { ($0 as? _PathComponent)?.description == pathDescription }) {

--- a/Tests/ApodiniTests/EndpointsTreeTests.swift
+++ b/Tests/ApodiniTests/EndpointsTreeTests.swift
@@ -63,7 +63,7 @@ final class EndpointsTreeTests: XCTestCase {
                 handleReturnType: TestHandler.Response.self
         )
         
-        let parameters: [EndpointParameter] = endpoint.parameters
+        let parameters: Set<EndpointParameter> = endpoint.parameters
         let nameParameter: EndpointParameter = parameters.first { $0.label == "_name" }!
         let timesParameter: EndpointParameter = parameters.first { $0.label == "_times" }!
         let birthdateParameter: EndpointParameter = parameters.first { $0.label == "_birthdate" }!


### PR DESCRIPTION
The PR adds a path parameter also if it is defined outside of Handler without explicit declaration inside Handler

The following corner case was not handled correctly:

```swift
struct TestHandler4: Component {
    func handle() -> String {
        "Hello Test Handler 4"
    }
}

struct TestComponent2: Component {
    @PathParameter
    var name: String

    var content: some Component {
        Group($name) {
            TestHandler4()
        }
    }
}
```
The corner case is now part of the `SharedSemanticModelBuilderTests`.

The `PathParameter` was included in the path but not listed as `EndpointParameter` in the `parameters` property of an `Endpoint`. 
 As a solution, one should retrieve `EndpointParameter`s from both, `RequestInjectables` (in case they are declared in a `Handler`) AND `_PathComponent`s included in the `Endpoint`s `absolutePath` (in the described case).