### PR TITLE
Fix Memory Leaks in WebSocket Exporter

### DIFF
--- a/Sources/WebSocketInfrastructure/ConnectionResponsible.swift
+++ b/Sources/WebSocketInfrastructure/ConnectionResponsible.swift
@@ -12,7 +12,7 @@ import NIOWebSocket
 typealias ContextOpener = (ConnectionResponsible, UUID) -> (ContextResponsible)
 
 class ConnectionResponsible: Identifiable {
-    let websocket: WebSocket
+    weak var websocket: WebSocket?
     
     let database: Database?
     
@@ -31,7 +31,7 @@ class ConnectionResponsible: Identifiable {
         self.endpoints = endpoints
         self.logger = logger
         
-        websocket.onText { _, message in
+        websocket.onText { websocket, message in
             var context: UUID?
             
             do {
@@ -63,7 +63,7 @@ class ConnectionResponsible: Identifiable {
                 throw SerializationError.expectedUTF8
             }
             
-            self.websocket.send(data)
+            self.websocket?.send(data)
         } catch {
             self.logger.report(error: error)
         }
@@ -78,14 +78,14 @@ class ConnectionResponsible: Identifiable {
                 throw SerializationError.expectedUTF8
             }
             
-            self.websocket.send(data)
+            self.websocket?.send(data)
         } catch {
             self.logger.report(error: error)
         }
     }
     
     func close(_ code: WebSocketErrorCode) {
-        _ = websocket.close(code: code)
+        _ = websocket?.close(code: code)
     }
     
     func destruct(_ context: UUID) {
@@ -97,7 +97,7 @@ class ConnectionResponsible: Identifiable {
                 throw SerializationError.expectedUTF8
             }
             
-            self.websocket.send(data)
+            self.websocket?.send(data)
         } catch {
             self.logger.report(error: error)
         }

--- a/Sources/WebSocketInfrastructure/ConnectionResponsible.swift
+++ b/Sources/WebSocketInfrastructure/ConnectionResponsible.swift
@@ -12,7 +12,7 @@ import NIOWebSocket
 typealias ContextOpener = (ConnectionResponsible, UUID) -> (ContextResponsible)
 
 class ConnectionResponsible: Identifiable {
-    weak var websocket: WebSocket?
+    unowned var websocket: WebSocket
     
     let database: Database?
     
@@ -63,7 +63,7 @@ class ConnectionResponsible: Identifiable {
                 throw SerializationError.expectedUTF8
             }
             
-            self.websocket?.send(data)
+            self.websocket.send(data)
         } catch {
             self.logger.report(error: error)
         }
@@ -78,14 +78,14 @@ class ConnectionResponsible: Identifiable {
                 throw SerializationError.expectedUTF8
             }
             
-            self.websocket?.send(data)
+            self.websocket.send(data)
         } catch {
             self.logger.report(error: error)
         }
     }
     
     func close(_ code: WebSocketErrorCode) {
-        _ = websocket?.close(code: code)
+        _ = websocket.close(code: code)
     }
     
     func destruct(_ context: UUID) {
@@ -97,7 +97,7 @@ class ConnectionResponsible: Identifiable {
                 throw SerializationError.expectedUTF8
             }
             
-            self.websocket?.send(data)
+            self.websocket.send(data)
         } catch {
             self.logger.report(error: error)
         }

--- a/Sources/WebSocketInfrastructure/ContextResponsible.swift
+++ b/Sources/WebSocketInfrastructure/ContextResponsible.swift
@@ -33,9 +33,13 @@ class TypeSafeContextResponsible<I: Input, O: Encodable>: ContextResponsible {
             (default: I, output: AnyPublisher<Message<O>, Error>),
         con: ConnectionResponsible,
         context: UUID) {
+        guard let websocket = con.websocket else {
+            fatalError("Destructed ConnectionResponsible tried to initialize ContextResponsible!")
+        }
+        
         self.init(
             opener,
-            eventLoop: con.websocket.eventLoop,
+            eventLoop: websocket.eventLoop,
             database: con.database,
             send: { message in
                 con.send(message, in: context)

--- a/Sources/WebSocketInfrastructure/ContextResponsible.swift
+++ b/Sources/WebSocketInfrastructure/ContextResponsible.swift
@@ -33,13 +33,9 @@ class TypeSafeContextResponsible<I: Input, O: Encodable>: ContextResponsible {
             (default: I, output: AnyPublisher<Message<O>, Error>),
         con: ConnectionResponsible,
         context: UUID) {
-        guard let websocket = con.websocket else {
-            fatalError("Destructed ConnectionResponsible tried to initialize ContextResponsible!")
-        }
-        
         self.init(
             opener,
-            eventLoop: websocket.eventLoop,
+            eventLoop: con.websocket.eventLoop,
             database: con.database,
             send: { message in
                 con.send(message, in: context)

--- a/Sources/WebSocketInfrastructure/SyncMap.swift
+++ b/Sources/WebSocketInfrastructure/SyncMap.swift
@@ -103,6 +103,7 @@ private extension SyncMap {
                 if let completion = self.completion {
                     // In case we received a `completion` while waiting for the
                     // future we are done after passing this `completion` `downstream`.
+                    self.subscription = nil
                     self.lock.unlock()
                     self.downstream.receive(completion: completion)
                 } else {
@@ -122,6 +123,7 @@ private extension SyncMap {
             if !self.awaiting {
                 // If not awaiting a future right now, then we have to
                 // forward the completion right now.
+                self.subscription = nil
                 self.downstream.receive(completion: completion)
             } else {
                 // If we are currently waiting for a future to complete,
@@ -147,9 +149,9 @@ private extension SyncMap.Inner {
     // whenever downstream requested new demand. It can be used to call
     // `requestOne` under certain conditions.
     private class Inner: Subscription {
-        var subscription: Subscription
+        var subscription: Subscription?
         
-        private var onDemand: () -> Void
+        private var onDemand: (() -> Void)?
         
         init(upstream: Subscription, onDemand: @escaping () -> Void) {
             self.subscription = upstream
@@ -163,18 +165,20 @@ private extension SyncMap.Inner {
             self.lock.lock()
             self.demand += demand
             self.lock.unlock()
-            self.onDemand()
+            self.onDemand?()
         }
         
         func cancel() {
-            self.subscription.cancel()
+            self.subscription?.cancel()
+            self.subscription = nil
+            self.onDemand = nil
         }
         
         func requestOne() {
             self.lock.lock()
             if demand > 0 {
                 self.demand -= 1
-                self.subscription.request(.max(1))
+                self.subscription?.request(.max(1))
             }
             self.lock.unlock()
         }


### PR DESCRIPTION
# Fix Memory Leaks in WebSocket Exporter

## :recycle: Current situation
`syncMap` had a leak resulting in small amounts of memory not being freed when a context was closed. `ConnectionContext` had a memory leak resulting it staying in memory when the WebSocket connection was closed.

## :bulb: Proposed solution
Cyclic references were either broken using `weak` or manually de-referencing optionals.

### Implications
None.

### Testing
No additional tests.

### Reviewer Nudging
Change-set is tiny...
