### PR TITLE
Move Fluent to Database Target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,11 +47,6 @@ let package = Package(
             name: "Apodini",
             dependencies: [
                 .product(name: "Vapor", package: "vapor"),
-                .product(name: "Fluent", package: "fluent"),
-                .product(name: "FluentMongoDriver", package: "fluent-mongo-driver"),
-                .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
-                .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
-                .product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),
                 .product(name: "AssociatedTypeRequirementsKit", package: "AssociatedTypeRequirementsKit"),
                 .product(name: "Runtime", package: "Runtime"),
                 .product(name: "APNS", package: "apns"),
@@ -72,6 +67,12 @@ let package = Package(
         .target(
             name: "ApodiniDatabase",
             dependencies: [
+                .product(name: "Vapor", package: "vapor"),
+                .product(name: "Fluent", package: "fluent"),
+                .product(name: "FluentMongoDriver", package: "fluent-mongo-driver"),
+                .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
+                .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
+                .product(name: "FluentMySQLDriver", package: "fluent-mysql-driver"),
                 .target(name: "Apodini")
             ]
         ),
@@ -142,7 +143,8 @@ let package = Package(
         .target(
             name: "Notifications",
             dependencies: [
-                .target(name: "Apodini")
+                .target(name: "Apodini"),
+                .target(name: "ApodiniDatabase")
             ]
         ),
         .testTarget(

--- a/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
+++ b/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
@@ -1,4 +1,5 @@
 import Fluent
+import Apodini
 @_implementationOnly import struct Vapor.Environment
 @_implementationOnly import FluentSQLiteDriver
 @_implementationOnly import FluentMySQLDriver
@@ -38,9 +39,6 @@ public final class DatabaseConfiguration: Configuration {
             databases.use(factory, as: databaseID)
             app.migrations.add(migrations)
             try app.autoMigrate().wait()
-            if let database = app.databases.ids().map({ app.db($0) }).first {
-                EnvironmentValues.shared.database = database
-            }
         } catch {
             fatalError("An error occured while configuring the database.")
         }

--- a/Sources/Notifications/DatabaseConfiguration+Notifications.swift
+++ b/Sources/Notifications/DatabaseConfiguration+Notifications.swift
@@ -1,4 +1,5 @@
 import Apodini
+import ApodiniDatabase
 
 extension DatabaseConfiguration {
     /// Adds a database migration which is used by the `NotificationCenter`.

--- a/Tests/ApodiniTests/ConfigurationTests/DatabaseConfigurationTests.swift
+++ b/Tests/ApodiniTests/ConfigurationTests/DatabaseConfigurationTests.swift
@@ -1,4 +1,5 @@
 @testable import Apodini
+@testable import ApodiniDatabase
 import XCTest
 
 final class DatabaseConfigurationTests: XCTestCase {

--- a/Tests/NotificationsTests/DatabaseSchemaCreation.swift
+++ b/Tests/NotificationsTests/DatabaseSchemaCreation.swift
@@ -1,4 +1,5 @@
 import Apodini
+import ApodiniDatabase
 import XCTest
 @testable import Notifications
 


### PR DESCRIPTION
# Fluent to Database Target

## :recycle: Current situation
Currently the main target holds the dependencies for Fluent and its database drivers although no file has a reference on them. 

## :bulb: Proposed solution
A User should not need to import Fluent or related products if he is not using any of its functionality. Therefore this pr moves all Fluent dependencies to the `ApodiniDatabase` target.

### Problem that is solved
Fluent is now imported when its needed.

### Related PRs
Provides a part-solution to #169 

### Testing
Only dependencies are moved, hence no tests.

### Reviewer Nudging
Should be an easy on.
