### PR TITLE
Fix: RequestInjectables wouldn't be properly injected when using SharedSemanticModelBuilder

### DIFF
--- a/Sources/Apodini/Semantic Model Builder/Context.swift
+++ b/Sources/Apodini/Semantic Model Builder/Context.swift
@@ -20,7 +20,8 @@ class Context {
     func get<C: ContextKey>(valueFor contextKey: C.Type = C.self) -> C.Value {
         contextNode.getContextValue(for: contextKey)
     }
-    
+
+    @available(*, deprecated, message: "To be replaced by the `requestHandlerBuilder` in the Endpoint model. See SharedSemanticModelBuilder")
     func createRequestHandler<C: Component>(withComponent component: C, using decoder: SemanticModelBuilder)
     -> (Vapor.Request) -> EventLoopFuture<Vapor.Response> {
         { (request: Vapor.Request) in

--- a/Sources/Apodini/Semantic Model Builder/EndpointParameter.swift
+++ b/Sources/Apodini/Semantic Model Builder/EndpointParameter.swift
@@ -51,8 +51,8 @@ class ParameterBuilder: RequestInjectableVisitor {
 
     var parameters: [EndpointParameter] = []
 
-    init(from requestInjectables: [String: RequestInjectable]) {
-        self.requestInjectables = requestInjectables
+    init<C: Component>(from component: C) {
+        self.requestInjectables = component.extractRequestInjectables()
     }
 
     func build() {
@@ -96,7 +96,7 @@ struct PathComponentAnalyzer: PathBuilder {
     mutating func append(_ string: String) {}
 
     /// This function does two things:
-    ///   * First it checks if the given `_PathComponent` is if type Parameter. If it is it returns
+    ///   * First it checks if the given `_PathComponent` is of type Parameter. If it is it returns
     ///     a `PathParameterAnalyzingResult` otherwise it returns nil.
     ///   * Secondly it retrieves the .http ParameterOption for the Parameter which is stored in the `PathParameterAnalyzingResult`
     static func analyzePathComponentForParameter(_ pathComponent: _PathComponent) -> PathParameterAnalyzingResult? {

--- a/Tests/ApodiniTests/EndpointsTreeTests.swift
+++ b/Tests/ApodiniTests/EndpointsTreeTests.swift
@@ -52,21 +52,19 @@ final class EndpointsTreeTests: XCTestCase {
         let testHandler = try XCTUnwrap(testComponent.content.content as? TestHandler)
         
         let requestInjectables: [String: RequestInjectable] = testHandler.extractRequestInjectables()
-        let parameterBuilder = ParameterBuilder(from: requestInjectables)
+        let parameterBuilder = ParameterBuilder(from: testHandler)
         parameterBuilder.build()
 
         let endpoint = Endpoint(
                 description: String(describing: testHandler),
                 context: Context(contextNode: ContextNode()),
                 operation: Operation.automatic,
-                guards: [],
-                requestInjectables: requestInjectables,
-                handleMethod: testHandler.handle,
-                responseTransformers: [],
+                requestHandlerBuilder: SharedSemanticModelBuilder.createRequestHandlerBuilder(with: testComponent),
                 handleReturnType: TestHandler.Response.self,
+                responseType: TestHandler.Response.self,
                 parameters: parameterBuilder.parameters
         )
-        
+
         let parameters: [EndpointParameter] = endpoint.parameters
         let nameParameter: EndpointParameter = parameters.first { $0.label == "_name" }!
         let timesParameter: EndpointParameter = parameters.first { $0.label == "_times" }!


### PR DESCRIPTION
As discovered by @theMomax and @hendesi the request handler of the `RESTInterfaceExporter` had an issue with RequestInjectables not being injected at all. The `Component` instance wasn't made available in the shared model, and thus the request handler passed the endpoint instance to `enterRequestContext`.

This was now changed so that the SharedSemanticModelBuilder provides the implementation for the request handler and thus is able to pass the `Component` instance to `enterRequestContext` to restore functionality. 