### PR TITLE
Retain HandleReturnType for Endpoint

### DIFF
--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter.swift
@@ -7,7 +7,7 @@ import Vapor
 protocol InterfaceExporter: RequestInjectableDecoder {
     init(_ app: Application)
 
-    func export(_ endpoint: Endpoint)
+    func export(_ endpoint: AnyEndpoint)
 
     func finishedExporting(_ webService: WebServiceModel)
 

--- a/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
@@ -66,7 +66,7 @@ class RESTInterfaceExporter: InterfaceExporter {
         self.app = app
     }
 
-    func export(_ endpoint: Endpoint) {
+    func export(_ endpoint: AnyEndpoint) {
         let pathBuilder = RESTPathBuilder(endpoint.absolutePath)
         let routesBuilder = pathBuilder.routesBuilder(app)
 

--- a/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
@@ -8,17 +8,17 @@ class WebServiceModel {
     fileprivate let root: EndpointsTreeNode = EndpointsTreeNode(path: RootPath())
     fileprivate var finishedParsing = false
 
-    lazy var rootEndpoints: [Endpoint] = {
+    lazy var rootEndpoints: [AnyEndpoint] = {
         if !finishedParsing {
             fatalError("rootEndpoints of the WebServiceModel was accessed before parsing was finished!")
         }
-        return root.endpoints.map { _, endpoint -> Endpoint in endpoint }
+        return root.endpoints.map { _, endpoint -> AnyEndpoint in endpoint }
     }()
     var relationships: [EndpointRelationship] {
         root.relationships
     }
 
-    fileprivate func addEndpoint(_ endpoint: inout Endpoint, at paths: [PathComponent]) {
+    fileprivate func addEndpoint<HandleReturnType: ResponseEncodable>(_ endpoint: inout Endpoint<HandleReturnType>, at paths: [PathComponent]) {
         root.addEndpoint(&endpoint, at: paths)
     }
 }
@@ -66,12 +66,11 @@ class SharedSemanticModelBuilder: SemanticModelBuilder {
             return lastResponseTransformer().transformedResponseType
         }
 
-        var endpoint = Endpoint(
+        var endpoint = Endpoint<C.Response>(
                 description: String(describing: component),
                 context: context,
                 operation: operation,
                 requestHandlerBuilder: requestHandlerBuilder,
-                handleReturnType: C.Response.self,
                 responseType: responseType,
                 parameters: parameterBuilder.parameters
         )

--- a/Tests/ApodiniTests/EndpointsTreeTests.swift
+++ b/Tests/ApodiniTests/EndpointsTreeTests.swift
@@ -55,12 +55,11 @@ final class EndpointsTreeTests: XCTestCase {
         let parameterBuilder = ParameterBuilder(from: testHandler)
         parameterBuilder.build()
 
-        let endpoint = Endpoint(
+        let endpoint = Endpoint<TestHandler.Response>(
                 description: String(describing: testHandler),
                 context: Context(contextNode: ContextNode()),
                 operation: Operation.automatic,
                 requestHandlerBuilder: SharedSemanticModelBuilder.createRequestHandlerBuilder(with: testComponent),
-                handleReturnType: TestHandler.Response.self,
                 responseType: TestHandler.Response.self,
                 parameters: parameterBuilder.parameters
         )

--- a/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
+++ b/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
@@ -84,9 +84,9 @@ final class SharedSemanticModelBuilderTests: XCTestCase {
         let treeNodeB: EndpointsTreeNode = treeNodeA.children.first { $0.path.description == "b" }!
         let treeNodeNameParameter: EndpointsTreeNode = treeNodeB.children.first!
         let treeNodeSomeOtherIdParameter: EndpointsTreeNode = treeNodeA.children.first { $0.path.description != "b" }!
-        let endpointGroupLevel: Endpoint = treeNodeSomeOtherIdParameter.endpoints.first!.value
+        let endpointGroupLevel: AnyEndpoint = treeNodeSomeOtherIdParameter.endpoints.first!.value
         let someOtherIdParameterId: UUID = endpointGroupLevel.parameters.first { $0.name == "someOtherId" }!.id
-        let endpoint: Endpoint = treeNodeNameParameter.endpoints.first!.value
+        let endpoint: AnyEndpoint = treeNodeNameParameter.endpoints.first!.value
         
         XCTAssertEqual(treeNodeA.endpoints.count, 0)
         XCTAssertEqual(treeNodeB.endpoints.count, 0)
@@ -104,7 +104,7 @@ final class SharedSemanticModelBuilderTests: XCTestCase {
         
         // test nested use of path parameter that is only set inside `Handler` (i.e. `TestHandler2`)
         let treeNodeSomeIdParameter: EndpointsTreeNode = treeNodeNameParameter.children.first!
-        let nestedEndpoint: Endpoint = treeNodeSomeIdParameter.endpoints.first!.value
+        let nestedEndpoint: AnyEndpoint = treeNodeSomeIdParameter.endpoints.first!.value
         let someIdParameterId: UUID = nestedEndpoint.parameters.first { $0.name == "someId" }!.id
         
         XCTAssertEqual(nestedEndpoint.parameters.count, 2)


### PR DESCRIPTION
I went ahead and added a generic type parameter to `Endpoint` in order to retain the type information gathered from `Component`. Further I've added `AnyEndpoint` as a type erased endpoint. 