### PR TITLE
fix default handler index paths

### DIFF
--- a/Sources/Apodini/Components/Component/Component.swift
+++ b/Sources/Apodini/Components/Component/Component.swift
@@ -39,7 +39,9 @@ extension Component {
             HandlerVisitorHelperImpl(visitor: visitor)(self)
             if Self.Content.self != Never.self {
                 visitor.enterContent {
-                    content.accept(visitor)
+                    visitor.enterComponentContext {
+                        content.accept(visitor)
+                    }
                 }
             }
         }


### PR DESCRIPTION
# fix default handler index paths

Fixes a bug where the default-generated handler identifiers (ie their index paths) could contain negative elements.
The issue was that we missed a `visitor.enterComponentContext` call for non-custom components.

Example:
```swift
struct WrappedComponent<T: Component>: Component {
    let wrapped: T
    var content: T { wrapped }
}

struct WebService: Apodini.WebService {
    var content: some Component {
        WrappedComponent(WrappedComponent(WrappedComponent(Text())))
    }
}
```

Here, all `WrappedComponent`s would use the default visit implementation, which only calls `enterContent` but not `enterComponentContext`. If we replace the `WrappedComponent`s with pathless `Group`s or manually constructed `TupleComponent`s (all three options would be semantically equivalent) we'd get the correct behaviour since Group's and TupleComponent's accept implementations call both functions (`enterContent` and `enterComponentContext`).


### Testing
added a test to catch this in the future


### Reviewer Nudging
look at the code, run the example
