### PR TITLE
Adding basic HATEOAS support to the REST exporter

### DIFF
--- a/Sources/Apodini/Properties/Request.swift
+++ b/Sources/Apodini/Properties/Request.swift
@@ -22,8 +22,6 @@ protocol Request: CustomStringConvertible, CustomDebugStringConvertible {
 
     var eventLoop: EventLoop { get }
 
-    var database: (() -> Database)? { get }
-
     func retrieveParameter<Element: Codable>(_ parameter: Parameter<Element>) throws -> Element
 }
 

--- a/Sources/Apodini/Semantic Model Builder/ApodiniRequest.swift
+++ b/Sources/Apodini/Semantic Model Builder/ApodiniRequest.swift
@@ -30,20 +30,16 @@ struct ApodiniRequest<I: InterfaceExporter, H: Handler>: Request {
 
     var eventLoop: EventLoop
 
-    var database: (() -> Database)?
-
     init(
         for exporter: I,
         with request: I.ExporterRequest,
         on endpoint: Endpoint<H>,
-        running eventLoop: EventLoop,
-        database: (() -> Database)? = nil
+        running eventLoop: EventLoop
     ) {
         self.exporter = exporter
         self.exporterRequest = request
         self.storedEndpoint = endpoint
         self.eventLoop = eventLoop
-        self.database = database
     }
 
     func retrieveParameter<Element: Codable>(_ parameter: Parameter<Element>) throws -> Element {

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
@@ -16,11 +16,6 @@ protocol WithEventLoop {
     var eventLoop: EventLoop { get }
 }
 
-/// Intermediate solution to have databases working.
-protocol WithDatabase {
-    var database: () -> Database { get }
-}
-
 func null<T>(_ type: T.Type = T.self) -> T? {
     T?(nil)
 }

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/RequestHandler.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/RequestHandler.swift
@@ -7,7 +7,7 @@ import protocol NIO.EventLoop
 import protocol FluentKit.Database
 
 class EndpointRequestHandler<I: InterfaceExporter> {
-    func callAsFunction(request: I.ExporterRequest, eventLoop: EventLoop, database: Database? = nil) -> EventLoopFuture<Encodable> {
+    func callAsFunction(request: I.ExporterRequest, eventLoop: EventLoop) -> EventLoopFuture<Encodable> {
         // We are doing nothing here. Everything is handled in InternalEndpointRequestHandler
         fatalError("EndpointRequestHandler.handleRequest() was not overridden. EndpointRequestHandler must not be created manually!")
     }
@@ -28,21 +28,8 @@ class InternalEndpointRequestHandler<I: InterfaceExporter, H: Handler>: Endpoint
         self.exporter = exporter
     }
 
-    override func callAsFunction(
-        request exporterRequest: I.ExporterRequest,
-        eventLoop: EventLoop,
-        database: Database? = nil
-    ) -> EventLoopFuture<Encodable> {
-        let databaseClosure: (() -> Database)?
-        if let database = database {
-            databaseClosure = { database }
-        } else if let requestWithDatabase = exporterRequest as? WithDatabase {
-            databaseClosure = requestWithDatabase.database
-        } else {
-            databaseClosure = nil
-        }
-
-        let request = ApodiniRequest(for: exporter, with: exporterRequest, on: endpoint, running: eventLoop, database: databaseClosure)
+    override func callAsFunction(request exporterRequest: I.ExporterRequest, eventLoop: EventLoop) -> EventLoopFuture<Encodable> {
+        let request = ApodiniRequest(for: exporter, with: exporterRequest, on: endpoint, running: eventLoop)
 
         let guardEventLoopFutures = endpoint.guards.map { guardClosure in
             request.enterRequestContext(with: guardClosure()) { requestGuard in

--- a/Sources/Apodini/Semantic Model Builder/Model/Endpoint.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/Endpoint.swift
@@ -144,8 +144,8 @@ class EndpointsTreeNode {
     lazy var relationships: [EndpointRelationship] = {
         var relationships: [EndpointRelationship] = []
         
-        for child in children {
-            child.collectRelationships(&relationships)
+        for (name, child) in nodeChildren {
+            child.collectRelationships(name: name, &relationships)
         }
         
         return relationships
@@ -221,14 +221,18 @@ class EndpointsTreeNode {
         relativePath.append(path)
     }
     
-    fileprivate func collectRelationships(_ relationships: inout [EndpointRelationship]) {
+    fileprivate func collectRelationships(name: String, _ relationships: inout [EndpointRelationship]) {
         if !endpoints.isEmpty {
-            relationships.append(EndpointRelationship(destinationPath: absolutePath))
+            relationships.append(EndpointRelationship(name: name, destinationPath: absolutePath))
             return
         }
         
-        for child in children {
-            child.collectRelationships(&relationships)
+        for (childName, child) in nodeChildren {
+            // as Parameter is currently inserted into the path (which will change)
+            // checking against RequestInjectable is a lazy check to determine if this is a path parameter
+            // or just a regular path component. To be adapted.
+            let name = name + (child.path is RequestInjectable ? "" : "_" + childName)
+            child.collectRelationships(name: name, &relationships)
         }
     }
     

--- a/Sources/Apodini/Semantic Model Builder/Model/Relationship.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/Relationship.swift
@@ -3,5 +3,6 @@
 //
 
 struct EndpointRelationship { // ... to be replaced by a proper Relationship model
-    var destinationPath: [_PathComponent]
+    let name: String
+    let destinationPath: [_PathComponent]
 }

--- a/Sources/Apodini/Semantic Model Builder/REST/RESTEndpointHandler.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/RESTEndpointHandler.swift
@@ -6,11 +6,7 @@ import Foundation
 @_implementationOnly import Vapor
 import protocol FluentKit.Database
 
-extension Vapor.Request: ExporterRequest, WithEventLoop, WithDatabase {
-    var database: () -> Database {{
-        self.db
-    }}
-}
+extension Vapor.Request: ExporterRequest, WithEventLoop {}
 
 struct ResponseContainer: Encodable, ResponseEncodable {
     var data: AnyEncodable

--- a/Sources/Apodini/Semantic Model Builder/REST/RESTEndpointHandler.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/RESTEndpointHandler.swift
@@ -1,0 +1,71 @@
+//
+// Created by Andi on 30.12.20.
+//
+
+import Foundation
+@_implementationOnly import Vapor
+import protocol FluentKit.Database
+
+extension Vapor.Request: ExporterRequest, WithEventLoop, WithDatabase {
+    var database: () -> Database {{
+        self.db
+    }}
+}
+
+struct ResponseContainer: Encodable, ResponseEncodable {
+    var data: AnyEncodable
+    var links: [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case data = "data"
+        case links = "_links"
+    }
+
+    init(_ data: Encodable, links: [String: String]) {
+        self.data = AnyEncodable(value: data)
+        self.links = links
+    }
+
+    func encodeResponse(for request: Vapor.Request) -> EventLoopFuture<Response> {
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = [.withoutEscapingSlashes, .prettyPrinted]
+        #warning("We may remove JSONEncoder .prettyPrinted in production or make it configurable in some way")
+
+        let response = Response()
+        do {
+            try response.content.encode(self, using: jsonEncoder)
+        } catch {
+            return request.eventLoop.makeFailedFuture(error)
+        }
+        return request.eventLoop.makeSucceededFuture(response)
+    }
+}
+
+struct RESTEndpointHandler<H: Handler> {
+    let endpoint: Endpoint<H>
+    let requestHandler: EndpointRequestHandler<RESTInterfaceExporter>
+
+    init(for endpoint: Endpoint<H>, with requestHandler: EndpointRequestHandler<RESTInterfaceExporter>) {
+        self.endpoint = endpoint
+        self.requestHandler = requestHandler
+    }
+
+    func register(at routesBuilder: Vapor.RoutesBuilder, with operation: Operation) {
+        routesBuilder.on(operation.httpMethod, [], use: self.handleRequest)
+    }
+
+    func handleRequest(request: Vapor.Request) -> EventLoopFuture<ResponseContainer> {
+        let response = requestHandler(request: request)
+
+        // swiftlint:disable:next todo
+        let uriPrefix = "http://127.0.0.1:8080/" // TODO resolve that somehow
+        var links = ["self": uriPrefix + endpoint.absolutePath.joinPathComponents()]
+        for relationship in endpoint.relationships {
+            links[relationship.name] = uriPrefix + relationship.destinationPath.joinPathComponents()
+        }
+
+        return response.flatMapThrowing { encodable in
+            ResponseContainer(encodable, links: links)
+        }
+    }
+}

--- a/Tests/ApodiniTests/Mocks/MockRequest.swift
+++ b/Tests/ApodiniTests/Mocks/MockRequest.swift
@@ -11,31 +11,26 @@ import protocol FluentKit.Database
 enum MockRequest {
     static func createRequest(
         running eventLoop: EventLoop,
-        database: Database? = nil,
         queuedParameters parameterValues: Any??...
     ) -> ApodiniRequest<MockExporter<String>, EmptyHandler> {
-        createRequest(on: EmptyHandler(), running: eventLoop, database: database, queuedParameters: parameterValues)
+        createRequest(on: EmptyHandler(), running: eventLoop, queuedParameters: parameterValues)
     }
 
     static func createRequest<H: Handler>(
         on handler: H,
         running eventLoop: EventLoop,
-        database: Database? = nil,
         queuedParameters parameterValues: Any??...
     ) -> ApodiniRequest<MockExporter<String>, H> {
-        createRequest(on: handler, running: eventLoop, database: database, queuedParameters: parameterValues)
+        createRequest(on: handler, running: eventLoop, queuedParameters: parameterValues)
     }
 
     private static func createRequest<H: Handler>(
         on handler: H,
         running eventLoop: EventLoop,
-        database: Database? = nil,
         queuedParameters parameterValues: [Any??]
     ) -> ApodiniRequest<MockExporter<String>, H> {
         let endpoint = handler.mockEndpoint()
         let exporter = MockExporter<String>(queued: parameterValues)
-        // swiftlint:disable:next force_unwrapping
-        let databaseClosure = database != nil ? { database! } : nil
-        return ApodiniRequest(for: exporter, with: "Undefined Exporter Request", on: endpoint, running: eventLoop, database: databaseClosure)
+        return ApodiniRequest(for: exporter, with: "Undefined Exporter Request", on: endpoint, running: eventLoop)
     }
 }

--- a/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
@@ -15,7 +15,7 @@ class RESTInterfaceExporterTests: ApodiniTests {
         var bird: Bird
     }
 
-    struct TestRestHandler: Handler {
+    struct ParameterRetrievalTestHandler: Handler {
         @Parameter
         var param0: String
         @Parameter
@@ -42,8 +42,44 @@ class RESTInterfaceExporterTests: ApodiniTests {
         }
     }
 
+    struct User: Content, Identifiable {
+        let id: String
+        let name: String
+    }
+    
+    struct DecodedResponseContainer<Data: Decodable>: Decodable {
+        var data: Data
+        var links: [String: String]
+        
+        enum CodingKeys: String, CodingKey {
+            case data = "data"
+            case links = "_links"
+        }
+    }
+
+    struct UserHandler: Handler {
+        @Parameter
+        var userId: User.ID
+        @Parameter
+        var name: String
+
+        func handle() -> User {
+            User(id: userId, name: name)
+        }
+    }
+
+    @PathParameter
+    var userId: User.ID
+
+    @ComponentBuilder
+    var testService: some Component {
+        Group("user", $userId) {
+            UserHandler(userId: $userId)
+        }
+    }
+
     func testParameterRetrieval() throws {
-        let handler = TestRestHandler()
+        let handler = ParameterRetrievalTestHandler()
         let endpoint = handler.mockEndpoint()
 
         let exporter = RESTInterfaceExporter(app)
@@ -72,5 +108,21 @@ class RESTInterfaceExporterTests: ApodiniTests {
         XCTAssertEqual(parametersResult.pathA, "a")
         XCTAssertEqual(parametersResult.pathB, nil)
         XCTAssertEqual(parametersResult.bird, body)
+    }
+
+    func testRESTRequest() throws {
+        let builder = SharedSemanticModelBuilder(app)
+            .with(exporter: RESTInterfaceExporter.self)
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [builder])
+        testService.accept(visitor)
+
+        let userId = "1234"
+        let name = "Rudi"
+        try app.testable(method: .inMemory).test(.GET, "user/\(userId)?name=\(name)") { response in
+            XCTAssertEqual(response.status, .ok)
+            let container = try response.content.decode(DecodedResponseContainer<User>.self)
+            XCTAssertEqual(container.data.id, userId)
+            XCTAssertEqual(container.data.name, name)
+        }
     }
 }


### PR DESCRIPTION
~Draft status: waiting for #85 to get merged, as features introduced there need to be incorporated~

# Adding basic HATEOAS support to the REST exporter

## :recycle: Current situation

In the current situation the REST exporter passes the Encodable instance returned from the `Handler` directly to the the Vapor Response encoder. HATEOAS information is not incorporated.

## :bulb: Proposed solution

This PR adds a very basic initial version of HATEOAS information to the responses, by adding a `_links` object to the json response.

### Problem that is solved

&ndash;

### Implications

&ndash;

## :heavy_plus_sign: Additional Information

### Related PRs

&ndash;

### Testing

Added a test case covering REST request handling. 

### Reviewer Nudging

&ndash;