### PR TITLE
Fix HandlerIdentifier Access Level

### DIFF
--- a/Sources/Apodini/Components/Handler/HandlerIdentifier.swift
+++ b/Sources/Apodini/Components/Handler/HandlerIdentifier.swift
@@ -10,7 +10,7 @@
 
 
 /// An `AnyHandlerIdentifier` object identifies a `Handler` regardless of its concrete type.
-public class AnyHandlerIdentifier: RawRepresentable, Hashable, Equatable, CustomStringConvertible {
+open class AnyHandlerIdentifier: RawRepresentable, Hashable, Equatable, CustomStringConvertible {
     public let rawValue: String
     
     public required init(rawValue: String) {
@@ -42,7 +42,7 @@ public class AnyHandlerIdentifier: RawRepresentable, Hashable, Equatable, Custom
 
 /// A `Handler` identifier which is scoped to a specific handler type.
 /// This is the primary way components should be identified and referenced.
-public class ScopedHandlerIdentifier<H: IdentifiableHandler>: AnyHandlerIdentifier {
+open class ScopedHandlerIdentifier<H: IdentifiableHandler>: AnyHandlerIdentifier {
     public required init(rawValue: String) {
         super.init(rawValue: "\(H.self).\(rawValue)")
     }


### PR DESCRIPTION
# Fix HandlerIdentifier Access Level

## :recycle: Current situation
Both `AnyHandlerIdentifier` and `ScopedHandlerIdentifier` are defined with an access level of `public`.
This means that, while they can be accessed from outside the Apodini module, they cannot be subclassed from outside the module.
However, being able to subclass `ScopedHandlerIdentifier` is the entire point of why this type exists.

## :bulb: Proposed solution
We replace the `public` access level with `open`. This both makes the type available outside the Apodini module (`open` implies `public`) and also allows subclassing.


## :heavy_plus_sign: Additional Information
Ideally I'd like just `ScopedHandlerIdentifier` to be subclassable, but open types cannot inherit from non-open types, so we also have to make `AnyHandlerIdentifier` subclassable. This shouldn't matter much, though, since none of the type's methods are open (meaning that, while someone could subclass the types, they couldn't override any methods (apart from the initializers)).


### Testing
This does not affect testing in any way.


### Reviewer Nudging
This should be an easy one
