### PR TITLE
Added ParameterType for HTTP Headers

### DIFF
--- a/Sources/Apodini/Properties/Options/HTTPParameterMode.swift
+++ b/Sources/Apodini/Properties/Options/HTTPParameterMode.swift
@@ -9,6 +9,8 @@ public enum HTTPParameterMode: PropertyOption {
     case path
     /// The property associated with the `@Parameter` property wrapper should be decoded from the URI query of the HTTP request
     case query
+    /// The property associated with the `@Parameter` property wrapper should be decoded from the HTTP headers.
+    case header
 }
 
 extension PropertyOptionKey where PropertyNameSpace == ParameterOptionNameSpace, Option == HTTPParameterMode {

--- a/Sources/Apodini/Semantic Model Builder/Model/EndpointParameter.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/EndpointParameter.swift
@@ -166,6 +166,8 @@ public struct EndpointParameter<Type: Codable>: _AnyEndpointParameter {
             parameterType = .lightweight
         case .body:
             parameterType = .content
+        case .header:
+            parameterType = .header
         default:
             parameterType = Type.self is LosslessStringConvertible.Type ? .lightweight : .content
         }

--- a/Sources/Apodini/Semantic Model Builder/Model/ParameterNamespace.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/ParameterNamespace.swift
@@ -49,7 +49,7 @@ public extension Array where Element == ParameterNamespace {
     static let global: [ParameterNamespace] = [.all]
     /// With the `.individual` level, a parameter name must be
     /// unique across all parameters with the same `ParameterTyp` on the given `Endpoint`.
-    static let individual: [ParameterNamespace] = [.lightweight, .content, .path]
+    static let individual: [ParameterNamespace] = [.lightweight, .content, .path, .header]
 }
 
 extension ParameterNamespace {

--- a/Sources/Apodini/Semantic Model Builder/Model/ParameterNamespace.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/ParameterNamespace.swift
@@ -46,10 +46,10 @@ public extension Array where Element == ParameterNamespace {
     /// With the `.global` level, a parameter name must be
     /// unique across all `ParameterType`s on the given `Endpoint`.
     /// This is the default namespace when nothing is specified by the exporter.
-    static let global: [ParameterNamespace] = [.all]
+    static let global: [ParameterNamespace] = [.lightweight, .content, .path]
     /// With the `.individual` level, a parameter name must be
     /// unique across all parameters with the same `ParameterTyp` on the given `Endpoint`.
-    static let individual: [ParameterNamespace] = [.lightweight, .content, .path]
+    static let individual: [ParameterNamespace] = [.lightweight, .content, .path, .header]
 }
 
 extension ParameterNamespace {

--- a/Sources/Apodini/Semantic Model Builder/Model/ParameterNamespace.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/ParameterNamespace.swift
@@ -46,10 +46,10 @@ public extension Array where Element == ParameterNamespace {
     /// With the `.global` level, a parameter name must be
     /// unique across all `ParameterType`s on the given `Endpoint`.
     /// This is the default namespace when nothing is specified by the exporter.
-    static let global: [ParameterNamespace] = [.lightweight, .content, .path]
+    static let global: [ParameterNamespace] = [.all]
     /// With the `.individual` level, a parameter name must be
     /// unique across all parameters with the same `ParameterTyp` on the given `Endpoint`.
-    static let individual: [ParameterNamespace] = [.lightweight, .content, .path, .header]
+    static let individual: [ParameterNamespace] = [.lightweight, .content, .path]
 }
 
 extension ParameterNamespace {

--- a/Sources/Apodini/Semantic Model Builder/Model/ParameterNamespace.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/ParameterNamespace.swift
@@ -14,8 +14,9 @@ public struct ParameterNamespace: OptionSet {
     public static let lightweight = ParameterNamespace(rawValue: 1 << 0)
     public static let content = ParameterNamespace(rawValue: 1 << 1)
     public static let path = ParameterNamespace(rawValue: 1 << 2)
+    public static let header = ParameterNamespace(rawValue: 1 << 3)
 
-    fileprivate static let all: ParameterNamespace = [.lightweight, .content, .path]
+    fileprivate static let all: ParameterNamespace = [.lightweight, .content, .path, .header]
 }
 
 extension ParameterNamespace: CustomStringConvertible {
@@ -30,6 +31,10 @@ extension ParameterNamespace: CustomStringConvertible {
         }
         if (rawValue & 4) > 0 {
             types.append(.path)
+        }
+
+        if (rawValue & 8) > 0 {
+            types.append(.header)
         }
 
         return types.description
@@ -56,6 +61,8 @@ extension ParameterNamespace {
             return contains(.path)
         case .content:
             return contains(.content)
+        case .header:
+            return contains(.header)
         }
     }
 }

--- a/Sources/Apodini/Semantic Model Builder/Model/ParameterType.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/ParameterType.swift
@@ -15,6 +15,8 @@ public enum ParameterType {
     /// Such parameters have a matching parameter in the `[EndpointPath]`.
     /// Such parameters are required to conform to `LosslessStringConvertible`.
     case path
+    /// Parameters contained in the HTTP headers of a request.
+    case header
 }
 
 extension ParameterType: CustomStringConvertible {
@@ -26,6 +28,8 @@ extension ParameterType: CustomStringConvertible {
             return "content"
         case .path:
             return "path"
+        case .header:
+            return "header"
         }
     }
 }

--- a/Sources/ApodiniOpenAPI/Extensions/OpenAPIParameterContext+AnyEndpointParameter.swift
+++ b/Sources/ApodiniOpenAPI/Extensions/OpenAPIParameterContext+AnyEndpointParameter.swift
@@ -14,7 +14,7 @@ extension OpenAPI.Parameter.Context {
             self = .query
         case .path:
             self = .path
-        case .content:
+        case .content, .header:
             return nil
         }
     }

--- a/Sources/ApodiniREST/RESTInterfaceExporter.swift
+++ b/Sources/ApodiniREST/RESTInterfaceExporter.swift
@@ -97,6 +97,9 @@ public final class RESTInterfaceExporter: InterfaceExporter {
                 return nil
             }
             return try? request.content.decode(Type.self, using: JSONDecoder())
+
+        case .header:
+            return request.headers.first(name: parameter.name) as? Type
         }
     }
 }


### PR DESCRIPTION
# Added ParameterType for HTTP Headers

## :recycle: Current situation
For my final project I added support for header parameters to Apodini, but I didn't end up using it. I'll just leaves this here and let you guys decide if we want to add it,

## :bulb: Proposed solution
Add header `ParameterType`

### Problem that is solved
HTTP headers can be accessed

### Implications

## :heavy_plus_sign: Additional Information

### Related PRs

### Testing

### Reviewer Nudging
