### PR TITLE
Adding support for optional ContextKeys

### DIFF
--- a/Sources/Apodini/Components/Path/PathComponentParser.swift
+++ b/Sources/Apodini/Components/Path/PathComponentParser.swift
@@ -3,7 +3,7 @@
 //
 
 protocol PathComponentParser {
-    mutating func addContext<C: ContextKey>(_ contextKey: C.Type, value: C.Value)
+    mutating func addContext<C: OptionalContextKey>(_ contextKey: C.Type, value: C.Value)
 
     mutating func visit(_ string: String)
     mutating func visit(_ version: Version)
@@ -12,7 +12,7 @@ protocol PathComponentParser {
 
 extension PathComponentParser {
     // simple parsers like the `StringPathBuilder` don't need to store the context
-    mutating func addContext<C: ContextKey>(_ contextKey: C.Type, value: C.Value) {}
+    mutating func addContext<C: OptionalContextKey>(_ contextKey: C.Type, value: C.Value) {}
 
     mutating func visit(_ version: Version) {
         visit(version.description)

--- a/Sources/Apodini/Components/Path/RelationshipNameModifier.swift
+++ b/Sources/Apodini/Components/Path/RelationshipNameModifier.swift
@@ -2,13 +2,8 @@
 // Created by Andi on 05.01.21.
 //
 
-struct RelationshipNameContextKey: ContextKey {
-    // Move to Optional type once fixed https://github.com/Apodini/Apodini/issues/75
-    static var defaultValue = ""
-
-    static func reduce(value: inout String, nextValue: () -> String) {
-        value = nextValue()
-    }
+struct RelationshipNameContextKey: OptionalContextKey {
+    typealias Value = String
 }
 
 public struct RelationshipNameModifier: PathComponentModifier {

--- a/Sources/Apodini/Modifier/GRPCMethodModifier.swift
+++ b/Sources/Apodini/Modifier/GRPCMethodModifier.swift
@@ -5,12 +5,8 @@
 //  Created by Moritz Schüll on 04.12.20.
 //
 
-struct GRPCMethodNameContextKey: ContextKey {
-    static var defaultValue = ""
-
-    static func reduce(value: inout String, nextValue: () -> String) {
-        value = nextValue()
-    }
+struct GRPCMethodNameContextKey: OptionalContextKey {
+    typealias Value = String
 }
 
 public struct GRPCMethodModifier<H: Handler>: HandlerModifier {

--- a/Sources/Apodini/Modifier/GRPCServiceModifier.swift
+++ b/Sources/Apodini/Modifier/GRPCServiceModifier.swift
@@ -5,12 +5,8 @@
 //  Created by Moritz Schüll on 04.12.20.
 //
 
-struct GRPCServiceNameContextKey: ContextKey {
-    static var defaultValue = ""
-
-    static func reduce(value: inout String, nextValue: () -> String) {
-        value = nextValue()
-    }
+struct GRPCServiceNameContextKey: OptionalContextKey {
+    typealias Value = String
 }
 
 public struct GRPCServiceModifier<H: Handler>: HandlerModifier {

--- a/Sources/Apodini/Modifier/OperationModifier.swift
+++ b/Sources/Apodini/Modifier/OperationModifier.swift
@@ -20,6 +20,7 @@ public enum Operation {
 }
 
 struct OperationContextKey: ContextKey {
+    typealias Value = Operation
     static var defaultValue: Operation = .automatic
 }
 

--- a/Sources/Apodini/Modifier/OperationModifier.swift
+++ b/Sources/Apodini/Modifier/OperationModifier.swift
@@ -21,10 +21,6 @@ public enum Operation {
 
 struct OperationContextKey: ContextKey {
     static var defaultValue: Operation = .automatic
-    
-    static func reduce(value: inout Operation, nextValue: () -> Operation) {
-        value = nextValue()
-    }
 }
 
 

--- a/Sources/Apodini/Semantic Model Builder/Context.swift
+++ b/Sources/Apodini/Semantic Model Builder/Context.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Context.swift
 //  
 //
 //  Created by Paul Schmiedmayer on 11/3/20.

--- a/Sources/Apodini/Semantic Model Builder/Context.swift
+++ b/Sources/Apodini/Semantic Model Builder/Context.swift
@@ -18,4 +18,8 @@ class Context {
     func get<C: ContextKey>(valueFor contextKey: C.Type = C.self) -> C.Value {
         contextNode.getContextValue(for: contextKey)
     }
+
+    func get<C: OptionalContextKey>(valueFor contextKey: C.Type = C.self) -> C.Value? {
+        contextNode.getContextValue(for: contextKey)
+    }
 }

--- a/Sources/Apodini/Semantic Model Builder/PathModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/PathModelBuilder.swift
@@ -53,7 +53,7 @@ struct PathModelBuilder: PathComponentParser {
         let name = currentContext.getContextValue(for: RelationshipNameContextKey.self)
         let hidden = currentContext.getContextValue(for: HideLinkContextKey.self)
         return PathRelationshipContext(
-            relationshipName: name.isEmpty ? nil : name,
+            relationshipName: name,
             linkHidden: hidden
         )
     }

--- a/Sources/Apodini/Semantic Model Builder/gRPC/Endpoint+GRPC.swift
+++ b/Sources/Apodini/Semantic Model Builder/gRPC/Endpoint+GRPC.swift
@@ -16,27 +16,26 @@ extension Endpoint {
     /// the Protobuffer and GRPC exporters
     /// for this `Endpoint`.
     var serviceName: String {
-        var serviceName = self.context.get(valueFor: GRPCServiceNameContextKey.self)
+        if let serviceName = self.context.get(valueFor: GRPCServiceNameContextKey.self) {
+            return serviceName
+        }
+
         // if no explicit servicename is provided via the modifier,
         // simply use the PathComponents to come up with one
-        if serviceName == GRPCServiceNameContextKey.defaultValue {
-            serviceName = self.absolutePath.asPathString(delimiter: "", parameterEncoding: .name)
-                .capitalized
-                .appending("Service")
-        }
-        return serviceName
+        return self.absolutePath.asPathString(delimiter: "", parameterEncoding: .name)
+            .capitalized
+            .appending("Service")
     }
 
     /// The name of the method that is exported
     /// by the Protobuffer and GRPC exporters
     /// for the `handle` method of this `Endpoint`.
     var methodName: String {
-        var methodName = self.context.get(valueFor: GRPCMethodNameContextKey.self)
+        if let methodName = self.context.get(valueFor: GRPCMethodNameContextKey.self) {
+            return methodName
+        }
         // if no explicit methodname is provided via the modifier,
         // we have to rely on the component name
-        if methodName == GRPCMethodNameContextKey.defaultValue {
-            methodName = "\(H.self)".lowercased()
-        }
-        return methodName
+        return "\(H.self)".lowercased()
     }
 }

--- a/Sources/Apodini/SyntaxTreeVisitor/ContextKey.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/ContextKey.swift
@@ -36,15 +36,6 @@ extension OptionalContextKey {
 /// A `ContextKey` is a `OptionalContextKey` with the addition of the definition of a default value.
 /// See implications of the reduction logic `OptionalContextKey.reduce(...)`.
 protocol ContextKey: OptionalContextKey {
-    /// The type of the value the `OptionalContextKey` identifies. The value MUST NOT be of type `Optional`.
-    /// The type is equal to `OptionalContextKey.Value`
-    associatedtype DefaultValue
-
     /// The default value this `ContextKey` provides.
-    static var defaultValue: DefaultValue { get }
-}
-
-extension ContextKey {
-    // I know the compiler creates a warning about this, but using it as a type constraint isn't actually the same thing
-    typealias Value = DefaultValue
+    static var defaultValue: Self.Value { get }
 }

--- a/Sources/Apodini/SyntaxTreeVisitor/ContextKey.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/ContextKey.swift
@@ -5,11 +5,34 @@
 //  Created by Paul Schmiedmayer on 6/26/20.
 //
 
-protocol ContextKey {
+/// A `OptionalContextKey` context key TODO document
+protocol OptionalContextKey {
     associatedtype Value
-    
-    static var defaultValue: Self.Value { get }
 
-    static func reduce(value: inout Self.Value,
-                       nextValue: () -> Self.Value)
+    static func reduce(value: inout Self.Value, nextValue: () -> Self.Value)
+}
+
+extension OptionalContextKey {
+    static func reduce(value: inout Self.Value, nextValue: () -> Self.Value) {
+        value = nextValue()
+    }
+}
+
+
+// TODO document
+protocol ContextKey: OptionalContextKey {
+    associatedtype DefaultValue
+
+    static var defaultValue: DefaultValue { get }
+}
+
+extension ContextKey {
+    // I know the compiler creates a warning about this, but using it as a type constraint isn't actually the same thing
+    typealias Value = DefaultValue
+}
+
+extension ContextKey {
+    static func reduce(value: inout Self.Value, nextValue: () -> Self.Value) {
+        value = nextValue()
+    }
 }

--- a/Sources/Apodini/SyntaxTreeVisitor/ContextKey.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/ContextKey.swift
@@ -5,10 +5,24 @@
 //  Created by Paul Schmiedmayer on 6/26/20.
 //
 
-/// A `OptionalContextKey` context key TODO document
+/// A `OptionalContextKey` serves as a key definition for a `ContextNode`.
+/// Optionally it can serve a reduction logic when inserting a new value into the `ContextNode`,
+/// see `OptionalContextKey.reduce(...)`.
+/// The `OptionalContextKey` is optional in the sense that it doesn't provide a default value, meaning
+/// it may not exists on the `Context` for a given `Handler`.
 protocol OptionalContextKey {
+    /// The type of the value the `OptionalContextKey` identifies. The value MUST NOT be of type `Optional`.
     associatedtype Value
 
+    /// This function can be optionally implemented to provide a reduction logic when inserting a new
+    /// value into a `ContextNode`. By default the previous value will just be overwritten.
+    /// As `OptionalContextKey` do not provide a default value, `reduce(...)` will not be called on first
+    /// insertion of a value for this `OptionalContextKey`.
+    ///
+    /// - Parameters:
+    ///   - value: The current value of the context key.
+    ///         The result of the reduction must be written into this inout parameter.
+    ///   - nextValue: The return value of the provided closure is the newly inserted value.
     static func reduce(value: inout Self.Value, nextValue: () -> Self.Value)
 }
 
@@ -19,20 +33,18 @@ extension OptionalContextKey {
 }
 
 
-// TODO document
+/// A `ContextKey` is a `OptionalContextKey` with the addition of the definition of a default value.
+/// See implications of the reduction logic `OptionalContextKey.reduce(...)`.
 protocol ContextKey: OptionalContextKey {
+    /// The type of the value the `OptionalContextKey` identifies. The value MUST NOT be of type `Optional`.
+    /// The type is equal to `OptionalContextKey.Value`
     associatedtype DefaultValue
 
+    /// The default value this `ContextKey` provides.
     static var defaultValue: DefaultValue { get }
 }
 
 extension ContextKey {
     // I know the compiler creates a warning about this, but using it as a type constraint isn't actually the same thing
     typealias Value = DefaultValue
-}
-
-extension ContextKey {
-    static func reduce(value: inout Self.Value, nextValue: () -> Self.Value) {
-        value = nextValue()
-    }
 }

--- a/Sources/Apodini/SyntaxTreeVisitor/ContextNode.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/ContextNode.swift
@@ -50,7 +50,7 @@ class ContextNode {
     func addContext<C: OptionalContextKey>(_ contextKey: C.Type = C.self, value: C.Value, scope: Scope) {
         let newValue: C.Value
 
-        if C.Value.self is ExpressibleByNilLiteral.Type {
+        if isOptional(C.Value.self) {
             fatalError("""
                        The `Value` type of a `ContextKey` or `OptionalContextKey` must not be a `Optional` type.
                        Found \(C.Value.self) as `Value` type for key \(C.self).

--- a/Sources/Apodini/SyntaxTreeVisitor/ContextNode.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/ContextNode.swift
@@ -5,6 +5,7 @@
 //  Created by Paul Schmiedmayer on 6/26/20.
 //
 
+@_implementationOnly import AssociatedTypeRequirementsVisitor
 
 class ContextNode {
     private var nodeOnlyContext: [ObjectIdentifier: Any] = [:]
@@ -84,15 +85,26 @@ class ContextNode {
             }
             newValue = contextValue
         } else {
-            if let type = contextKey as? ContextKeyWithDefault.Type {
-                // If there is no value in the local ContextNode nor in the global context we use the default value
-                // as the old value and the new value as the newValue in the reduce function call.
+            // we need to check if `OptionalContextKey` is type of `ContextKey`
+            // aka if the `ContextKey provides a default value. Because if it provides a defaultValue
+            // we need to call `reduce(...)` with it before inserting.
+            let visitor = StandardContextKeyTypeVisitor()
+            let defaultValue = visitor(contextKey)
 
-                var defaultValue: C.Value = type.getDefaultValue()
-                C.reduce(value: &defaultValue) {
-                    value
+            // if defaultValue is nil the contextKey didn't conform to `ContextKey` => doesn't have a default value
+            if let defaultValue = defaultValue {
+                // the visitor above returns Any, thus we need to properly cast. I can't think of a scenario
+                // where this can't go wrong, but that's what fatalErrors are for right?
+                if var defaultValue = defaultValue as? C.Value {
+                    // If there is no value in the local ContextNode nor in the global context we use the default value
+                    // as the old value and the new value as the newValue in the reduce function call.
+                    C.reduce(value: &defaultValue) {
+                        value
+                    }
+                    newValue = defaultValue
+                } else {
+                    fatalError("Failed to cast type of defaultValue \(type(of: defaultValue)) to expected Type of the ContextKey \(C.Value.self)")
                 }
-                newValue = defaultValue
             } else {
                 // we have a OptionalContextKey, there is no defaultValue with can reduce into
                 // thus we just store the supplied value
@@ -122,16 +134,18 @@ class ContextNode {
 
 // MARK: Helpers to retrieve default value
 
-private protocol ContextKeyWithDefault {
-    static func getDefaultValue<Value>() -> Value
+private protocol ContextKeyTypeVisitor: AssociatedTypeRequirementsTypeVisitor {
+    associatedtype Visitor = ContextKeyTypeVisitor
+    associatedtype Input = ContextKey
+    associatedtype Output
+
+    func callAsFunction<T: ContextKey>(_ type: T.Type) -> Output
 }
 
-private extension ContextKey {
-    static func getDefaultValue<DefaultValue>() -> DefaultValue {
-        if let value = defaultValue as? DefaultValue {
-            return value
-        }
-
-        fatalError("Failed to cast ContextKey.Value \(Value.self) to expected DefaultValue \(DefaultValue.self)")
+private struct StandardContextKeyTypeVisitor: ContextKeyTypeVisitor {
+    func callAsFunction<T: ContextKey>(_ type: T.Type) -> Any {
+        // we can't directly cast here to the desired Type
+        // I tried using generics but that crashes the AssociatedTypesRequirementsKit
+        type.defaultValue
     }
 }

--- a/Sources/Apodini/SyntaxTreeVisitor/ContextNode.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/ContextNode.swift
@@ -50,7 +50,6 @@ class ContextNode {
         let newValue: C.Value
 
         if C.Value.self is ExpressibleByNilLiteral.Type {
-            // TODO is there a compile time way to do this?
             fatalError("""
                        The `Value` type of a `ContextKey` or `OptionalContextKey` must not be a `Optional` type.
                        Found \(C.Value.self) as `Value` type for key \(C.self).
@@ -62,10 +61,10 @@ class ContextNode {
             // Component are parsed in a reverse order:
             //
             // Component()
-            //     .modifer(1) // Parsed second
-            //     .modifer(2) // Parsed first, stored in `nodeOnlyContext` or `context`
+            //     .modifier(1) // Parsed second
+            //     .modifier(2) // Parsed first, stored in `nodeOnlyContext` or `context`
             //
-            // As we expect that Components is using `2` based on the modifers we pass the `value` as the existing
+            // As we expect that Components is using `2` based on the modifiers we pass the `value` as the existing
             // value and `currentLocalValue` as the new value to take advantage of the reduce function.
             var value = value
             C.reduce(value: &value) {
@@ -78,8 +77,8 @@ class ContextNode {
             // Example:
             // Group {
             //     Component()
-            //         .modifer(2) // We expect Component to use `2`
-            // }.modifer(1)
+            //         .modifier(2) // We expect Component to use `2`
+            // }.modifier(1)
             C.reduce(value: &contextValue) {
                 value
             }

--- a/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
@@ -123,6 +123,7 @@ struct HandlerIndexPath: RawRepresentable {
     let rawValue: String
     
     struct ContextKey: Apodini.ContextKey {
+        typealias Value = HandlerIndexPath
         static let defaultValue: HandlerIndexPath = .init(rawValue: "")
     }
 }

--- a/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
@@ -124,9 +124,5 @@ struct HandlerIndexPath: RawRepresentable {
     
     struct ContextKey: Apodini.ContextKey {
         static let defaultValue: HandlerIndexPath = .init(rawValue: "")
-        
-        static func reduce(value: inout HandlerIndexPath, nextValue: () -> HandlerIndexPath) {
-            value = nextValue()
-        }
     }
 }

--- a/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
@@ -79,7 +79,7 @@ class SyntaxTreeVisitor {
     ///   - contextKey: The key of the context value
     ///   - value: The value that is assocated to the `ContextKey`
     ///   - scope: The scope of the context value as defined by the `Scope` enum
-    func addContext<C: ContextKey>(_ contextKey: C.Type = C.self, value: C.Value, scope: Scope) {
+    func addContext<C: OptionalContextKey>(_ contextKey: C.Type = C.self, value: C.Value, scope: Scope) {
         currentNode.addContext(contextKey, value: value, scope: scope)
     }
     

--- a/Sources/Apodini/Utilities/Optional.swift
+++ b/Sources/Apodini/Utilities/Optional.swift
@@ -2,6 +2,8 @@
 // Created by Andi on 25.12.20.
 //
 
+@_implementationOnly import Runtime
+
 protocol ApodiniOptional {
     associatedtype Member
 
@@ -22,5 +24,17 @@ extension Optional: ApodiniOptional {
 extension Optional where Wrapped: ExpressibleByNilLiteral {
     static var null: Self {
         .some(nil)
+    }
+}
+
+func isOptional<T>(_ type: T.Type = T.self) -> Bool {
+    do {
+        let typeInfo = try Runtime.typeInfo(of: type)
+        return typeInfo.kind == .optional
+    } catch {
+        // typeInfo(of:) only throws if the `Kind` enum isn't one of the supported cases:
+        //  .struct, .class, .existential, .tuple, .enum, .optional.
+        // Thus if it throws, we know for sure that it isn't a optional.
+        return false
     }
 }

--- a/Sources/Apodini/Version.swift
+++ b/Sources/Apodini/Version.swift
@@ -58,10 +58,6 @@ extension Version: _PathComponent {
     }
 }
 
-struct APIVersionContextKey: ContextKey {
-    static var defaultValue = Version()
-    
-    static func reduce(value: inout Version, nextValue: () -> Version) {
-        value = nextValue()
-    }
+struct APIVersionContextKey: OptionalContextKey {
+    typealias Value = Version
 }

--- a/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
+++ b/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
@@ -21,6 +21,7 @@ struct TestComponent: Handler {
 
 
 struct IntContextKey: ContextKey {
+    typealias Value = Int
     static var defaultValue: Int = 0
 }
 
@@ -31,7 +32,7 @@ struct IntOptionalContextKey: OptionalContextKey {
 struct IntAdditionContextKey: ContextKey {
     static var defaultValue: Int = 2
 
-    static func reduce(value: inout Value, nextValue: () -> Value) {
+    static func reduce(value: inout Int, nextValue: () -> Int) {
         value += nextValue()
     }
 }

--- a/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
+++ b/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
@@ -20,21 +20,12 @@ struct TestComponent: Handler {
 }
 
 
-struct IntEnvironmentContextKey: ContextKey {
+struct IntContextKey: ContextKey {
     static var defaultValue: Int = 0
-
-    static func reduce(value: inout Int, nextValue: () -> Int) {
-        value = nextValue()
-    }
 }
 
-
-struct IntNextComponentContextKey: ContextKey {
-    static var defaultValue: Int = 0
-
-    static func reduce(value: inout Int, nextValue: () -> Int) {
-        value = nextValue()
-    }
+struct IntOptionalContextKey: OptionalContextKey {
+    typealias Value = Int
 }
 
 
@@ -52,9 +43,9 @@ struct IntModifier<C: Component>: Modifier, SyntaxTreeVisitable {
     func accept(_ visitor: SyntaxTreeVisitor) {
         switch scope {
         case .environment:
-            visitor.addContext(IntEnvironmentContextKey.self, value: value, scope: .environment)
+            visitor.addContext(IntContextKey.self, value: value, scope: .environment)
         case .current:
-            visitor.addContext(IntNextComponentContextKey.self, value: value, scope: .current)
+            visitor.addContext(IntContextKey.self, value: value, scope: .current)
         }
         component.accept(visitor)
     }
@@ -65,17 +56,45 @@ extension IntModifier: Handler, HandlerModifier where ModifiedComponent: Handler
     typealias Response = ModifiedComponent.Response
 }
 
+struct OptionalIntModifier<C: Component>: Modifier, SyntaxTreeVisitable {
+    let component: C
+    let scope: Scope
+    let value: Int
+
+    init(_ component: C, scope: Scope, value: Int) {
+        self.component = component
+        self.scope = scope
+        self.value = value
+    }
+
+    func accept(_ visitor: SyntaxTreeVisitor) {
+        switch scope {
+        case .environment:
+            visitor.addContext(IntOptionalContextKey.self, value: value, scope: .environment)
+        case .current:
+            visitor.addContext(IntOptionalContextKey.self, value: value, scope: .current)
+        }
+        component.accept(visitor)
+    }
+}
+
+extension OptionalIntModifier: Handler, HandlerModifier where ModifiedComponent: Handler {
+    typealias Response = ModifiedComponent.Response
+}
 
 extension Component {
     func modifier(_ scope: Scope, value: Int) -> IntModifier<Self> {
         IntModifier(self, scope: scope, value: value)
     }
+
+    func optionalModifier(_ scope: Scope, value: Int) -> OptionalIntModifier<Self> {
+        OptionalIntModifier(self, scope: scope, value: value)
+    }
 }
 
 
-/**
- * Regression test for https://github.com/Apodini/Apodini/issues/12
- */
+/// Includes regression testing for https://github.com/Apodini/Apodini/issues/12.
+/// Read through this issues before doing any changes!
 final class ContextNodeTests: ApodiniTests {
     var groupWithSingleComponent: some Component {
         Group("test") {
@@ -87,12 +106,12 @@ final class ContextNodeTests: ApodiniTests {
         class TestSemanticModelBuilder: SemanticModelBuilder {
             override func register<H: Handler>(handler: H, withContext context: Context) {
                 if let testComponent = handler as? TestComponent {
-                    let localInt = context.get(valueFor: IntNextComponentContextKey.self)
+                    let intValue = context.get(valueFor: IntContextKey.self)
 
                     switch testComponent.type {
                     case 1:
                         // 0 is the default value for IntNextComponentContextKey
-                        XCTAssertEqual(localInt, 0, "TestComponent is seemingly sharing the same ContextNode with the Group")
+                        XCTAssertEqual(intValue, 0, "TestComponent is seemingly sharing the same ContextNode with the Group")
                     default:
                         XCTFail("Received unknown component type \(testComponent.type)")
                     }
@@ -114,6 +133,12 @@ final class ContextNodeTests: ApodiniTests {
                 .modifier(.environment, value: 1)
             Group("test2") {
                 TestComponent(2)
+
+                Group("test3") {
+                    TestComponent(3)
+                        .modifier(.current, value: 4)
+                    TestComponent(4)
+                }.modifier(.current, value: 99)
             }.modifier(.environment, value: 2)
         }.modifier(.environment, value: 3)
     }
@@ -124,15 +149,21 @@ final class ContextNodeTests: ApodiniTests {
                 if let testComponent = handler as? TestComponent {
                     let path = context.get(valueFor: PathComponentContextKey.self)
                     let pathString = path.asPathString()
-                    let environmentInt = context.get(valueFor: IntEnvironmentContextKey.self)
+                    let intValue = context.get(valueFor: IntContextKey.self)
 
                     switch testComponent.type {
                     case 1:
                         XCTAssertEqual(pathString, "test")
-                        XCTAssertEqual(environmentInt, 1)
+                        XCTAssertEqual(intValue, 1)
                     case 2:
                         XCTAssertEqual(pathString, "test/test2")
-                        XCTAssertEqual(environmentInt, 2)
+                        XCTAssertEqual(intValue, 2)
+                    case 3:
+                        XCTAssertEqual(pathString, "test/test2/test3")
+                        XCTAssertEqual(intValue, 4)
+                    case 4:
+                        XCTAssertEqual(pathString, "test/test2/test3")
+                        XCTAssertEqual(intValue, 2)
                     default:
                         XCTFail("Received unknown component type \(testComponent.type)")
                     }
@@ -163,15 +194,15 @@ final class ContextNodeTests: ApodiniTests {
                 if let testComponent = handler as? TestComponent {
                     let path = context.get(valueFor: PathComponentContextKey.self)
                     let pathString = path.asPathString()
-                    let environmentInt = context.get(valueFor: IntEnvironmentContextKey.self)
+                    let intValue = context.get(valueFor: IntContextKey.self)
 
                     switch testComponent.type {
                     case 1:
                         XCTAssertEqual(pathString, "test")
-                        XCTAssertEqual(environmentInt, 0) // 0 is the default value for IntEnvironmentContextKey
+                        XCTAssertEqual(intValue, 0) // 0 is the default value for IntEnvironmentContextKey
                     case 2:
                         XCTAssertEqual(pathString, "test/test2")
-                        XCTAssertEqual(environmentInt, 1)
+                        XCTAssertEqual(intValue, 1)
                     default:
                         XCTFail("Received unknown component type \(testComponent.type)")
                     }
@@ -183,6 +214,60 @@ final class ContextNodeTests: ApodiniTests {
 
         let visitor = SyntaxTreeVisitor(semanticModelBuilders: [TestSemanticModelBuilder(app)])
         groupWithGroupAndComponent.accept(visitor)
+        visitor.finishParsing()
+    }
+
+    var groupWithOptionalModifier: some Component {
+        Group("test") {
+            Group("test2") {
+                TestComponent(3)
+                TestComponent(4)
+                    .optionalModifier(.environment, value: 4)
+            }.optionalModifier(.environment, value: 3)
+            TestComponent(1)
+            TestComponent(2)
+                .optionalModifier(.current, value: 2)
+            TestComponent(5)
+                .optionalModifier(.current, value: 2)
+                .optionalModifier(.current, value: 5)
+        }
+    }
+
+    func testGroupWithOptionalModifier() {
+        class TestSemanticModelBuilder: SemanticModelBuilder {
+            override func register<H: Handler>(handler: H, withContext context: Context) {
+                if let testComponent = handler as? TestComponent {
+                    let path = context.get(valueFor: PathComponentContextKey.self)
+                    let pathString = path.asPathString()
+                    let intValue = context.get(valueFor: IntOptionalContextKey.self)
+
+                    switch testComponent.type {
+                    case 1:
+                        XCTAssertEqual(pathString, "test")
+                        XCTAssertEqual(intValue, nil)
+                    case 2:
+                        XCTAssertEqual(pathString, "test")
+                        XCTAssertEqual(intValue, 2)
+                    case 3:
+                        XCTAssertEqual(pathString, "test/test2")
+                        XCTAssertEqual(intValue, 3)
+                    case 4:
+                        XCTAssertEqual(pathString, "test/test2")
+                        XCTAssertEqual(intValue, 4)
+                    case 5:
+                        XCTAssertEqual(pathString, "test")
+                        XCTAssertEqual(intValue, 5)
+                    default:
+                        XCTFail("Received unknown component type \(testComponent.type)")
+                    }
+                } else {
+                    XCTFail("Received registration for unexpected component type \(handler)")
+                }
+            }
+        }
+
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [TestSemanticModelBuilder(app)])
+        groupWithOptionalModifier.accept(visitor)
         visitor.finishParsing()
     }
 }

--- a/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
+++ b/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
@@ -36,6 +36,11 @@ struct IntAdditionContextKey: ContextKey {
     }
 }
 
+struct IllegalOptionalContextKey: OptionalContextKey {
+    // The Value of a ContextKey MUST NOT be an Optional type
+    typealias Value = String?
+}
+
 
 struct IntModifier<C: Component>: Modifier, SyntaxTreeVisitable {
     let component: C
@@ -348,5 +353,11 @@ final class ContextNodeTests: ApodiniTests {
         let visitor = SyntaxTreeVisitor(semanticModelBuilders: [TestSemanticModelBuilder(app)])
         groupWithIntAddition.accept(visitor)
         visitor.finishParsing()
+    }
+
+    func testAddingIllegalContextKey() {
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [])
+        XCTAssertRuntimeFailure(visitor.addContext(IllegalOptionalContextKey.self, value: nil, scope: .nextHandler))
+        XCTAssertRuntimeFailure(visitor.addContext(IllegalOptionalContextKey.self, value: "test", scope: .nextHandler))
     }
 }

--- a/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
+++ b/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
@@ -112,8 +112,8 @@ struct IntAdditionModifier<C: Component>: Modifier, SyntaxTreeVisitable {
         switch scope {
         case .environment:
             visitor.addContext(IntAdditionContextKey.self, value: value, scope: .environment)
-        case .nextHandler:
-            visitor.addContext(IntAdditionContextKey.self, value: value, scope: .nextHandler)
+        case .current:
+            visitor.addContext(IntAdditionContextKey.self, value: value, scope: .current)
         }
         component.accept(visitor)
     }
@@ -323,7 +323,7 @@ final class ContextNodeTests: ApodiniTests {
         Group("test") {
             TestComponent(1)
             TestComponent(2)
-                .addingInt(.nextHandler, value: 1)
+                .addingInt(.current, value: 1)
         }.addingInt(.environment, value: 1)
     }
 
@@ -332,7 +332,7 @@ final class ContextNodeTests: ApodiniTests {
             override func register<H: Handler>(handler: H, withContext context: Context) {
                 if let testComponent = handler as? TestComponent {
                     let path = context.get(valueFor: PathComponentContextKey.self)
-                    let pathString = ContextNodeTests.buildStringFromPathComponents(path)
+                    let pathString = path.asPathString()
                     let intValue = context.get(valueFor: IntAdditionContextKey.self)
 
                     switch testComponent.type {
@@ -358,7 +358,7 @@ final class ContextNodeTests: ApodiniTests {
 
     func testAddingIllegalContextKey() {
         let visitor = SyntaxTreeVisitor(semanticModelBuilders: [])
-        XCTAssertRuntimeFailure(visitor.addContext(IllegalOptionalContextKey.self, value: nil, scope: .nextHandler))
-        XCTAssertRuntimeFailure(visitor.addContext(IllegalOptionalContextKey.self, value: "test", scope: .nextHandler))
+        XCTAssertRuntimeFailure(visitor.addContext(IllegalOptionalContextKey.self, value: nil, scope: .current))
+        XCTAssertRuntimeFailure(visitor.addContext(IllegalOptionalContextKey.self, value: "test", scope: .current))
     }
 }

--- a/Tests/ApodiniTests/Utilitites/OptionalTests.swift
+++ b/Tests/ApodiniTests/Utilitites/OptionalTests.swift
@@ -1,0 +1,23 @@
+//
+// Created by Andi on 12.01.21.
+//
+
+import XCTest
+@testable import Apodini
+
+class OptionalTests: ApodiniTests {
+    func testIsOptional() {
+        /// A custom type
+        struct Test {}
+
+        XCTAssertEqual(isOptional(String.self), false)
+        XCTAssertEqual(isOptional(Int.self), false)
+        XCTAssertEqual(isOptional(Test.self), false)
+        XCTAssertEqual(isOptional(Optional<Test>.self), true)
+        XCTAssertEqual(isOptional(Optional<Test>.self), true)
+        XCTAssertEqual(isOptional(String?.self), true)
+        XCTAssertEqual(isOptional(String??.self), true)
+        XCTAssertEqual(isOptional(String???.self), true)
+        XCTAssertEqual(isOptional(Never.self), false)
+    }
+}


### PR DESCRIPTION
# Adding support for optional ContextKeys

## :recycle: Current situation

Defining `ContextKeys` with an optional type doesn't work properly (see #75).

## :bulb: Proposed solution

This PR adds a new `OptionalContextKey` protocol, which can be used for `ContextKey`s without a default value.
To reflect this behavior, a specific `Context.get(...)` was added to return an optional, to support the case where no value was provided for a given value.

### Problem that is solved

#75 

Some of the gRPC modifiers already needed that behavior and were adjusted.

I provided a default implementation for the `reduce(...)` function, which is widely used.

### Implications

Any `ContextKey` MUST NOT be defined with the associated type being a `Optional<...>`. I added documentation stating this and additionally a runtime check, however I couldn't figure out a way to move this to a compiler warning (not sure if this is possible).

I have tried ways of adding optional `ContextKeys` by defining the `Value` associated type as `Optional<...>`, however this was a bit unclean approach, as one need to still define a `defaultValue` and the signature of the `reduce(...)` function wasn't really fitting.

## :heavy_plus_sign: Additional Information

### Related PRs
* #117 The `DescriptionModifier` can make use of the new `OptionalContextKey` protocol.

### Testing
Test cases checking `OptionalContextKey`s were added.

### Reviewer Nudging
--
