### PR TITLE
Fix in SharedSemanticModelBuilder for _PathComponents that are only defined inside Handler

### DIFF
--- a/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
@@ -12,9 +12,7 @@ class WebServiceModel {
         if !finishedParsing {
             fatalError("rootEndpoints of the WebServiceModel was accessed before parsing was finished!")
         }
-        return root.endpoints.map { _, endpoint -> Endpoint in
-            endpoint
-        }
+        return root.endpoints.map { _, endpoint -> Endpoint in endpoint }
     }()
     var relationships: [EndpointRelationship] {
         root.relationships
@@ -32,9 +30,7 @@ class SharedSemanticModelBuilder: SemanticModelBuilder {
     var rootNode: EndpointsTreeNode
 
     init(_ app: Application, interfaceExporters: InterfaceExporter.Type...) {
-        self.interfaceExporters = interfaceExporters.map { exporterType in
-            exporterType.init(app)
-        }
+        self.interfaceExporters = interfaceExporters.map { exporterType in exporterType.init(app) }
         webService = WebServiceModel()
         rootNode = webService.root // used to provide the unit test a reference to the root of the tree
 

--- a/Tests/ApodiniTests/CustomComponentTest.swift
+++ b/Tests/ApodiniTests/CustomComponentTest.swift
@@ -1,5 +1,5 @@
 //
-//  CustomCompoentTest.swift
+//  CustomComponentTest.swift
 //
 //
 //  Created by Paul Schmiedmayer on 6/27/20.

--- a/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
+++ b/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
@@ -71,6 +71,7 @@ final class SharedSemanticModelBuilderTests: XCTestCase {
     
     func testEndpointsTreeNodes() {
         // swiftlint:disable force_unwrapping
+        // swiftlint:disable force_cast
         let modelBuilder = SharedSemanticModelBuilder(app)
         let visitor = SyntaxTreeVisitor(semanticModelBuilders: [modelBuilder])
         let testComponent = TestComponent()

--- a/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
+++ b/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
@@ -93,6 +93,8 @@ final class SharedSemanticModelBuilderTests: XCTestCase {
         XCTAssertEqual(treeNodeSomeOtherIdParameter.endpoints.count, 1)
         XCTAssertEqual(endpointGroupLevel.absolutePath[0].description, "a")
         XCTAssertEqual(endpointGroupLevel.absolutePath[1].description, ":\(someOtherIdParameterId.uuidString)")
+        XCTAssertNoThrow(endpointGroupLevel.absolutePath[1] as! Parameter<Int>)
+        XCTAssertEqual((endpointGroupLevel.absolutePath[1] as! Parameter<Int>).id, someOtherIdParameterId)
         XCTAssertEqual(endpoint.absolutePath[0].description, "a")
         XCTAssertEqual(endpoint.absolutePath[1].description, "b")
         XCTAssertEqual(endpoint.absolutePath[2].description, ":\(nameParameterId.uuidString)")


### PR DESCRIPTION
Minor bugfix which resolves the issue of only having a `String` as `_PathComponent` for those `Parameter`s, that were only defined inside a `Handler` and need to be added manually to the `paths: [_PathComponent]` later on.