### PR TITLE
Resolve a Deadlock-Bug in SyncMap and Buffer

### DIFF
--- a/Sources/WebSocketInfrastructure/Buffer.swift
+++ b/Sources/WebSocketInfrastructure/Buffer.swift
@@ -186,7 +186,7 @@ private extension Buffer.Inner {
             self.onCancel = onCancel
         }
 
-        private let lock = NSLock()
+        private let lock = NSRecursiveLock()
 
         func request(_ demand: Subscribers.Demand) {
             self.lock.lock()

--- a/Sources/WebSocketInfrastructure/SyncMap.swift
+++ b/Sources/WebSocketInfrastructure/SyncMap.swift
@@ -159,7 +159,7 @@ private extension SyncMap.Inner {
             self.onDemand = onDemand
         }
         
-        private let lock = NSLock()
+        private let lock = NSRecursiveLock()
         private var demand: Subscribers.Demand = .none
         
         func request(_ demand: Subscribers.Demand) {


### PR DESCRIPTION
# Resolve a Deadlock-Bug in SyncMap and Buffer

## :recycle: Current situation
While working on my example project I ran into deadlocks in the `Subscription`s of those two `Publisher`s. 

## :bulb: Proposed solution
Usage of `NSRecursiveLock` makes sure a EventLoop cannot be locked by one of its promises.

### Implications
Tiny performance impact.
