### PR TITLE
Fix crash when creating RestRequest from a Vapor.Request without a db

### DIFF
--- a/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
@@ -63,15 +63,23 @@ extension Operation {
 
 struct RESTRequest: Request {
     private var parameterDecoder: (UUID) -> Codable?
-    var eventLoop: EventLoop
-    var database: Fluent.Database?
-    var description: String
+    private var vaporRequest: Vapor.Request
+
+    var eventLoop: EventLoop {
+        vaporRequest.eventLoop
+    }
+
+    var database: Fluent.Database? {
+        vaporRequest.db
+    }
+
+    var description: String {
+        vaporRequest.description
+    }
 
     init(_ vaporRequest: Vapor.Request, parameterDecoder: @escaping (UUID) -> Codable?) {
-        self.eventLoop = vaporRequest.eventLoop
-        self.database = vaporRequest.db
         self.parameterDecoder = parameterDecoder
-        self.description = vaporRequest.description
+        self.vaporRequest = vaporRequest
     }
 
     func parameter<T: Codable>(for parameter: UUID) throws -> T? {

--- a/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
+++ b/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
@@ -143,7 +143,7 @@ final class SharedSemanticModelBuilderTests: XCTestCase {
                                                                              guards: [ { printGuard } ],
                                                                              responseModifiers: [ { transformer } ])
         let name = "Craig"
-        let request = MockRequest { _ in name }
+        let request = RESTRequest(Vapor.Request(application: app, on: app.eventLoopGroup.next())) { _ in name }
         let response = try requestHandler(request).wait()
         let responseString = try XCTUnwrap(response as? String)
 

--- a/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
+++ b/Tests/ApodiniTests/SharedSemanticModelBuilderTests.swift
@@ -32,6 +32,15 @@ final class SharedSemanticModelBuilderTests: XCTestCase {
             "Hello \(name)"
         }
     }
+
+    struct PrintGuard: SyncGuard {
+        @_Request
+        var request: Apodini.Request
+
+        func check() {
+            print(request.description)
+        }
+    }
     
     struct TestHandler2: Component {
         @Parameter
@@ -129,8 +138,9 @@ final class SharedSemanticModelBuilderTests: XCTestCase {
 
     func testCreateRequestHandler() throws {
         let transformer = EmojiMediator(emojis: "✅")
+        let printGuard = AnyGuard(PrintGuard())
         let requestHandler = SharedSemanticModelBuilder.createRequestHandler(with: TestHandler(),
-                                                                             guards: [],
+                                                                             guards: [ { printGuard } ],
                                                                              responseModifiers: [ { transformer } ])
         let name = "Craig"
         let request = MockRequest { _ in name }


### PR DESCRIPTION
Fix crash when creating RestRequest from a Vapor.Request without a db.

Nice