### PR TITLE
Combine Build and Test steps to reduce Action runtime

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -26,9 +26,7 @@ jobs:
       run: xcodebuild -version
     - name: Check Swift version
       run: swift --version
-    - name: Build
-      run: swift build --build-tests
-    - name: Test
+    - name: Build & Test
       run: swift test --enable-code-coverage
     - name: Convert coverage report
       run: xcrun llvm-cov export -format="lcov" .build/debug/ApodiniPackageTests.xctest/Contents/MacOS/ApodiniPackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
@@ -51,7 +49,5 @@ jobs:
         key: ${{ runner.os }}-${{matrix.linux}}-spm-cachev2-${{ hashFiles('**/Package.resolved') }}
     - name: Check Swift version
       run: swift --version
-    - name: Build
-      run: swift build --build-tests --enable-test-discovery
-    - name: Test
+    - name: Build & Test
       run: swift test --enable-test-discovery


### PR DESCRIPTION
# Combine Build and Test steps to reduce Action runtime

## :recycle: Current situation

Previously the GitHub workflow would always have two steps `Build` and `Test`.
`Build` compiled the whole project, including tests, and `Test` just ran all unit tests.

With the introduction of code coverage measurement #49, the command line option `--enable-code-coverage` was added to `swift test` execution. SPM needs to recompile the whole project in order to provide code coverage measurement data (I assume adding some sort of instructions to the binary, idk). This basically results in compiling the project twice in every execution of the action.

## :bulb: Proposed solution

Combining `Build` and `Test` steps into one. For consistency reasons this is also done to the linux based jobs.

### Problem that is solved
Reduced waiting time for actions (specifically the job running on macOS, at it is the only one reporting code coverage).

### Implications
--

## :heavy_plus_sign: Additional Information
--

### Related PRs
--

### Testing
--

### Reviewer Nudging
--
