### PR TITLE
Fix DSL context

### DIFF
--- a/Sources/Apodini/Components/Group.swift
+++ b/Sources/Apodini/Components/Group.swift
@@ -24,19 +24,11 @@ public struct Group<Content: Component>: Component, SyntaxTreeVisitable {
     }
     
     func accept(_ visitor: SyntaxTreeVisitor) {
-        func forwardToContent() {
-            visitor.addContext(PathComponentContextKey.self, value: pathComponents, scope: .environment)
-            content.accept(visitor)
-        }
-        
-        if !String(describing: type(of: content)).hasPrefix("TupleComponent<") {
-            visitor.enterContent {
-                visitor.enterComponentContext {
-                    forwardToContent()
-                }
+        visitor.enterContent {
+            visitor.enterComponentContext {
+                visitor.addContext(PathComponentContextKey.self, value: pathComponents, scope: .environment)
+                content.accept(visitor)
             }
-        } else {
-            forwardToContent()
         }
     }
 }

--- a/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
@@ -112,7 +112,7 @@ class SyntaxTreeVisitor {
     
     private func formHandlerIndexPathForCurrentNode() -> HandlerIndexPath {
         let rawValue = currentNodeIndexPath
-            .map { String($0 - 1) } // We remove one from the current indexPath to have 0 as the first index
+            .map { String(max($0, 1) - 1) } // We remove one from the current indexPath to have 0 as the first index
             .joined(separator: ":")
         return HandlerIndexPath(rawValue: rawValue)
     }

--- a/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
@@ -112,7 +112,7 @@ class SyntaxTreeVisitor {
     
     private func formHandlerIndexPathForCurrentNode() -> HandlerIndexPath {
         let rawValue = currentNodeIndexPath
-            .map { String(max($0, 1) - 1) } // We remove one from the current indexPath to have 0 as the first index
+            .map { String($0 - 1) } // We remove one from the current indexPath to have 0 as the first index
             .joined(separator: ":")
         return HandlerIndexPath(rawValue: rawValue)
     }

--- a/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
@@ -134,19 +134,16 @@ class RESTInterfaceExporterTests: ApodiniTests {
     
     func testEndpointPaths() throws {
         struct WebService: Apodini.WebService {
-            struct EmptyHandler: Apodini.Handler {
-                typealias Response = Never
-            }
             var content: some Component {
                 Group("api") {
                     Group("user") {
-                        EmptyHandler().operation(.read)
-                        EmptyHandler().operation(.create)
+                        Text("").operation(.read)
+                        Text("").operation(.create)
                     }
                 }
                 Group("api") {
                     Group("post") {
-                        EmptyHandler().operation(.read)
+                        Text("").operation(.read)
                     }
                 }
             }

--- a/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
@@ -130,4 +130,62 @@ class RESTInterfaceExporterTests: ApodiniTests {
             XCTAssertEqual(container.data.name, name)
         }
     }
+    
+    
+    func testEndpointPaths() throws {
+        struct WebService: Apodini.WebService {
+            struct EmptyHandler: Apodini.Handler {
+                typealias Response = Never
+            }
+            var content: some Component {
+                Group("api") {
+                    Group("user") {
+                        EmptyHandler().operation(.read)
+                        EmptyHandler().operation(.create)
+                    }
+                }
+                Group("api") {
+                    Group("post") {
+                        EmptyHandler().operation(.read)
+                    }
+                }
+            }
+        }
+        
+        let builder = SharedSemanticModelBuilder(app)
+            .with(exporter: RESTInterfaceExporter.self)
+        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [builder])
+        WebService().accept(visitor)
+        visitor.finishParsing()
+        
+        let endpointPaths = builder.rootNode
+            .collectAllEndpoints()
+            .map { StringPathBuilder($0.absolutePath).build() }
+        
+        let expectedEndpointPaths: [String] = [
+            "api/user", "api/user", "api/post"
+        ]
+        XCTAssert(endpointPaths.compareIgnoringOrder(expectedEndpointPaths))
+    }
+}
+
+
+extension Collection where Element: Hashable {
+    /// Returns `true` if the two collections contain the same elements, regardless of their order.
+    /// - Note: this is different from `Set(self) == Set(other)`, insofar as this also
+    ///         takes into account how often an element occurs, which the Set version would ignore
+    func compareIgnoringOrder<S>(_ other: S) -> Bool where S: Collection, S.Element == Element {
+        guard self.count == other.count else {
+            return false
+        }
+        return self.countOccurrences() == other.countOccurrences()
+    }
+    
+    
+    /// Returns a dictionary containing the dictinct elements of the collection (ie, without duplicates) as the keys, and each element's occurrence count as value
+    func countOccurrences() -> [Element: Int] {
+        reduce(into: [:]) { result, element in
+            result[element] = (result[element] ?? 0) + 1
+        }
+    }
 }

--- a/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
@@ -151,16 +151,14 @@ class RESTInterfaceExporterTests: ApodiniTests {
         
         let builder = SharedSemanticModelBuilder(app)
             .with(exporter: RESTInterfaceExporter.self)
-        let visitor = SyntaxTreeVisitor(semanticModelBuilders: [builder])
-        WebService().accept(visitor)
-        visitor.finishParsing()
+        WebService().register(builder)
         
         let endpointPaths = builder.rootNode
             .collectAllEndpoints()
             .map { StringPathBuilder($0.absolutePath).build() }
         
         let expectedEndpointPaths: [String] = [
-            "api/user", "api/user", "api/post"
+            "v1/api/user", "v1/api/user", "v1/api/post"
         ]
         XCTAssert(endpointPaths.compareIgnoringOrder(expectedEndpointPaths))
     }


### PR DESCRIPTION
Fixes #111, by rolling back some of the changes introduced in #88.

We no longer try to ignore `TupleComponent`s when entering/exiting DSL content contexts.

Pro: we now get correct paths when generating endpoints.
Con: auto-generated endpoint/handler identifiers are a bit longer.