### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# *Name of the PR*
+
+## :recycle: Current situation
+*Describe the current situation (if possible with and exemplary (or real) code snippet and/or where this is used)*
+
+## :bulb: Proposed solution
+*Describe the solution (if possible with and exemplary (or real) code snippet)*
+
+### Problem that is solved
+*Provide a description and link issues that are solved*
+
+### Implications
+*Describe the implications, e.g. refactoring*
+
+## :heavy_plus_sign: Additional Information
+*Provide some additional information if possible*
+
+### Related PRs
+*Reference the related PRs*
+
+### Testing
+*Are there tests included? If yes, which situations are tested and which corner cases are missing?*
+
+### Reviewer Nudging
+*Where should the reviewer start, where is a good entry point?*


### PR DESCRIPTION
# Template for Pull Requests
Preface: I am using the subject of the PR, i.e., the PR-template, to describe my PR. Thereby, I eat my own dog food :dog:.
## :recycle: Current situation

We do not have a PR template

## :bulb: Proposed solution
In the future, we rely on a single template that allows to both, to understand pull requests and its implications on the own features/code base and quickly and write the description for PRs more efficiently.

### Problem that is solved

**Initiator of PR** 

Everybody tries his/her best to provide the necessary information for a PR and therefore comes up with individual approaches/structures

**Reader of PR**

1. It is not easy to grasp the essence of a PR and the concrete implications if not stated explicitly
2. One could not track easily which parts of the current code is affected if only the newly proposed solution is described visionary 

### Implications
On each newly opened PR, the template is automatically applied. The initiator should adhere to this commonly agreed on structure.

## :heavy_plus_sign: Additional Information

### Related PRs
None

### Testing
None - hope that codecov bot :robot: is not angry!

### Reviewer Nudging
This is an easy review task, as only one file is changed ...

