### PR TITLE
Get rid of NSObject

### DIFF
--- a/Sources/Apodini/Properties/Options/PropertyOptionKey.swift
+++ b/Sources/Apodini/Properties/Options/PropertyOptionKey.swift
@@ -3,7 +3,6 @@ import Foundation
 
 /// A type erasure for the `PropertyOptionKey`
 public class AnyPropertyOptionKey: Equatable, Hashable {
-    let id = UUID()
     /// Combines two `PropertyOptionKey`s.
     /// - Parameters:
     ///   - lhs: The left hand side `PropertyOptionKey` that should be combined
@@ -13,12 +12,12 @@ public class AnyPropertyOptionKey: Equatable, Hashable {
         fatalError("AnyPropertyOptionKey.combine should be overridden!")
     }
 
-    public static func ==(lhs: AnyPropertyOptionKey, rhs: AnyPropertyOptionKey) -> Bool {
-        lhs.id == rhs.id
+    public static func == (lhs: AnyPropertyOptionKey, rhs: AnyPropertyOptionKey) -> Bool {
+        ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
+        hasher.combine(ObjectIdentifier(self))
     }
 }
 

--- a/Sources/Apodini/Properties/Options/PropertyOptionKey.swift
+++ b/Sources/Apodini/Properties/Options/PropertyOptionKey.swift
@@ -2,7 +2,8 @@ import Foundation
 
 
 /// A type erasure for the `PropertyOptionKey`
-public class AnyPropertyOptionKey: NSObject {
+public class AnyPropertyOptionKey: Equatable, Hashable {
+    let id = UUID()
     /// Combines two `PropertyOptionKey`s.
     /// - Parameters:
     ///   - lhs: The left hand side `PropertyOptionKey` that should be combined
@@ -10,6 +11,14 @@ public class AnyPropertyOptionKey: NSObject {
     /// - Returns: The combined `PropertyOptionKey`
     func combine(lhs: Any, rhs: Any) -> Any {
         fatalError("AnyPropertyOptionKey.combine should be overridden!")
+    }
+
+    public static func ==(lhs: AnyPropertyOptionKey, rhs: AnyPropertyOptionKey) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }
 


### PR DESCRIPTION
# *Get rid of NSObject*

## :recycle: Current situation
We are currently using `NSObject` for `AnyPropertyOptionKey` to conform to `Hashable`.

## :bulb: Proposed solution
Instead of using the `Hashable` implementation of `NSObject` use `ObjectIdentifier` to give the object an identity and use that to implement `Hashable` and `Equatable`.

### Problem that is solved
Less legacy Objective-C code.

### Implications
None

### Related PRs
None