### PR TITLE
[BUG FIX] Add test case to stop flaky test coverage

### DIFF
--- a/Tests/ApodiniTests/SemanticModel/EndpointsTreeTests.swift
+++ b/Tests/ApodiniTests/SemanticModel/EndpointsTreeTests.swift
@@ -7,6 +7,7 @@
 
 @testable import Apodini
 import XCTest
+import Foundation
 
 
 final class EndpointsTreeTests: ApodiniTests {
@@ -129,5 +130,18 @@ final class EndpointsTreeTests: ApodiniTests {
         }
         
         XCTAssertEqual(responseValue, "✅ Hello \(name) ✅")
+    }
+    
+    func testEndpointPathEquatable() throws {
+        let path1: EndpointPath = .root
+        let path2: EndpointPath = .string("a")
+        let path3: EndpointPath = .parameter(EndpointPathParameter<String>(id: UUID()))
+        
+        XCTAssertEqual(path1, path1)
+        XCTAssertEqual(path2, path2)
+        XCTAssertEqual(path3, path3)
+        XCTAssertNotEqual(path1, path2)
+        XCTAssertNotEqual(path2, path3)
+        XCTAssertNotEqual(path1, path3)
     }
 }


### PR DESCRIPTION
# Add test case to avoid flaky test coverage

## :recycle: Current situation
We had a bug producing flaky test coverage results.

## :bulb: Proposed solution
As proposed in https://github.com/Apodini/Apodini/issues/152#issuecomment-762516823, we would add a test case that ensures to cover all cases in [`EndpointPath: Equatable`](https://github.com/Apodini/Apodini/blob/62dbacbb64be9f3782637d94cab7840a943d9aea/Sources/Apodini/Semantic%20Model%20Builder/Model/EndpointPath.swift#L62) as done by:

`testEndpointPathEquatable()` in `EndpointsTreeTests`

### Problem that is solved
#152 

### Implications
We can expect stable test coverage results.

## :heavy_plus_sign: Additional Information

### Reviewer Nudging
Questions would be:

1. Is this the right test class to add the test?
2. Is is too exhaustive to test all cases, even though we know, that only the default case was not deterministically executed?
