### PR TITLE
Update SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -165,7 +165,7 @@ only_rules:
   - multiline_parameters
     # Functions and methods parameters should be either on the same line, or one per line.
   - nesting
-    # Types and statements should only be nested to a certain level deep.
+    # Types and functions should only be nested to a certain level deep.
     # See nesting below for the exact configuration.
   - nimble_operator
     # Prefer Nimble operator overloads over free matcher functions.
@@ -363,7 +363,7 @@ line_length: # Lines should not span too many characters.
   ignores_function_declarations: false # default: false
   ignores_interpolated_strings: true # default: false
 
-nesting: # Types should be nested at most 2 level deep, and statements should be nested at most 5 levels deep.
+nesting: # Types should be nested at most 2 level deep, and functions should be nested at most 5 levels deep.
   type_level:
     warning: 2 # warning - default: 1
   function_level:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -366,7 +366,7 @@ line_length: # Lines should not span too many characters.
 nesting: # Types should be nested at most 2 level deep, and statements should be nested at most 5 levels deep.
   type_level:
     warning: 2 # warning - default: 1
-  statement_level:
+  function_level:
     warning: 5 # warning - default: 5
     
 trailing_closure:


### PR DESCRIPTION
## :recycle: Current situation

Running `swiftlint` locally produces:
```
'statement_level' has been renamed to 'function_level' and will be completely removed in a future release.
```

## :bulb: Proposed solution

Replace statement_level with function_level.

### Problem that is solved

The warning is resolved.

## :heavy_plus_sign: Additional Information

SwiftLint 0.42.0 release: https://github.com/realm/SwiftLint/releases/tag/0.42.0