### PR TITLE
Use callAsFunction in the EndpointRequestHandler

### DIFF
--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/RequestHandler.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/RequestHandler.swift
@@ -7,15 +7,15 @@ import protocol NIO.EventLoop
 import protocol FluentKit.Database
 
 class EndpointRequestHandler<I: InterfaceExporter> {
-    func handleRequest(request: I.ExporterRequest, eventLoop: EventLoop, database: Database? = nil) -> EventLoopFuture<Encodable> {
+    func callAsFunction(request: I.ExporterRequest, eventLoop: EventLoop, database: Database? = nil) -> EventLoopFuture<Encodable> {
         // We are doing nothing here. Everything is handled in InternalEndpointRequestHandler
         fatalError("EndpointRequestHandler.handleRequest() was not overridden. EndpointRequestHandler must not be created manually!")
     }
 }
 
 extension EndpointRequestHandler where I.ExporterRequest: WithEventLoop {
-    func handleRequest(request: I.ExporterRequest) -> EventLoopFuture<Encodable> {
-        handleRequest(request: request, eventLoop: request.eventLoop)
+    func callAsFunction(request: I.ExporterRequest) -> EventLoopFuture<Encodable> {
+        callAsFunction(request: request, eventLoop: request.eventLoop)
     }
 }
 
@@ -28,7 +28,7 @@ class InternalEndpointRequestHandler<I: InterfaceExporter, H: Handler>: Endpoint
         self.exporter = exporter
     }
 
-    override func handleRequest(
+    override func callAsFunction(
         request exporterRequest: I.ExporterRequest,
         eventLoop: EventLoop,
         database: Database? = nil

--- a/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
@@ -85,7 +85,7 @@ class RESTInterfaceExporter: InterfaceExporter {
         let requestHandler = endpoint.createRequestHandler(for: self)
 
         routesBuilder.on(operation.httpMethod, []) { (request: Vapor.Request) -> EventLoopFuture<Vapor.Response> in
-            let responseFuture = requestHandler.handleRequest(request: request)
+            let responseFuture = requestHandler(request: request)
 
             return responseFuture.flatMap { encodable in
                 let jsonEncoder = JSONEncoder()

--- a/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
@@ -7,8 +7,6 @@ import NIO
 @_implementationOnly import AssociatedTypeRequirementsVisitor
 
 
-typealias RequestHandler = (ExporterRequest) -> EventLoopFuture<Encodable>
-
 /// This struct is used to model the RootPath for the root of the endpoints tree
 struct RootPath: _PathComponent {
     var description: String {

--- a/Tests/ApodiniTests/EndpointsTreeTests.swift
+++ b/Tests/ApodiniTests/EndpointsTreeTests.swift
@@ -121,8 +121,7 @@ final class EndpointsTreeTests: ApodiniTests {
         let requestHandler = endpoint.createRequestHandler(for: exporter)
 
         // handle a request (The actual request is unused in the MockExporter)
-        let response = try requestHandler
-                .handleRequest(request: "Example Request", eventLoop: app.eventLoopGroup.next())
+        let response = try requestHandler(request: "Example Request", eventLoop: app.eventLoopGroup.next())
                 .wait()
         let responseString: String = try XCTUnwrap(response as? String)
 

--- a/Tests/ApodiniTests/ParameterRetrievalTests.swift
+++ b/Tests/ApodiniTests/ParameterRetrievalTests.swift
@@ -33,8 +33,7 @@ class ParameterRetrievalTests: ApodiniTests {
         let exporter = MockExporter<String>(queued: "Rudi", 3, nil, .null)
 
         let requestHandler = endpoint.createRequestHandler(for: exporter)
-        let result = try requestHandler
-                .handleRequest(request: "Example Request", eventLoop: app.eventLoopGroup.next())
+        let result = try requestHandler(request: "Example Request", eventLoop: app.eventLoopGroup.next())
                 .wait()
         let stringResult: String = try XCTUnwrap(result as? String)
 

--- a/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
@@ -63,8 +63,7 @@ class RESTInterfaceExporterTests: ApodiniTests {
         // we hardcode the pathId currently here
         request.parameters.set(":\(handler.pathAParameter.id)", to: "a")
 
-        let result = try requestHandler
-                .handleRequest(request: request)
+        let result = try requestHandler(request: request)
                 .wait()
         let parametersResult: Parameters = try XCTUnwrap(result as? Parameters)
 


### PR DESCRIPTION
# Use callAsFunction in the EndpointRequestHandler

## :recycle: Current situation

Currently the `EndpointRequestHandler` exposes a `handleRequest` method an exporter would call like:
Like.
```swift
requestHandler.handleRequest(request: ...)
```

## :bulb: Proposed solution

Using `callAsFunction` we add a little bit of syntactic sugar and the above becomes this:
```swift
requestHandler(request: ...)
```

Additionally the left over `RequestHandler` type alias was removed.

### Problem that is solved

There was no problem 🙃

### Implications

`handleRequest` was renamed to `callAsFunction` imposing the need of refactoring for exporters which already adopted changes of #81 (@theMomax, @lschlesinger, @moritzschuell).
We could have added backwards compatibility, but I don't think it is worth it for this change.

## :heavy_plus_sign: Additional Information

### Related PRs

* #81 originally introducing the `EndpointRequestHandler`

**PRs impacted by this change:**
* #74 WebSocket exporter
* #35 OpenAPI exporter
* #43 gRPC exporter

### Testing

Nothing to test.

### Reviewer Nudging

I assume this is an easy one.
