### PR TITLE
Single Read Handler

### DIFF
--- a/Sources/ApodiniDatabase/Handlers/Read/ReadAll.swift
+++ b/Sources/ApodiniDatabase/Handlers/Read/ReadAll.swift
@@ -11,7 +11,7 @@ import Apodini
 /// }
 /// Sending a request to  ~/api/birds/birds?age=19&name=Foo would 
 ///return an array of `Bird` object that have an age of 19 and the name Foo.
-public struct Read<Model: DatabaseModel>: Handler {
+public struct ReadAll<Model: DatabaseModel>: Handler {
     @Apodini.Environment(\.database)
     private var database: Fluent.Database
 

--- a/Sources/ApodiniDatabase/Handlers/Read/ReadOne.swift
+++ b/Sources/ApodiniDatabase/Handlers/Read/ReadOne.swift
@@ -2,7 +2,7 @@ import Fluent
 import Apodini
 @_implementationOnly import Vapor
 
-struct SingleRead<Model: DatabaseModel>: Handler {
+struct ReadOne<Model: DatabaseModel>: Handler {
     @Throws(.notFound, reason: "No object was found in the database under the given id")
     var objectNotFoundError: ApodiniError
     

--- a/Sources/ApodiniDatabase/Handlers/Read/SingleRead.swift
+++ b/Sources/ApodiniDatabase/Handlers/Read/SingleRead.swift
@@ -1,0 +1,18 @@
+import Fluent
+import Apodini
+@_implementationOnly import Vapor
+
+struct SingleRead<Model: DatabaseModel>: Handler {
+    @Throws(.notFound, reason: "No object was found in the database under the given id")
+    var objectNotFoundError: ApodiniError
+    
+    @Apodini.Environment(\.database)
+    private var database: Fluent.Database
+    
+    @Parameter(.http(.path))
+    var id: Model.IDValue
+    
+    func handle() throws -> EventLoopFuture<Model> {
+        Model.find(id, on: database).unwrap(orError: objectNotFoundError)
+    }
+}

--- a/Tests/ApodiniTests/DatabaseTests/DatabaseHandlerTests.swift
+++ b/Tests/ApodiniTests/DatabaseTests/DatabaseHandlerTests.swift
@@ -44,6 +44,39 @@ final class DatabaseHandlerTests: ApodiniTests {
         XCTAssertEqual(response, foundBird)
     }
     
+    func testSingleReadHandler() throws {
+        let bird = Bird(name: "Mockingbird", age: 20)
+        let dbBird = try bird
+            .save(on: self.app.db)
+            .transform(to: bird)
+            .wait()
+        let birdId = try XCTUnwrap(dbBird.id)
+        
+        let handler = SingleRead<Bird>()
+        let endpoint = handler.mockEndpoint()
+        
+        let exporter = RESTInterfaceExporter(app)
+        var context = endpoint.createConnectionContext(for: exporter)
+        
+        let uri = URI("http://example.de/test/id")
+        let request = Vapor.Request(
+            application: vaporApp,
+            method: .GET,
+            url: uri,
+            on: app.eventLoopGroup.next()
+        )
+        
+        let idParameter = try pathParameter(for: handler)
+        request.parameters.set("\(idParameter.id)", to: "\(birdId)")
+        
+        let result = try context.handle(request: request).wait()
+        guard case let .final(response) = result.typed(Bird.self) else {
+            XCTFail("Expected return value to be wrapped in Action.final by default")
+            return
+        }
+        XCTAssert(response == dbBird)
+    }
+    
     func testReadHandler() throws {
         let bird1 = Bird(name: "Mockingbird", age: 20)
         let dbBird1 = try bird1

--- a/Tests/ApodiniTests/DatabaseTests/DatabaseHandlerTests.swift
+++ b/Tests/ApodiniTests/DatabaseTests/DatabaseHandlerTests.swift
@@ -52,7 +52,7 @@ final class DatabaseHandlerTests: ApodiniTests {
             .wait()
         let birdId = try XCTUnwrap(dbBird.id)
         
-        let handler = SingleRead<Bird>()
+        let handler = ReadOne<Bird>()
         let endpoint = handler.mockEndpoint()
         
         let exporter = RESTInterfaceExporter(app)
@@ -92,7 +92,7 @@ final class DatabaseHandlerTests: ApodiniTests {
         XCTAssertNotNil(dbBird1.id)
         XCTAssertNotNil(dbBird2.id)
         
-        let readHandler = Read<Bird>()
+        let readHandler = ReadAll<Bird>()
         let endpoint = readHandler.mockEndpoint()
         
         let exporter = RESTInterfaceExporter(app)


### PR DESCRIPTION
# Single Read Handler

## :recycle: Current situation
As already mentioned in this [review](https://github.com/Apodini/Apodini/pull/70#pullrequestreview-571105829), there is currently no possibility to retrieve just one item from the database by its id. As this is something every web service should offer, this PR adds the corresponding functionality.

## :bulb: Proposed solution
Adding a handler that returns the object found by the id in the database. Nothing too fancy.

### Problem that is solved
Now single object queries (by id) are possible.

### Testing
Yes, one test covering the functionality of the new handler.

### Reviewer Nudging
These are just minor additions. Should be self-explanatory.
