### PR TITLE
Align REST response container and OAS response types

### DIFF
--- a/Sources/Apodini/Semantic Model Builder/OpenAPI/Document/OpenAPIComponentsObjectBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/OpenAPI/Document/OpenAPIComponentsObjectBuilder.swift
@@ -49,6 +49,14 @@ class OpenAPIComponentsObjectBuilder {
         return JSONSchema.reference(.component(named: schemaName))
     }
 
+    func buildResponse(for type: Encodable.Type) throws -> JSONSchema {
+        let schema = try buildSchema(for: type)
+        return JSONSchema.object(properties: [
+            ResponseContainer.CodingKeys.data.rawValue: schema,
+            ResponseContainer.CodingKeys.links.rawValue: try buildSchema(for: [String: String].self)
+        ])
+    }
+
     func buildSchema(for type: Encodable.Type) throws -> JSONSchema {
         let node: Node<JSONSchema>? = try Self.node(type)?
             .contextMap(contextMapNode)
@@ -70,12 +78,7 @@ class OpenAPIComponentsObjectBuilder {
                 }
             }
             let schemaObject = JSONSchema.object(properties: properties)
-            // in case of `ResponseContainer` we do not want to create a `schema` here
-            if node.value.typeInfo.mangledName != "ResponseContainer" {
-                self.componentsObject.schemas[componentKey(for: schemaName)] = schemaObject
-            } else {
-                schema = schemaObject
-            }
+            self.componentsObject.schemas[componentKey(for: schemaName)] = schemaObject
         }
         return schema
     }

