### PR TITLE
Corrected the contentType of EndpointParameter to match what is required by the Parameter generic

### DIFF
--- a/Sources/Apodini/Semantic Model Builder/EndpointParameter.swift
+++ b/Sources/Apodini/Semantic Model Builder/EndpointParameter.swift
@@ -11,7 +11,7 @@ struct EndpointParameter {
     let id: UUID
     let name: String?
     let label: String
-    let contentType: Any.Type
+    let contentType: Codable.Type
     let options: PropertyOptionSet<ParameterOptionNameSpace>
     let parameterType: EndpointParameterType
     
@@ -22,7 +22,7 @@ struct EndpointParameter {
         case path
     }
 
-    init(id: UUID, name: String?, label: String, contentType: Any.Type, options: PropertyOptionSet<ParameterOptionNameSpace>) {
+    init(id: UUID, name: String?, label: String, contentType: Codable.Type, options: PropertyOptionSet<ParameterOptionNameSpace>) {
         self.id = id
         self.name = name
         self.label = label


### PR DESCRIPTION
Minor fix. The headline describes it. `@Parameter` is defined as `Parameter<Element: Codable>`. This is now reflected in the `EndpointParameter` model as well.

This might be relevant to solve parameter retrieval in #32 (my [thoughts](https://github.com/Apodini/Apodini/pull/32#discussion_r541814050))

EDIT: requesting review from @lschlesinger as she is the code owner for that