### PR TITLE
Add Parameter Initializers for Easier Usage of Options without Name

### DIFF
--- a/Sources/Apodini/Request/Parameter.swift
+++ b/Sources/Apodini/Request/Parameter.swift
@@ -48,9 +48,18 @@ public struct Parameter<Element: Codable> {
     /// - Parameters:
     ///   - name: The name that identifies this property when decoding the property from the input of a `Component`
     ///   - options: Options passed on to different interface exporters to clarify the functionality of this `@Parameter` for different API types
-    public init(_ name: String? = nil, _ options: Option...) {
+    public init(_ name: String, _ options: Option...) {
         self.defaultValue = nil
         self.name = name
+        self.options = PropertyOptionSet(options)
+    }
+    
+    /// Creates a new `@Parameter` that indicates input of a `Component`.
+    /// - Parameters:
+    ///   - options: Options passed on to different interface exporters to clarify the functionality of this `@Parameter` for different API types
+    public init(_ options: Option...) {
+        self.defaultValue = nil
+        self.name = nil
         self.options = PropertyOptionSet(options)
     }
     
@@ -65,10 +74,20 @@ public struct Parameter<Element: Codable> {
         self.options = PropertyOptionSet(options)
     }
     
+    /// Creates a new `@Parameter` that indicates input of a `Component`.
+    /// - Parameters:
+    ///   - defaultValue: The default value that should be used in case the interface exporter can not decode the value from the input of the `Component`
+    ///   - options: Options passed on to different interface exporters to clarify the functionality of this `@Parameter` for different API types
+    public init(wrappedValue defaultValue: Element, _ options: Option...) {
+        self.defaultValue = defaultValue
+        self.name = nil
+        self.options = PropertyOptionSet(options)
+    }
+    
     /// Creates a new `@Parameter` that indicates input of a `Component's` `@PathParameter` based on an existing component.
     /// - Parameter id: The `UUID` that can be passed in from a parent `Component`'s `@PathParameter`.
     /// - Precondition: A `@Parameter` with a specific `http` type `.body` or `.query` can not be passed to a seperate componet. Please remove the specific `.http` property option or specify the `.http` property option to `.path`.
-    init(_ id: UUID) {
+    init(from id: UUID) {
         self.options = PropertyOptionSet([.http(.path)])
         self.id = id
     }

--- a/Sources/Apodini/Request/PathParameter.swift
+++ b/Sources/Apodini/Request/PathParameter.swift
@@ -17,7 +17,7 @@ public struct PathParameter<Element: Codable & LosslessStringConvertible> {
     
     /// Accessing the projected value allows you to pass the `@PathParameter` to a `Handler` or `Component`
     public var projectedValue: Parameter<Element> {
-        Parameter(id)
+        Parameter(from: id)
     }
     
     

--- a/Sources/TestWebService/main.swift
+++ b/Sources/TestWebService/main.swift
@@ -42,7 +42,7 @@ struct TestWebService: Apodini.WebService {
     }
     
     struct Greeter: Component {
-        @Parameter var name: String
+        @Parameter(.http(.path)) var name: String
 
         func handle() -> String {
             "Hello \(name)"

--- a/Tests/ApodiniTests/EndpointsTreeTests.swift
+++ b/Tests/ApodiniTests/EndpointsTreeTests.swift
@@ -17,13 +17,13 @@ final class EndpointsTreeTests: XCTestCase {
     }
     
     struct TestHandler: Component {
-        @Parameter
+        @Parameter(.http(.path))
         var name: String
         
-        @Parameter("times", .http(.body))
-        var times: Int
+        @Parameter(.http(.query))
+        var times: Int = 0
         
-        @Parameter
+        @Parameter(.http(.body))
         var birthdate: Birthdate
         
         func handle() -> String {
@@ -79,7 +79,7 @@ final class EndpointsTreeTests: XCTestCase {
         
         // check whether categorization works
         XCTAssertEqual(birthdateParameter.parameterType, .content)
-        XCTAssertEqual(timesParameter.parameterType, .content)
+        XCTAssertEqual(timesParameter.parameterType, .lightweight)
         XCTAssertEqual(nameParameter.parameterType, .path)
     }
 }


### PR DESCRIPTION
# Add Parameter Initializers for Easier Usage of Options without Name

## :recycle: Current situation
`@Parameter` without `name` but with `options` does not work:
![image](https://user-images.githubusercontent.com/21169289/102994174-d7fdc500-451e-11eb-8d5c-6e7d83a45b8a.png)

...even when specifying what `.http()` is:
![image](https://user-images.githubusercontent.com/21169289/102994684-cec12800-451f-11eb-9e37-8c24aede0f0c.png)

`@Parameter` with `name` and with `options` does work:
![image](https://user-images.githubusercontent.com/21169289/102994329-24e19b80-451f-11eb-9602-4385bb6da892.png)

## :bulb: Proposed solution
The complicated initializers on `Parameter` (featuring default value for `name` and variadic `options` were split up. This results in two initializers, one requiring the `name` and one without the `name` parameter.

In addition the internal `init(_ id: UUID)` had to be reworked to `init(from id: UUID)`.

### Problem that is solved
Options can now be used on `@Parameter` without specifying a `name`. All of the above samples work now.

### Implications
Only calls to the UUID-based initializer had to be refactored. Everything that compiled before still compiles.

## :heavy_plus_sign: Additional Information
None.

### Related PRs
None.

### Testing
No additional tests were added. I did minor modifications to other tests so that all initializers are used at least once.

### Reviewer Nudging
Should be an easy one😉.
