### PR TITLE
Exclude Mock Certificates from Test Target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -67,7 +67,9 @@ let package = Package(
                 "ConfigurationTests/mock_fcm.json",
                 "ConfigurationTests/mock_invalid_fcm.json",
                 "ConfigurationTests/mock.p8",
-                "ConfigurationTests/mock.pem"
+                "ConfigurationTests/mock.pem",
+                "ConfiguartionTests/cert.pem",
+                "ConfiguartionTests/key.pem"
             ]
         ),
         .target(


### PR DESCRIPTION
# Exclude Mock Certificates from Test Target

## :recycle: Current situation
I forgot to exclude the certificates I added to test the http2 config from the test target

## :bulb: Proposed solution
Just exclude them

### Problem that is solved
Warning is fixed

### Implications
none

### Related PRs
#82 
