### PR TITLE
Introduce StaticInterfaceExporter protocol

### DIFF
--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
@@ -2,7 +2,7 @@
 // Created by Andi on 22.11.20.
 //
 
-import class Vapor.Application
+@_implementationOnly import class Vapor.Application
 import protocol NIO.EventLoop
 import protocol FluentKit.Database
 

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
@@ -16,14 +16,11 @@ protocol WithEventLoop {
     var eventLoop: EventLoop { get }
 }
 
-func null<T>(_ type: T.Type = T.self) -> T? {
-    T?(nil)
-}
-
-/// Any Apodini Interface Exporter must conform to this protocol.
-protocol InterfaceExporter {
-    /// Defines the type of the Request the exporter uses.
-    associatedtype ExporterRequest: Apodini.ExporterRequest
+/// This is the base protocol shared by any Exporter type supported by Apodini.
+/// Currently the following two types are supported:
+/// - `InterfaceExporter`: This type should be used for Exporters serving an accessible WebService
+/// - `StaticInterfaceExporter`: This type should be used for Exporters service a representation of the WebService (e.g. documentation)
+protocol BaseInterfaceExporter {
     /// Defines the return type of the `export` method. The return type is currently unused.
     associatedtype EndpointExportOutput = Void
     /// Defines the return type of the `exportParameter` method. For more details see `exportParameter(...)`
@@ -53,6 +50,24 @@ protocol InterfaceExporter {
     /// - Parameter webService: A model representing the exported `WebService`
     func finishedExporting(_ webService: WebServiceModel)
 
+    /// Internal method used with the `InterfaceExporterVisitor`.
+    /// A proper implementation is provided by default for any exporter type.
+    /// - Parameter visitor: The instance of the `InterfaceExporterVisitor`
+    func accept(_ visitor: InterfaceExporterVisitor)
+}
+
+// Providing empty default implementations for Parameters
+extension BaseInterfaceExporter {
+    func exportParameter<Type: Codable>(_ parameter: EndpointParameter<Type>) {}
+    func finishedExporting(_ webService: WebServiceModel) {}
+}
+
+
+/// Any Interface Exporter creating an accessible WebService must conform to this protocol.
+protocol InterfaceExporter: BaseInterfaceExporter {
+    /// Defines the type of the Request the exporter uses.
+    associatedtype ExporterRequest: Apodini.ExporterRequest
+
     /// This method is called on `EndpointParameter` injection to retrieve the value from the given `ExporterRequest`.
     /// Be aware that the generic `Type` holds the Wrapped type for `Optional`s (see `EndpointParameter`).
     ///
@@ -73,22 +88,35 @@ protocol InterfaceExporter {
 
 // MARK: Interface Exporter Visitor
 extension InterfaceExporter {
-    func exportParameter<Type: Codable>(_ parameter: EndpointParameter<Type>) {}
-    func finishedExporting(_ webService: WebServiceModel) {}
-
     func accept(_ visitor: InterfaceExporterVisitor) {
         visitor.visit(exporter: self)
     }
 }
 
+
+/// Any InterfaceExporter creating a representation of the WebService must conform to this protocol.
+///
+/// Such exporters do not actively create a accessible WebService themselves but rather a static representation
+/// of the WebService is created (e.g. a Endpoint serving documentation of the WebService).
+protocol StaticInterfaceExporter: BaseInterfaceExporter {}
+
+extension StaticInterfaceExporter {
+    func accept(_ visitor: InterfaceExporterVisitor) {
+        visitor.visit(staticExporter: self)
+    }
+}
+
+
 protocol InterfaceExporterVisitor {
     func visit<I: InterfaceExporter>(exporter: I)
+    func visit<I: StaticInterfaceExporter>(staticExporter: I)
 }
+
 
 struct AnyInterfaceExporter {
     private let _accept: (_ visitor: InterfaceExporterVisitor) -> Void
 
-    init<I: InterfaceExporter>(_ exporter: I) {
+    init<I: BaseInterfaceExporter>(_ exporter: I) {
         _accept = exporter.accept
     }
 

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
@@ -2,7 +2,7 @@
 // Created by Andi on 22.11.20.
 //
 
-@_implementationOnly import class Vapor.Application
+import class Vapor.Application
 import protocol NIO.EventLoop
 import protocol FluentKit.Database
 

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
@@ -56,7 +56,7 @@ protocol BaseInterfaceExporter {
     func accept(_ visitor: InterfaceExporterVisitor)
 }
 
-// Providing empty default implementations for Parameters
+// Providing empty default implementations for optional methods
 extension BaseInterfaceExporter {
     func exportParameter<Type: Codable>(_ parameter: EndpointParameter<Type>) {}
     func finishedExporting(_ webService: WebServiceModel) {}
@@ -97,7 +97,7 @@ extension InterfaceExporter {
 /// Any InterfaceExporter creating a representation of the WebService must conform to this protocol.
 ///
 /// Such exporters do not actively create a accessible WebService themselves but rather a static representation
-/// of the WebService is created (e.g. a Endpoint serving documentation of the WebService).
+/// of the WebService (e.g. a Endpoint serving documentation of the WebService).
 protocol StaticInterfaceExporter: BaseInterfaceExporter {}
 
 extension StaticInterfaceExporter {

--- a/Sources/Apodini/Semantic Model Builder/Model/Endpoint.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/Endpoint.swift
@@ -34,7 +34,7 @@ protocol AnyEndpoint: CustomStringConvertible {
     var guards: [LazyGuard] { get }
     var responseTransformers: [() -> (AnyResponseTransformer)] { get }
 
-    func exportEndpoint<I: InterfaceExporter>(on exporter: I) -> I.EndpointExportOutput
+    func exportEndpoint<I: BaseInterfaceExporter>(on exporter: I) -> I.EndpointExportOutput
 
     func createConnectionContext<I: InterfaceExporter>(for exporter: I) -> AnyConnectionContext<I>
     
@@ -102,7 +102,7 @@ struct Endpoint<H: Handler>: AnyEndpoint {
         self.parameters = parameters
     }
     
-    func exportEndpoint<I: InterfaceExporter>(on exporter: I) -> I.EndpointExportOutput {
+    func exportEndpoint<I: BaseInterfaceExporter>(on exporter: I) -> I.EndpointExportOutput {
         exporter.export(self)
     }
     

--- a/Sources/Apodini/Semantic Model Builder/OpenAPI/OpenAPIInterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/OpenAPI/OpenAPIInterfaceExporter.swift
@@ -6,7 +6,7 @@
 @_implementationOnly import Vapor
 import Foundation
 
-class OpenAPIInterfaceExporter: InterfaceExporter {
+class OpenAPIInterfaceExporter: StaticInterfaceExporter {
     let app: Application
     var documentBuilder: OpenAPIDocumentBuilder
     let configuration: OpenAPIConfiguration
@@ -40,9 +40,5 @@ class OpenAPIInterfaceExporter: InterfaceExporter {
                 print("Not implemented yet.")
             }
         }
-    }
-
-    func retrieveParameter<Type: Decodable>(_ parameter: EndpointParameter<Type>, for request: Vapor.Request) throws -> Type?? {
-        fatalError("OpenAPIInterfaceExporter is not intended to retrieve parameters.")
     }
 }

--- a/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
@@ -53,7 +53,13 @@ class SharedSemanticModelBuilder: SemanticModelBuilder, InterfaceExporterVisitor
         interfaceExporters.append(AnyInterfaceExporter(exporter))
         return self
     }
-    
+
+    func with<T: StaticInterfaceExporter>(exporter exporterType: T.Type) -> Self {
+        let exporter = exporterType.init(app)
+        interfaceExporters.append(AnyInterfaceExporter(exporter))
+        return self
+    }
+
 
     override func register<H: Handler>(handler: H, withContext context: Context) {
         super.register(handler: handler, withContext: context)
@@ -113,7 +119,12 @@ class SharedSemanticModelBuilder: SemanticModelBuilder, InterfaceExporterVisitor
         exporter.finishedExporting(webService)
     }
 
-    private func call<I: InterfaceExporter>(exporter: I, for node: EndpointsTreeNode) {
+    func visit<I>(staticExporter: I) where I: StaticInterfaceExporter {
+        call(exporter: staticExporter, for: webService.root)
+        staticExporter.finishedExporting(webService)
+    }
+
+    private func call<I: BaseInterfaceExporter>(exporter: I, for node: EndpointsTreeNode) {
         for (_, endpoint) in node.endpoints {
             #warning("The result of export is currently unused. Could that be useful in the future?")
             _ = endpoint.exportEndpoint(on: exporter)


### PR DESCRIPTION
# Introduce StaticInterfaceExporter protocol

## :recycle: Current situation

Currently any `InterfaceExporter` is forced to define a `ExporterRequest` type and implement a `retrieveParameter` method.

## :bulb: Proposed solution

This PR adds a second exporter type, namely the `StaticInterfaceExporter` protocol, which removes the requirement for a `ExporterRequest`  type and the definition of a `retrieveParameter` function.

### Problem that is solved

The current situation is problematic for "static" interface exporters like OpenAPI which only server a representation of the WebService but not the WebService itself (see https://github.com/Apodini/Apodini/pull/35#discussion_r551764556).

### Implications

A `BaseInterfaceExporter` protocol was created to prevent code duplication of methods shared by those two exporter types.
The protocol should not be used directly, meaning it is considered to be a internal component of the Exporter API.
Direct usage is also prevented by the Exporter API.

## :heavy_plus_sign: Additional Information

### Related PRs

* #35 introduces the OpenAPI Exporter. Thus that PR would need to be adjusted if this PR gets merged first.
 My plan however is to give priority to #35 and merging this PR second (don't want to create another blocking change for #35). Once its merged I will adjust this PR to modify the OpenAPI exporter accordingly.

### Testing

The newly added parts are currently uncovered as no `StaticInterfaceExporter` exists in our codebase. However once #35 is merged (and this PR is adjusted) those parts will be covered automatically.

### Reviewer Nudging

I consider review of this PR simple.
