### PR TITLE
[POC] EncoderConfiguration and visions for a potential InterfaceExporterConfiguration

### DIFF
--- a/Sources/Apodini/Configurations/JSONEncoderConfiguration.swift
+++ b/Sources/Apodini/Configurations/JSONEncoderConfiguration.swift
@@ -1,0 +1,74 @@
+//
+// Created by Andi on 08.01.21.
+//
+
+import Foundation
+import class Vapor.Application
+
+/// This configuration provides a way to alter the configuration of `JSONEncoder` instances used in Apodini.
+/// As `JSONEncoder` is declared `open`, it also allows for supplying your own subclass.
+///
+/// A JSONEncoderConfiguration definition for the standard `JSONEncoder` could look like the following:
+/// ```swift
+/// @ConfigurationBuilder
+/// var configuration: some Configuration {
+///     JSONEncoderConfiguration()
+///         .with(\.outputFormatting, value: [.withoutEscapingSlashes, .prettyPrinted])
+///         .with(\.dateEncodingStrategy, value: .secondsSince1970)
+/// }
+/// ```
+public struct JSONEncoderConfiguration<Encoder: JSONEncoder>: Configuration {
+    private let initializer: () -> Encoder
+    private var configurations: [AnyKeyPathConfiguration<Encoder>] = []
+
+    /// Creates a new `JSONEncoderConfiguration` instance with a custom `JSONEncoder` implementation.
+    public init(_ initializer: @escaping @autoclosure () -> Encoder) {
+        self.initializer = initializer
+    }
+
+    public func with<Value>(_ property: WritableKeyPath<Encoder, Value>, value: Value) -> Self {
+        var configuration = self
+        configuration.configurations.append(KeyPathConfiguration(property, value: value))
+        return configuration
+    }
+
+    public func configure(_ app: Application) {
+        // TODO somehow store this configuration so Exporters can access it
+    }
+
+    func instance() -> Encoder {
+        var encoder = initializer()
+        for configuration in configurations {
+            configuration.apply(to: &encoder)
+        }
+        return encoder
+    }
+}
+
+extension JSONEncoderConfiguration where Encoder == JSONEncoder {
+    /// Creates a new instance of `JSONEncoderConfiguration` using the standard `JSONEncoder`.
+    public init() {
+        self.initializer = { JSONEncoder() }
+    }
+}
+
+class AnyKeyPathConfiguration<Root> {
+    func apply(to instance: inout Root) {
+        fatalError("\(self) did not properly overwrite apply of AnyKeyPathConfiguration!")
+    }
+}
+
+class KeyPathConfiguration<Root, Value>: AnyKeyPathConfiguration<Root> {
+    let keyPath: WritableKeyPath<Root, Value>
+    let value: Value
+
+    init(_ keyPath: WritableKeyPath<Root, Value>, value: Value) {
+        self.keyPath = keyPath
+        self.value = value
+        super.init()
+    }
+
+    override func apply(to instance: inout Root) {
+        instance[keyPath: keyPath] = value
+    }
+}

--- a/Sources/Apodini/Semantic Model Builder/REST/RESTEndpointHandler.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/RESTEndpointHandler.swift
@@ -25,7 +25,6 @@ struct ResponseContainer: Encodable, ResponseEncodable {
     func encodeResponse(for request: Vapor.Request) -> EventLoopFuture<Response> {
         let jsonEncoder = JSONEncoder()
         jsonEncoder.outputFormatting = [.withoutEscapingSlashes, .prettyPrinted]
-        #warning("We may remove JSONEncoder .prettyPrinted in production or make it configurable in some way")
 
         let response = Response()
         do {

--- a/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SharedSemanticModelBuilder.swift
@@ -126,7 +126,6 @@ class SharedSemanticModelBuilder: SemanticModelBuilder, InterfaceExporterVisitor
 
     private func call<I: BaseInterfaceExporter>(exporter: I, for node: EndpointsTreeNode) {
         for (_, endpoint) in node.endpoints {
-            #warning("The result of export is currently unused. Could that be useful in the future?")
             _ = endpoint.exportEndpoint(on: exporter)
         }
         

--- a/Sources/TestWebService/main.swift
+++ b/Sources/TestWebService/main.swift
@@ -5,6 +5,7 @@
 //  Created by Paul Schmiedmayer on 7/6/20.
 //
 
+import Foundation
 import Apodini
 
 
@@ -107,6 +108,11 @@ struct TestWebService: Apodini.WebService {
             UserHandler(userId: $userId)
                 .guard(PrintGuard())
         }
+    }
+
+    var configuration: some Configuration {
+        JSONEncoderConfiguration()
+            .with(\.outputFormatting, value: [.prettyPrinted, .withoutEscapingSlashes])
     }
 }
 


### PR DESCRIPTION
# Implement a draft version of the JSONEncoderConfiguration

## :recycle: Current situation

Currently Exporters like the `RESTInterfaceExporter` aren't configurable, specifically in the way they encode the response.

## :bulb: Proposed solution

We definitely need some sort of `RESTConfiguration` (InterfaceExporter specific Configurations in general) sometime in the future. Especially to **change** the used encoder to e.g. something XML based.

However this Draft PR explores a solution where the user can configure any `JSONEncoder` instances used in the whole Apodini project, by using KeyPaths and providing a value for it.
As `JSONEncoder` is declared as `open`, it can be overwritten, thus the configuration also supports providing custom implementation of `JSONEncoder`.

```swift
var configuration: some Configuration {
    JSONEncoderConfiguration()
        .with(\.outputFormatting, value: [.prettyPrinted, .withoutEscapingSlashes])
}
```

I could maybe even imagine doing a generic `EncoderConfiguration` (and `DecoderConfiguration` accordingly) and adding a default initializer as it is right now. Just weren't able to do this right away as `JSONEncoder` seemingly confirms to `TopLevelEncoder` which is part of the `Combine` framework (? idk). Probably one of the reason why `Vapor` has its own `ContentEncoder` protocol.

In addition one could even write a completely abstracted version, for any kind of KeyPath Configurable objects (useful for at least a `DecoderConfiguration`).

### Problem that is solved

User can configure JSONEncoder instances used in the project.

### Implications

Consider this Draft as a Proof of Concept. It isn't ready to be used, as `Configuration` currently doesn't allow for storing such configurations in a `Exporter` accessible way. I assume we would need to wait for #82 to support that.

For the long term, where we have Exporter specific `Configuration`s I could imagine, that e.g. the user could define a `RESTConfiguration`. Within this `RESTConfiguration` the user can place a `EncoderConfiguration` (and `DecoderConfiguration`). Such a definition would then overwrite a global definition of a `EncoderConfiguration` instance.

So maybe its worth working on some infrastructure code to support `InterfaceExporterConfiguration`s (@hendesi)?

<!-- ## :heavy_plus_sign: Additional Information -->
<!--*Provide some additional information if possible* -->

<!-- ### Related PRs -->
<!-- *Reference the related PRs* -->

<!-- ### Testing -->
<!-- *Are there tests included? If yes, which situations are tested and which corner cases are missing?* -->

<!-- ### Reviewer Nudging -->
<!--*Where should the reviewer start, where is a good entry point?* -->