--- a/Sources/Apodini/Semantic Model Builder/OpenAPI/Document/OpenAPIComponentsObjectBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/OpenAPI/Document/OpenAPIComponentsObjectBuilder.swift
@@ -51,7 +51,7 @@ class OpenAPIComponentsObjectBuilder {
 
     func buildResponse(for type: Encodable.Type) throws -> JSONSchema {
         let schema = try buildSchema(for: type)
-        return JSONSchema.object(properties: [
+        return .object(properties: [
             ResponseContainer.CodingKeys.data.rawValue: schema,
             ResponseContainer.CodingKeys.links.rawValue: try buildSchema(for: ResponseContainer.Links.self)
         ])

--- a/Sources/Apodini/Semantic Model Builder/OpenAPI/Document/OpenAPIComponentsObjectBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/OpenAPI/Document/OpenAPIComponentsObjectBuilder.swift
@@ -67,7 +67,7 @@ class OpenAPIComponentsObjectBuilder {
     }
 
     private func contextMapNode(node: Node<EnrichedInfo>) -> JSONSchema {
-        var schema = mapInfo(node)
+        let schema = mapInfo(node)
         let schemaName = node.value.typeInfo.mangledName
 
         if schema.isReference && !schemaExists(for: schemaName) {

--- a/Sources/Apodini/Semantic Model Builder/OpenAPI/Document/OpenAPIComponentsObjectBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/OpenAPI/Document/OpenAPIComponentsObjectBuilder.swift
@@ -53,7 +53,7 @@ class OpenAPIComponentsObjectBuilder {
         let schema = try buildSchema(for: type)
         return JSONSchema.object(properties: [
             ResponseContainer.CodingKeys.data.rawValue: schema,
-            ResponseContainer.CodingKeys.links.rawValue: try buildSchema(for: [String: String].self)
+            ResponseContainer.CodingKeys.links.rawValue: try buildSchema(for: ResponseContainer.Links.self)
         ])
     }
 

--- a/Sources/Apodini/Semantic Model Builder/OpenAPI/Document/OpenAPIPathsObjectBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/OpenAPI/Document/OpenAPIPathsObjectBuilder.swift
@@ -124,7 +124,7 @@ private extension OpenAPIPathsObjectBuilder {
         var responseContent: OpenAPI.Content.Map = [:]
         let responseJSONSchema: JSONSchema
         do {
-            responseJSONSchema = try componentsObjectBuilder.buildSchema(for: responseType)
+            responseJSONSchema = try componentsObjectBuilder.buildResponse(for: responseType)
         } catch {
             fatalError("Could not build schema for response body for type \(responseType).")
         }

--- a/Sources/Apodini/Semantic Model Builder/REST/RESTEndpointHandler.swift
+++ b/Sources/Apodini/Semantic Model Builder/REST/RESTEndpointHandler.swift
@@ -9,8 +9,9 @@ import protocol FluentKit.Database
 extension Vapor.Request: ExporterRequest, WithEventLoop {}
 
 struct ResponseContainer: Encodable, ResponseEncodable {
+    typealias Links = [String: String]
     var data: AnyEncodable?
-    var links: [String: String]
+    var links: Links
 
     enum CodingKeys: String, CodingKey {
         case data = "data"

--- a/Tests/ApodiniTests/OpenAPITests/OpenAPIComponentsObjectBuilderTests.swift
+++ b/Tests/ApodiniTests/OpenAPITests/OpenAPIComponentsObjectBuilderTests.swift
@@ -54,11 +54,6 @@ final class OpenAPIComponentsObjectBuilderTests: XCTestCase {
         let someString: String?
     }
     
-    struct ResponseContainer<T>: Encodable where T: Encodable {
-        var data: T
-        var links: [String: String]
-    }
-
     // add primitive types and non structs (will not be added to components map, but defined inline)
     func testBuildSchemaNonStructs() throws {
         let componentsBuilder = OpenAPIComponentsObjectBuilder()
@@ -87,16 +82,16 @@ final class OpenAPIComponentsObjectBuilderTests: XCTestCase {
     }
 
     // add complex type (will be added to components map)
-    func testBuildSchemaResponseContainer() throws {
+    func testBuildSchemaForResponses() throws {
         let componentsBuilder = OpenAPIComponentsObjectBuilder()
-        XCTAssertNoThrow(try componentsBuilder.buildSchema(for: ResponseContainer<SomeStruct>.self))
-        let schema = try componentsBuilder.buildSchema(for: ResponseContainer<SomeStruct>.self)
+        XCTAssertNoThrow(try componentsBuilder.buildResponse(for: SomeStruct.self))
+        let schema = try componentsBuilder.buildResponse(for: SomeStruct.self)
         
-        XCTAssertThrowsError(try JSONSchema.reference(.component(named: "\(ResponseContainer<SomeStruct>.self)")).dereferenced(in: componentsBuilder.componentsObject))
+        XCTAssertThrowsError(try JSONSchema.reference(.component(named: "SomeStruct.self")).dereferenced(in: componentsBuilder.componentsObject))
         
         XCTAssertEqual(schema, .object(properties: [
-            "data": try componentsBuilder.buildSchema(for: SomeStruct.self),
-            "links": try componentsBuilder.buildSchema(for: type(of: someDict))
+            ResponseContainer.CodingKeys.data.rawValue: try componentsBuilder.buildSchema(for: SomeStruct.self),
+            ResponseContainer.CodingKeys.links.rawValue: try componentsBuilder.buildSchema(for: ResponseContainer.Links.self)
         ]))
         XCTAssertEqual(componentsBuilder.componentsObject.schemas.count, 1)
     }

--- a/Tests/ApodiniTests/OpenAPITests/OpenAPIDocumentBuilderTests.swift
+++ b/Tests/ApodiniTests/OpenAPITests/OpenAPIDocumentBuilderTests.swift
@@ -44,7 +44,10 @@ final class OpenAPIDocumentBuilderTests: XCTestCase {
                                 OpenAPI.Response(
                                     description: "OK",
                                     content: [
-                                        .json: .init(schema: .reference(.component(named: "SomeStruct")))
+                                        .json: .init(schema: .object(properties: [
+                                            ResponseContainer.CodingKeys.data.rawValue: .reference(.component(named: "SomeStruct")),
+                                            ResponseContainer.CodingKeys.links.rawValue: .object(additionalProperties: .init(.string))
+                                        ]))
                                     ]
                                 )
                             ),
@@ -70,7 +73,7 @@ final class OpenAPIDocumentBuilderTests: XCTestCase {
         )
 
         let builtDocument = documentBuilder.build()
-        
+
         XCTAssertNotNil(documentBuilder.jsonDescription)
         XCTAssertEqual(builtDocument, document)
     }

--- a/Tests/ApodiniTests/OpenAPITests/OpenAPIPathsObjectBuilderTests.swift
+++ b/Tests/ApodiniTests/OpenAPITests/OpenAPIPathsObjectBuilderTests.swift
@@ -45,6 +45,7 @@ final class OpenAPIPathsObjectBuilderTests: XCTestCase {
     }
 
     @PathParameter var param: String
+
     struct HandlerParam: Handler {
         @Parameter
         var pathParam: String
@@ -146,9 +147,15 @@ final class OpenAPIPathsObjectBuilderTests: XCTestCase {
             ),
             responses: [
                 .status(code: 200): .init(
-                    OpenAPI.Response(description: "OK", content: [
-                        .json: .init(schema: .reference(.component(named: "ResponseStruct")))
-                    ])),
+                    OpenAPI.Response(
+                        description: "OK",
+                        content: [
+                            .json: .init(schema: .object(properties: [
+                                ResponseContainer.CodingKeys.data.rawValue: .reference(.component(named: "ResponseStruct")),
+                                ResponseContainer.CodingKeys.links.rawValue: .object(additionalProperties: .init(.string))
+                            ]))
+                        ]
+                    )),
                 .status(code: 401): .init(
                     OpenAPI.Response(description: "Unauthorized")),
                 .status(code: 403): .init(


### PR DESCRIPTION
#  Align REST response container and OAS response types
## :recycle: Current situation
With merging #138 the OAS representation should have been prepared for using the same response container as the REST exporter (`ResponseContainer`).
To keep it simple and short: When I wanted to incorporate a refactored REST `ResponseContainer<T>`, I ended up with this problem:

```swift
// the following does not work (you can't instantiate a generic type with a variable, here `responseType: Encodable.Type`)
responseJSONSchema = try componentsObjectBuilder.buildResponse(for: ResponseContainer<responseType>.self)
```
No workaround I could think of worked (e.g., using a function `func getWrappedType<T>(of type: T.Type) -> ResponseContainer<T>.Type { ResponseContainer<T>.self }`).
After some reconsideration and suggest to keep `ResponseContainer` in REST as it is and "refactor/undo" what was done in #138.
As proposed below, we can still share the `ResponseContainer` data structure between REST and OAS.

## :bulb: Proposed solution

To still keep the response representation of OpenAPI- and RESTInterfaceExporter in sync, instead of sharing the same type, I propose to share `Coding Keys` and a `typealias` for `links`.

### Problem that is solved
#118

### Implications
ResponseContainer in RESTInterfaceExporter:
```swift
struct ResponseContainer: Encodable, ResponseEncodable {
    typealias Links = [String: String]
    var data: AnyEncodable?
    var links: Links

   //...
}
```
In the OpenAPIExporter, building the schema for responses is now differently handled than building the schema for requests:

```swift
func buildResponse(for type: Encodable.Type) throws -> JSONSchema {
        let schema = try buildSchema(for: type)
        return .object(properties: [
            ResponseContainer.CodingKeys.data.rawValue: schema, // the "data" 
            ResponseContainer.CodingKeys.links.rawValue: try buildSchema(for: ResponseContainer.Links.self) // the "links"
        ])
    }
```

## :heavy_plus_sign: Additional Information

### Related PRs
#138 (merged)
#147 

### Testing
I needed to refactor some existing tests.

### Reviewer Nudging
Should be easy to review by just investigating the files changed.
