### PR TITLE
Minor code cleanup in the REST Interface Exporter

### DIFF
--- a/Sources/Apodini/Components/Path/HideLinkModifier.swift
+++ b/Sources/Apodini/Components/Path/HideLinkModifier.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 05.01.21.
+// Created by Andreas Bauer on 05.01.21.
 //
 
 struct HideLinkContextKey: OptionalContextKey {

--- a/Sources/Apodini/Components/Path/PathComponentModifier.swift
+++ b/Sources/Apodini/Components/Path/PathComponentModifier.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 05.01.21.
+// Created by Andreas Bauer on 05.01.21.
 //
 
 protocol PathComponentModifier: _PathComponent {

--- a/Sources/Apodini/Components/Path/PathComponentParser.swift
+++ b/Sources/Apodini/Components/Path/PathComponentParser.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 05.01.21.
+// Created by Andreas Bauer on 05.01.21.
 //
 
 protocol PathComponentParser {

--- a/Sources/Apodini/Components/Path/RelationshipNameModifier.swift
+++ b/Sources/Apodini/Components/Path/RelationshipNameModifier.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 05.01.21.
+// Created by Andreas Bauer on 05.01.21.
 //
 
 struct RelationshipNameContextKey: OptionalContextKey {

--- a/Sources/Apodini/Relationships/RelationshipDefinition.swift
+++ b/Sources/Apodini/Relationships/RelationshipDefinition.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 20.12.20.
+// Created by Andreas Bauer on 20.12.20.
 //
 
 /// The `WithRelationships` protocol can be used on `Content` definitions

--- a/Sources/Apodini/Response/ResponseTransformable.swift
+++ b/Sources/Apodini/Response/ResponseTransformable.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 01.01.21.
+// Created by Andreas Bauer on 01.01.21.
 //
 
 import Foundation

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 22.11.20.
+// Created by Andreas Bauer on 22.11.20.
 //
 
 import protocol NIO.EventLoop

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/RequestHandler.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/RequestHandler.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 25.12.20.
+// Created by Andreas Bauer on 25.12.20.
 //
 
 import class NIO.EventLoopFuture

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/ValidatedRequest.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/ValidatedRequest.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 29.12.20.
+// Created by Andreas Bauer on 29.12.20.
 //
 import NIO
 import Foundation

--- a/Sources/Apodini/Semantic Model Builder/Model/Endpoint.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/Endpoint.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 22.11.20.
+// Created by Andreas Bauer on 22.11.20.
 //
 import Foundation
 

--- a/Sources/Apodini/Semantic Model Builder/Model/EndpointPath.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/EndpointPath.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 03.01.21.
+// Created by Andreas Bauer on 03.01.21.
 //
 
 import Foundation

--- a/Sources/Apodini/Semantic Model Builder/Model/ParameterNamespace.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/ParameterNamespace.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 06.01.21.
+// Created by Andreas Bauer on 06.01.21.
 //
 
 import Foundation

--- a/Sources/Apodini/Semantic Model Builder/Model/ParameterType.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/ParameterType.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 12.01.21.
+// Created by Andreas Bauer on 12.01.21.
 //
 
 /// `Parameter` categorization needed for certain interface exporters (e.g., HTTP-based).

--- a/Sources/Apodini/Semantic Model Builder/ParameterModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/ParameterModelBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 05.01.21.
+// Created by Andreas Bauer on 05.01.21.
 //
 
 extension Handler {

--- a/Sources/Apodini/Semantic Model Builder/PathModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/PathModelBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 05.01.21.
+// Created by Andreas Bauer on 05.01.21.
 //
 
 import Foundation

--- a/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 22.11.20.
+// Created by Andreas Bauer on 22.11.20.
 //
 
 import NIO

--- a/Sources/Apodini/Utilities/Optional.swift
+++ b/Sources/Apodini/Utilities/Optional.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 25.12.20.
+// Created by Andreas Bauer on 25.12.20.
 //
 
 @_implementationOnly import Runtime

--- a/Sources/ApodiniREST/RESTInterfaceExporter.swift
+++ b/Sources/ApodiniREST/RESTInterfaceExporter.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 22.11.20.
+// Created by Andreas Bauer on 22.11.20.
 //
 
 import Apodini
@@ -29,31 +29,25 @@ public final class RESTInterfaceExporter: InterfaceExporter {
 
         let operation = endpoint.operation
 
-        let exportedParameterNames = endpoint.exportParameters(on: self)
+        let endpointHandler = RESTEndpointHandler(with: configuration, for: endpoint, on: self)
+        endpointHandler.register(at: routesBuilder, using: operation)
 
-        let endpointHandler = RESTEndpointHandler(
-            configuration: configuration,
-            for: endpoint,
-            using: { endpoint.createConnectionContext(for: self) }
-        )
-        endpointHandler.register(at: routesBuilder, with: operation)
-
-        app.logger.info("Exported '\(Vapor.HTTPMethod(operation).rawValue) \(pathBuilder.pathDescription)' with parameters: \(exportedParameterNames)")
+        app.logger.info("Exported '\(Vapor.HTTPMethod(operation).rawValue) \(pathBuilder.pathDescription)' with parameters: \(endpoint.parameters.map { $0.name })")
 
         if endpoint.inheritsRelationship {
-            app.logger.info("  - inherits from: \(endpoint.selfRelationship.destinationPath.asPathString())")
+            for selfRelationship in endpoint.selfRelationships() where selfRelationship.destinationPath != endpoint.absolutePath {
+                app.logger.info("""
+                                  - inherits from: \(Vapor.HTTPMethod(selfRelationship.operation).rawValue) \
+                                \(selfRelationship.destinationPath.asPathString())
+                                """)
+            }
         }
 
-        for destination in endpoint.relationships(for: .read) {
-            let path = destination.destinationPath
-            app.logger.info("  - links to: \(path.asPathString())")
+        for operation in Operation.allCases.sorted(by: \.linksOperationPriority) {
+            for destination in endpoint.relationships(for: operation) {
+                app.logger.info("  - links to: \(destination.destinationPath.asPathString())")
+            }
         }
-    }
-
-    public func exportParameter<Type: Codable>(_ parameter: EndpointParameter<Type>) -> String {
-        // This is currently just a example on how one can use the exportParameter method
-        // The return type can be whatever you want
-        parameter.name
     }
 
     public func finishedExporting(_ webService: WebServiceModel) {

--- a/TestWebService/Package.resolved
+++ b/TestWebService/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/nerdsupremacist/AssociatedTypeRequirementsKit.git",
         "state": {
           "branch": null,
-          "revision": "d861e6dd41ad0c1096a9a730611fa6a8cc307b0c",
-          "version": "0.3.1"
+          "revision": "2e4c49c21ffb2135f1c99fbfcf2119c9d24f5e8c",
+          "version": "0.3.2"
         }
       },
       {

--- a/Tests/ApodiniTests/Helper/Components/Guards.swift
+++ b/Tests/ApodiniTests/Helper/Components/Guards.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 25.12.20.
+// Created by Andreas Bauer on 25.12.20.
 //
 
 @testable import Apodini

--- a/Tests/ApodiniTests/Helper/Components/ResponseTransformers.swift
+++ b/Tests/ApodiniTests/Helper/Components/ResponseTransformers.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 25.12.20.
+// Created by Andreas Bauer on 25.12.20.
 //
 
 @testable import Apodini

--- a/Tests/ApodiniTests/Helper/Mocks/MockEndpoint.swift
+++ b/Tests/ApodiniTests/Helper/Mocks/MockEndpoint.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 25.12.20.
+// Created by Andreas Bauer on 25.12.20.
 //
 
 @testable import Apodini

--- a/Tests/ApodiniTests/Helper/Mocks/MockExporter.swift
+++ b/Tests/ApodiniTests/Helper/Mocks/MockExporter.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 25.12.20.
+// Created by Andreas Bauer on 25.12.20.
 //
 
 import Foundation

--- a/Tests/ApodiniTests/Helper/Mocks/MockRequest.swift
+++ b/Tests/ApodiniTests/Helper/Mocks/MockRequest.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 25.12.20.
+// Created by Andreas Bauer on 25.12.20.
 //
 
 import XCTest

--- a/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 25.12.20.
+// Created by Andreas Bauer on 25.12.20.
 //
 
 @testable import Apodini

--- a/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
@@ -86,7 +86,7 @@ class RESTInterfaceExporterTests: ApodiniTests {
         }
     }
 
-    @PathParameter
+    @PathParameter(identifying: User.self)
     var userId: User.ID
 
     @ComponentBuilder

--- a/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
@@ -82,7 +82,7 @@ class RESTInterfaceExporterTests: ApodiniTests {
 
     struct AuthenticatedHandler: Handler {
         func handle() -> User {
-            User(id: 2, name: "Name")
+            User(id: "2", name: "Name")
         }
     }
 

--- a/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
@@ -80,6 +80,12 @@ class RESTInterfaceExporterTests: ApodiniTests {
         }
     }
 
+    struct AuthenticatedHandler: Handler {
+        func handle() -> User {
+            User(id: 2, name: "Name")
+        }
+    }
+
     @PathParameter
     var userId: User.ID
 
@@ -92,6 +98,9 @@ class RESTInterfaceExporterTests: ApodiniTests {
             $userId
         } content: {
             UserHandler(userId: $userId)
+        }
+        Group("authenticated") {
+            AuthenticatedHandler()
         }
     }
 

--- a/Tests/ApodiniTests/SemanticModel/ParameterNamespaceTests.swift
+++ b/Tests/ApodiniTests/SemanticModel/ParameterNamespaceTests.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 06.01.21.
+// Created by Andreas Bauer on 06.01.21.
 //
 
 import XCTest

--- a/Tests/ApodiniTests/SemanticModel/ParameterRetrievalTests.swift
+++ b/Tests/ApodiniTests/SemanticModel/ParameterRetrievalTests.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 25.12.20.
+// Created by Andreas Bauer on 25.12.20.
 //
 
 @testable import Apodini

--- a/Tests/ApodiniTests/SemanticModel/RelationshipPreliminaryTests.swift
+++ b/Tests/ApodiniTests/SemanticModel/RelationshipPreliminaryTests.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 21.12.20.
+// Created by Andreas Bauer on 21.12.20.
 //
 
 import XCTest

--- a/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
+++ b/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
@@ -1,5 +1,5 @@
 //
-// Created by Andi on 20.11.20.
+// Created by Andreas Bauer on 20.11.20.
 //
 
 import XCTest


### PR DESCRIPTION
# Minor code cleanup in the REST Interface Exporter

## :recycle: Current situation
--

## :bulb: Proposed solution
--

### Problem that is solved
* Code inside the `RESTInterfaceExporter` is simplified.
* Additionally the logging output is adjusted to correctly resemble what happens in the `RESTEndpointHandler`
* Ensure consistent and formal File author naming

### Implications
--

## :heavy_plus_sign: Additional Information
--

### Related PRs
--

### Testing
--

### Reviewer Nudging
--
