### PR TITLE
Tame Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ codecov:
 coverage:
   range: "60...90"
   precision: 2
-  round: down
+  round: up
   status:
     # The project status measures overall project coverage and compares it against the base of the pull request
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,9 +6,24 @@ codecov:
   require_ci_to_pass: yes
 
 coverage:
+  range: "60...90"
   precision: 2
   round: down
-  range: "70...100"
+  status:
+    # The project status measures overall project coverage and compares it against the base of the pull request
+    project:
+      default:
+        # Choose a minimum coverage ratio that the commit must meet to be considered a success
+        target: auto
+        # Allow the coverage to drop by X%, and posting a success status.
+        threshold: 0%
+    # The patch status only measures lines adjusted in the pull request
+    patch:
+      default:
+        # Choose a minimum coverage ratio that the commit must meet to be considered a success
+        target: auto
+        # Allow the coverage to drop by X%, and posting a success status.
+        threshold: 5%  
 
 parsers:
   gcov:

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,7 +23,7 @@ coverage:
         # Choose a minimum coverage ratio that the commit must meet to be considered a success
         target: auto
         # Allow the coverage to drop by X%, and posting a success status.
-        threshold: 5%  
+        threshold: 15%  
 
 parsers:
   gcov:


### PR DESCRIPTION
- Changed total coverage range from 70% - 100% to: 60% - 90% to allow for some files to not be covered.
- Rounding up to avoid -0.01% coverage blocking anyone
- Allow PR coverage to be 15% smaller than total project coverage.

Feel free to suggest adjustments to this