### PR TITLE
Ensure Java 11 is installed for the SonarCloud Scanner

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1.1
         with:
           xcode-version: latest
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Install sonar-scanner
         run: brew install sonar-scanner
       - uses: actions/cache@v2


### PR DESCRIPTION
# Ensure Java 11 is installed for the SonarCloud Scanner

## :recycle: Current situation
SonarCloud dropped Java 8 support.

## :bulb: Proposed solution
The action prepares Java 11 runtime.

### Problem that is solved
SonarCloud Scanner runs again.

### Implications
--
## :heavy_plus_sign: Additional Information
--

### Related PRs
* Fixes #195 

### Testing
--

### Reviewer Nudging
--
