### PR TITLE
Remove warning about .content Parameters in the REST Exporter

### DIFF
--- a/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/RESTInterfaceExporter.swift
@@ -165,12 +165,6 @@ class RESTInterfaceExporter: InterfaceExporter {
                 return nil
             }
 
-            #warning("""
-                     A Handler could define multiple .content Parameters. In such a case the REST exporter would
-                     need to decode the content via a struct containing those .content parameters as properties.
-                     This is currently unsupported.
-                     """)
-
             return try request.content.decode(Type.self, using: JSONDecoder())
         }
     }


### PR DESCRIPTION
# Remove warning about .content Parameters in the REST Exporter

## :recycle: Current situation
We have warnings in the code.

## :bulb: Proposed solution
This Mini PR removes the warning and created a dedicated issue #133 for it.

### Problem that is solved
Less warnings

### Implications
--

## :heavy_plus_sign: Additional Information

### Related PRs
--

### Testing
none

### Reviewer Nudging
--
