### PR TITLE
Adjust the SonarCloud build cache key to the latest changes

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: .build
-          key: ${{ runner.os }}-spm-cachev2-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-spm-cache-${{ hashFiles('Package.resolved') }}
       - name: Check Xcode version
         run: xcodebuild -version
       - name: Check Swift version


### PR DESCRIPTION
# Adjust the SonarCloud build cache key to the latest changes

## :recycle: Current situation
In the latest changes of the Action files #193 #171 cache keys were adjusted.
But the SonarCloud workflow still used the old one.
As GitHub enforces a 5 GB cache limit, this is an unnecessary stress on that limit.

## :bulb: Proposed solution
Adjust the cache key as well.

### Problem that is solved
One cache entry less.

### Implications
--

## :heavy_plus_sign: Additional Information
--

### Related PRs
* #171 
* #193 

### Testing
--

### Reviewer Nudging
--