### PR TITLE
Replace `APNS` with `APNSwift`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "apns",
-        "repositoryURL": "https://github.com/vapor/apns.git",
-        "state": {
-          "branch": null,
-          "revision": "a8bc863a718eb23e05b2ae3bfc7de66407b6b85d",
-          "version": "1.0.1"
-        }
-      },
-      {
         "package": "apnswift",
         "repositoryURL": "https://github.com/kylebrowning/APNSwift.git",
         "state": {
           "branch": null,
-          "revision": "ce8213a3e0ec0581c4c39a155e7778401ec5e24a",
-          "version": "2.2.0"
+          "revision": "03e83e2332d13a3c06d5cd70948166e5724c43c7",
+          "version": "3.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         // Used to parse command line arguments
         .package(url: "https://github.com/vapor/console-kit.git", from: "4.2.4"),
         // Used by the `NotificationCenter` to send push notifications to `APNS`.
-        .package(url: "https://github.com/vapor/apns.git", from: "1.0.1"),
+        .package(name: "apnswift", url: "https://github.com/kylebrowning/APNSwift.git", from: "3.0.0"),
         // Used by the `NotificationCenter` to send push notifications to `FCM`.
         .package(url: "https://github.com/MihaelIsaev/FCM.git", from: "2.8.0"),
         .package(url: "https://github.com/vapor/fluent-mongo-driver.git", from: "1.0.2"),
@@ -136,7 +136,7 @@ let package = Package(
                 .target(name: "Apodini"),
                 .target(name: "ApodiniVaporSupport"),
                 .target(name: "ApodiniDatabase"),
-                .product(name: "APNS", package: "apns"),
+                .product(name: "APNSwift", package: "apnswift"),
                 .product(name: "FCM", package: "FCM")
             ]
         ),

--- a/Sources/Apodini/Application/Application+Connection.swift
+++ b/Sources/Apodini/Application/Application+Connection.swift
@@ -1,9 +1,33 @@
 //
-//  Connection.swift
+//  Application+Connection.swift
 //
 //
 //  Created by Moritz Schüll on 09.12.20.
 //
+// This code is based on the Vapor project: https://github.com/vapor/vapor
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Qutheory, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 
 import Foundation
 import NIO

--- a/Sources/Apodini/Application/Application+Core.swift
+++ b/Sources/Apodini/Application/Application+Core.swift
@@ -1,9 +1,33 @@
 //
-//  Core.swift
+//  Application+Core.swift
 //  
 //
 //  Created by Tim Gymnich on 22.12.20.
 //
+// This code is based on the Vapor project: https://github.com/vapor/vapor
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Qutheory, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 
 import NIO
 

--- a/Sources/Apodini/Application/Application+Directory.swift
+++ b/Sources/Apodini/Application/Application+Directory.swift
@@ -1,3 +1,34 @@
+//
+//  Application+Directory.swift
+//
+//
+//  Created by Tim Gymnich on 22.12.20.
+//
+// This code is based on the Vapor project: https://github.com/vapor/vapor
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Qutheory, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
 #if os(Linux)
 import Glibc
 #else

--- a/Sources/Apodini/Application/Application+Exporters.swift
+++ b/Sources/Apodini/Application/Application+Exporters.swift
@@ -1,9 +1,33 @@
 //
-//  File.swift
+//  Application+Exporters.swift
 //  
 //
 //  Created by Tim Gymnich on 1.2.21.
 //
+// This code is based on the Vapor project: https://github.com/vapor/vapor
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Qutheory, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 
 import NIO
 

--- a/Sources/Apodini/Application/Application+HTTP.swift
+++ b/Sources/Apodini/Application/Application+HTTP.swift
@@ -4,6 +4,30 @@
 //
 //  Created by Tim Gymnich on 26.12.20.
 //
+// This code is based on the Vapor project: https://github.com/vapor/vapor
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Qutheory, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 
 import NIOSSL
 

--- a/Sources/Apodini/Application/Application+Running.swift
+++ b/Sources/Apodini/Application/Application+Running.swift
@@ -4,6 +4,31 @@
 //
 //  Created by Tim Gymnich on 22.12.20.
 //
+//
+// This code is based on the Vapor project: https://github.com/vapor/vapor
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Qutheory, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 
 import NIO
 

--- a/Sources/Apodini/Application/Application.swift
+++ b/Sources/Apodini/Application/Application.swift
@@ -4,6 +4,30 @@
 //
 //  Created by Tim Gymnich on 22.12.20.
 //
+// This code is based on the Vapor project: https://github.com/vapor/vapor
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Qutheory, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 
 import Logging
 import NIO

--- a/Sources/Apodini/Application/Storage.swift
+++ b/Sources/Apodini/Application/Storage.swift
@@ -4,6 +4,31 @@
 //
 //  Created by Tim Gymnich on 22.12.20.
 //
+//
+// This code is based on the Vapor project: https://github.com/vapor/vapor
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Qutheory, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 
 import Logging
 

--- a/Sources/ApodiniDatabase/Application+Databases.swift
+++ b/Sources/ApodiniDatabase/Application+Databases.swift
@@ -4,6 +4,29 @@
 //
 //  Created by Tim Gymnich on 23.12.20.
 //
+// This code is based on the Vapor project: https://github.com/vapor/vapor
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Qutheory, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import Apodini
 import FluentKit

--- a/Sources/ApodiniNotifications/Configurations/APNSConfiguration.swift
+++ b/Sources/ApodiniNotifications/Configurations/APNSConfiguration.swift
@@ -1,4 +1,4 @@
-import APNS
+import APNSwift
 import JWTKit
 import Apodini
 

--- a/Sources/ApodiniNotifications/Configurations/Application/Application+APNS.swift
+++ b/Sources/ApodiniNotifications/Configurations/Application/Application+APNS.swift
@@ -45,7 +45,6 @@ extension Application {
 /// Holds the APNS Configuration
 public struct APNS {
     struct ConfigurationKey: StorageKey {
-        // swiftlint:disable nesting
         typealias Value = APNSwiftConfiguration
     }
     

--- a/Sources/ApodiniNotifications/Configurations/Application/Application+APNS.swift
+++ b/Sources/ApodiniNotifications/Configurations/Application/Application+APNS.swift
@@ -4,7 +4,8 @@
 //
 //  Created by Tim Gymnich on 23.12.20.
 //
-
+// This code is based on the Vapor project: https://github.com/vapor/vapor
+//
 // The MIT License (MIT)
 //
 // Copyright (c) 2020 Qutheory, LLC

--- a/Sources/ApodiniNotifications/DatabaseConfiguration+Notifications.swift
+++ b/Sources/ApodiniNotifications/DatabaseConfiguration+Notifications.swift
@@ -1,4 +1,3 @@
-import Apodini
 import ApodiniDatabase
 
 extension DatabaseConfiguration {

--- a/Sources/ApodiniNotifications/Models/Notification.swift
+++ b/Sources/ApodiniNotifications/Models/Notification.swift
@@ -1,4 +1,4 @@
-import APNS
+import APNSwift
 import FCM
 import Foundation
 

--- a/Sources/ApodiniNotifications/Models/NotificationPayload.swift
+++ b/Sources/ApodiniNotifications/Models/NotificationPayload.swift
@@ -1,4 +1,4 @@
-import APNS
+import APNSwift
 import FCM
 
 /// The `Payload` is used to configure plattform specific settings of a `Notification`.

--- a/Sources/ApodiniNotifications/NotificationCenter.swift
+++ b/Sources/ApodiniNotifications/NotificationCenter.swift
@@ -1,6 +1,6 @@
 // swiftlint:disable first_where
 import Fluent
-import APNS
+import APNSwift
 import FCM
 import NIO
 import Apodini

--- a/Tests/ApodiniNotificationsTests/NotificationCenterTests.swift
+++ b/Tests/ApodiniNotificationsTests/NotificationCenterTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import XCTApodini
 import Fluent
 import FCM
-import APNS
+import APNSwift
 import XCTVapor
 import Apodini
 @testable import ApodiniNotifications


### PR DESCRIPTION
# Replace `APNS` with `APNSwift`

## :recycle: Current situation

At the moment, we're using the [APNS](https://github.com/vapor/apns) library from Vapor to send push notifications. However, this library is only an abstraction of [APNSwift](https://github.com/kylebrowning/APNSwift), therefore, we can also replace it with `APNSwift` directly. This would reduce the target size of `ApodiniNotifications` since `APNSwift` is a peer dependency of `APNS`. Furthermore, this enables us to move the `APNS` struct of Apodini from a nested struct inside of `Application` to its own entity because the name collision with the `APNS` library is resolved. This is helpful when injecting the `apns` computed property with `@Environment` since the type changes from `Application.APNS` to just `APNS`.

## :bulb: Proposed solution

Replace `APNS` with `APNSwift` and adapt the `Application+APNS` file.

### Implications

Shouldn't have any usage on the usage.

## :heavy_plus_sign: Additional Information

Includes the MIT License of Vapor, since the implementation to `APNS` is similar.

### Testing

### Reviewer Nudging

The exisiting code base was just restructured.
