### PR TITLE
Export Additional Products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,8 @@ let package = Package(
             name: "ApodiniTests",
             dependencies: [
                 .product(name: "XCTVapor", package: "vapor"),
-                .target(name: "XCTApodini")
+                .target(name: "XCTApodini"),
+                .target(name: "ApodiniDatabase")
             ],
             exclude: [
                 "ConfigurationTests/Certificates/cert.pem",

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,10 @@ let package = Package(
         .macOS(.v10_15)
     ],
     products: [
-        .library(name: "Apodini", targets: ["Apodini"])
+        .library(name: "Apodini", targets: ["Apodini"]),
+        .library(name: "ApodiniDatabase", targets: ["ApodiniDatabase"]),
+        .library(name: "Notifications", targets: ["Notifications"]),
+        .library(name: "Jobs", targets: ["Jobs"])
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.35.0"),
@@ -65,8 +68,7 @@ let package = Package(
             dependencies: [
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
                 .product(name: "CwlPreconditionTesting", package: "CwlPreconditionTesting", condition: .when(platforms: [.macOS])),
-                .target(name: "Apodini"),
-                .target(name: "ApodiniDatabase")
+                .target(name: "Apodini")
             ]
         ),
         .testTarget(

--- a/Tests/ApodiniTests/DatabaseTests/DatabaseFieldPropertyTests.swift
+++ b/Tests/ApodiniTests/DatabaseTests/DatabaseFieldPropertyTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import NIO
 import Vapor
 import Fluent
-import Runtime
+@_implementationOnly import Runtime
 @testable import Apodini
 @testable import ApodiniDatabase
 

--- a/Tests/ApodiniTests/DatabaseTests/DatabaseHandlerTests.swift
+++ b/Tests/ApodiniTests/DatabaseTests/DatabaseHandlerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import NIO
 import Vapor
 import Fluent
-import Runtime
+@_implementationOnly import Runtime
 @testable import Apodini
 @testable import ApodiniDatabase
 


### PR DESCRIPTION
# *Export Additional Products*

## :recycle: Current situation
Apodini web services defined outside of the Apodini project can not use the `ApodiniDatabase`, `Jobs`, and `Notifications` targets as they are only defined internally and not exported as `products` in Package.swift.

## :bulb: Proposed solution
This PR exposes `ApodiniDatabase`, `Jobs`, and `Notifications` as`products` in Package.swift.

### Problem that is solved
Other web service implementations can now use the `ApodiniDatabase`, `Jobs`, and `Notifications` implementations.

### Implications
No implications on Apodini itself. Contributors of `ApodiniDatabase`, `Jobs`, and `Notifications` have to be aware that their public interface can now used by external dependencies.
