### PR TITLE
Binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,130 @@
 
 A declarative, composable framework to build web services using Swift.
 
-The framework is in a very early alpha phase. You can inspect the current development manifestos describing the framework in the [documentation folder](Documentation/)
+## Getting Started
+
+### Installation
+
+Apodini uses the Swift Package Manager:
+
+Add it as a project-dependency:
+```swift
+dependencies: [
+    .package(url: "https://github.com/Apodini/Apodini.git", .branch("develop"))
+]
+```
+
+Add the base package and all exporters you want to use to your target:
+```swift
+targets: [
+    .target(
+        name: "Your Target",
+        dependencies: [
+            .product(name: "Apodini", package: "Apodini"),
+            .product(name: "ApodiniREST", package: "Apodini"),
+            .product(name: "ApodiniOpenAPI", package: "Apodini")
+        ])
+]‚
+
+```
+
+### Hello World
+
+Getting started is really easy:
+
+```swift
+import Apodini
+import ApodiniREST
+
+struct Greeter: Handler {
+    @Parameter var country: String?
+
+    func handle() -> String {
+        "Hello, \(country ?? "World")!"
+    }
+}
+
+struct HelloWorld: WebService {
+    var configuration: Configuration {
+        ExporterConfiguration()
+            .exporter(RESTInterfaceExporter.self)
+    }
+
+    var content: some Component {
+        Greeter()
+    }
+}
+
+try HelloWorld.main()
+
+// http://localhost:8080/v1 -> Hello, World!
+// http://localhost:8080/v1?country=Italy -> Hello, Italy!
+```
+
+Apodini knows enough about your service to automatically generate OpenAPI docs. Just add the respective exporter:
+
+```swift
+import ApodiniOpenAPI
+...
+struct HelloWorld: WebService {
+    var configuration: Configuration {
+        ExporterConfiguration()
+            .exporter(RESTInterfaceExporter.self)
+            .exporter(OpenAPIInterfaceExporter.self)
+    }
+    ...
+}
+
+// JSON definition: http://localhost:8080/openapi
+// Swagger UI: http://localhost:8080/openapi-ui
+```
+
+With `Binding`s we can re-use `Handler`s in different contexts:
+```swift
+struct Greeter: Handler {
+    @Binding var country: String?
+
+    func handle() -> String {
+        "Hello, \(country ?? "World")!"
+    }
+}
+
+struct HelloWorld: WebService {
+    var configuration: Configuration {
+        ExporterConfiguration()
+            .exporter(RESTInterfaceExporter.self)
+            .exporter(OpenAPIInterfaceExporter.self)
+    }
+    
+    @PathParameter var country: String
+
+    var content: some Component {
+        Greeter(country: .constant(nil))
+            .description("Say 'Hello' to the World.")
+        Group("country") {
+            CountrySubsystem()
+        }
+    }
+}
+
+struct CountrySubsystem: Component {
+    @PathParameter var country: String
+    
+    var content: some Component {
+        Group($country) {
+            Greeter(country: Binding<String?>($country.projectedValue))
+                .description("Say 'Hello' to a country.")
+        }
+    }
+}
+
+// http://localhost:8080/v1 -> Hello, World!
+// http://localhost:8080/v1/country/Italy -> Hello, Italy!
+```
+
+## Documentation
+
+The framework is in early alpha phase. You can inspect the current development manifestos describing the framework in the [documentation folder](Documentation/)
 
 You can find a generated technical documentation for the different Swift types at [https://apodini.github.io/Apodini](https://apodini.github.io/Apodini)
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ struct HelloWorld: WebService {
             .exporter(RESTInterfaceExporter.self)
             .exporter(OpenAPIInterfaceExporter.self)
     }
-    
-    @PathParameter var country: String
 
     var content: some Component {
         Greeter(country: .constant(nil))

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ struct HelloWorld: WebService {
     }
 
     var content: some Component {
-        Greeter(country: .constant(nil))
+        Greeter(country: nil)
             .description("Say 'Hello' to the World.")
         Group("country") {
             CountrySubsystem()
@@ -114,7 +114,7 @@ struct CountrySubsystem: Component {
     
     var content: some Component {
         Group($country) {
-            Greeter(country: Binding<String?>($country.projectedValue))
+            Greeter(country: Binding<String?>(_country.binding))
                 .description("Say 'Hello' to a country.")
         }
     }

--- a/Sources/Apodini/Properties/Binding.swift
+++ b/Sources/Apodini/Properties/Binding.swift
@@ -1,0 +1,99 @@
+//
+//  Binding.swift
+//
+//
+//  Created by Max Obermeier on 23.02.21.
+//
+
+import Foundation
+
+private enum Retrieval<Value> {
+    case constant(Value)
+    case storage((Properties) -> Value)
+}
+
+/// A `Property` that can be used on `Handler`s for better re-usability. Depending on
+/// the context the `Binding` can be bound to a `Binding.constant`, an `@Parameter`,
+/// or an `@Environment`. The latter `Binding`s for the latter two are contained in their
+/// `projectedValue`s.
+@propertyWrapper
+public struct Binding<Value>: DynamicProperty {
+    private let store: Properties
+    private var retrieval: Retrieval<Value>
+    
+    public var wrappedValue: Value {
+        switch self.retrieval {
+        case .constant(let value):
+            return value
+        case .storage(let retriever):
+            return retriever(store)
+        }
+    }
+}
+
+// MARK: Constant
+
+extension Binding {
+    private init(constant: Value) {
+        self.store = Properties()
+        self.retrieval = .constant(constant)
+    }
+    
+    /// Create a `Binding` that always returns the given `value`.
+    public static func constant(_ value: Value) -> Binding<Value> {
+        Binding(constant: value)
+    }
+}
+
+// MARK: Environment
+
+extension Binding {
+    private init<K: EnvironmentAccessible>(environment: Environment<K, Value>) {
+        self.store = Properties(wrappedValue: ["environment": environment])
+        self.retrieval = .storage({ store in
+            guard let parameter = store.wrappedValue["environment"] as? Environment<K, Value> else {
+                fatalError("Could not find Environment object in store. The internal logic of Binding is broken!")
+            }
+            return parameter.wrappedValue
+        })
+    }
+    
+    internal static func environment<K: EnvironmentAccessible>(_ environment: Environment<K, Value>) -> Binding<Value> {
+        Binding(environment: environment)
+    }
+}
+
+// MARK: Parameter
+
+extension Binding where Value: Codable {
+    private init(parameter: Parameter<Value>) {
+        self.store = Properties(wrappedValue: ["parameter": parameter], namingStrategy: { names in
+            names[names.count - 3]
+        })
+        self.retrieval = .storage({ store in
+            guard let parameter = store.wrappedValue["parameter"] as? Parameter<Value> else {
+                fatalError("Could not find Parameter object in store. The internal logic of Binding is broken!")
+            }
+            return parameter.wrappedValue
+        })
+    }
+    
+    internal static func parameter(_ parameter: Parameter<Value>) -> Binding<Value> {
+        Binding(parameter: parameter)
+    }
+}
+
+// MARK: Optional Wrapping
+
+extension Binding {
+    /// Creates a binding by projecting the base value to an optional value.
+    public init<V: Codable>(_ base: Binding<V>) where Value == V? {
+        self.store = base.store
+        switch base.retrieval {
+        case .constant(let value):
+            self.retrieval = .constant(value)
+        case .storage(let retriever):
+            self.retrieval = .storage(retriever)
+        }
+    }
+}

--- a/Sources/Apodini/Properties/Environment.swift
+++ b/Sources/Apodini/Properties/Environment.swift
@@ -28,7 +28,7 @@ public struct Environment<K: EnvironmentAccessible, Value>: Property {
             fatalError("The wrapped value was accessed before it was activated.")
         }
         
-        if let value = dynamicValues[keyPath] as? Value {
+        if let value = dynamicValues[keyPath] as? Value, dynamicValues[keyPath] != nil {
             return value
         }
         if let key = keyPath as? KeyPath<Application, Value> {
@@ -38,6 +38,10 @@ public struct Environment<K: EnvironmentAccessible, Value>: Property {
             return value
         }
         fatalError("Key path not found")
+    }
+    
+    public var projectedValue: Binding<Value> {
+        Binding.environment(self)
     }
 
     /// Sets the value for the given KeyPath.

--- a/Sources/Apodini/Properties/Environment.swift
+++ b/Sources/Apodini/Properties/Environment.swift
@@ -40,6 +40,7 @@ public struct Environment<K: EnvironmentAccessible, Value>: Property {
         fatalError("Key path not found")
     }
     
+    /// A `Binding` that reflects this `Environment`.
     public var projectedValue: Binding<Value> {
         Binding.environment(self)
     }

--- a/Sources/Apodini/Properties/Parameter.swift
+++ b/Sources/Apodini/Properties/Parameter.swift
@@ -46,8 +46,7 @@ public struct Parameter<Element: Codable>: Property {
         id: UUID = UUID(),
         name: String? = nil,
         defaultValue: (() -> Element)? = nil,
-        options: [Option] = [],
-        checkOptionality: Bool = true
+        options: [Option] = []
     ) {
         if let name = name {
             precondition(!name.isEmpty, "The name for Parameter cannot be empty!")
@@ -58,7 +57,7 @@ public struct Parameter<Element: Codable>: Property {
         self.name = name
         self.options = PropertyOptionSet(options)
 
-        if checkOptionality && option(for: PropertyOptionKey.http) == .path {
+        if option(for: PropertyOptionKey.http) == .path {
             precondition(!isOptional(Element.self), "A `PathParameter` cannot annotate a property with Optional type!")
         }
     }
@@ -118,7 +117,7 @@ public struct Parameter<Element: Codable>: Property {
             pathParameterOptions.append(.identifying(type))
         }
 
-        self.init(id: id, options: pathParameterOptions, checkOptionality: false)
+        self.init(id: id, options: pathParameterOptions)
     }
     
     

--- a/Sources/Apodini/Properties/Parameter.swift
+++ b/Sources/Apodini/Properties/Parameter.swift
@@ -38,6 +38,7 @@ public struct Parameter<Element: Codable>: Property {
         return element
     }
     
+    /// A `Binding` that reflects this `Parameter`.
     public var projectedValue: Binding<Element> {
         Binding.parameter(self)
     }

--- a/Sources/Apodini/Properties/Parameter.swift
+++ b/Sources/Apodini/Properties/Parameter.swift
@@ -37,13 +37,17 @@ public struct Parameter<Element: Codable>: Property {
         
         return element
     }
-
+    
+    public var projectedValue: Binding<Element> {
+        Binding.parameter(self)
+    }
 
     private init(
         id: UUID = UUID(),
         name: String? = nil,
         defaultValue: (() -> Element)? = nil,
-        options: [Option] = []
+        options: [Option] = [],
+        checkOptionality: Bool = true
     ) {
         if let name = name {
             precondition(!name.isEmpty, "The name for Parameter cannot be empty!")
@@ -54,7 +58,7 @@ public struct Parameter<Element: Codable>: Property {
         self.name = name
         self.options = PropertyOptionSet(options)
 
-        if option(for: PropertyOptionKey.http) == .path {
+        if checkOptionality && option(for: PropertyOptionKey.http) == .path {
             precondition(!isOptional(Element.self), "A `PathParameter` cannot annotate a property with Optional type!")
         }
     }
@@ -114,7 +118,7 @@ public struct Parameter<Element: Codable>: Property {
             pathParameterOptions.append(.identifying(type))
         }
 
-        self.init(id: id, options: pathParameterOptions)
+        self.init(id: id, options: pathParameterOptions, checkOptionality: false)
     }
     
     

--- a/Sources/Apodini/Properties/PathParameter.swift
+++ b/Sources/Apodini/Properties/PathParameter.swift
@@ -41,3 +41,10 @@ public struct PathParameter<Element: Codable & LosslessStringConvertible> {
         self.identifyingType = IdentifyingType(identifying: type)
     }
 }
+
+extension PathParameter {
+    /// A `Binding` that reflects this `PathParameter`.
+    public var binding: Binding<Element> {
+        self.projectedValue.projectedValue
+    }
+}

--- a/Sources/Apodini/Properties/Properties.swift
+++ b/Sources/Apodini/Properties/Properties.swift
@@ -16,19 +16,23 @@ import Foundation
 public struct Properties: Property {
     internal var elements: [String: Property]
     
+    internal var namingStrategy: ([String]) -> String? = Self.defaultNamingStrategy
+    
     /// Create a new `Properties` from the given `elements`
     /// - Complexity: O(1)
-    public init(wrappedValue elements: [String: Property]) {
+    public init(wrappedValue elements: [String: Property], namingStrategy: @escaping ([String]) -> String? = Self.defaultNamingStrategy) {
         self.elements = elements
+        self.namingStrategy = namingStrategy
     }
     
     /// Create a new `Properties` from the given `elements`
     /// - Complexity: O(n)
-    public init(_ elements: [(String, Property)]) {
+    public init(_ elements: [(String, Property)], namingStrategy: @escaping ([String]) -> String? = Self.defaultNamingStrategy) {
         self.elements = [:]
         for element in elements {
             self.elements[element.0] = element.1
         }
+        self.namingStrategy = namingStrategy
     }
     
     subscript<T>(dynamicMember name: String) -> T? {
@@ -38,6 +42,10 @@ public struct Properties: Property {
     /// The named elements managed by this object.
     public var wrappedValue: [String: Property] {
         self.elements
+    }
+    
+    public static var defaultNamingStrategy: ([String]) -> String? = { names in
+        names.last
     }
 }
 

--- a/Sources/Apodini/Properties/Properties.swift
+++ b/Sources/Apodini/Properties/Properties.swift
@@ -19,6 +19,13 @@ public struct Properties: Property {
     internal var namingStrategy: ([String]) -> String? = Self.defaultNamingStrategy
     
     /// Create a new `Properties` from the given `elements`
+    /// - Parameters:
+    ///     - namingStrategy: The `namingStrategy` is called when the framework decides to interact with one of
+    ///         the `Properties`'s elements. By default it assumes the key of this element to be the
+    ///         desired name of the element.
+    ///         This behavior can be changed by providing a different `namingStrategy`. E.g. to expose an internal
+    ///         `@Parameter` using the name that was given to the wrapping `Properties` the
+    ///         `namingStrategy` would be to return `names[names.count-2]`.
     /// - Complexity: O(1)
     public init(wrappedValue elements: [String: Property], namingStrategy: @escaping ([String]) -> String? = Self.defaultNamingStrategy) {
         self.elements = elements
@@ -26,6 +33,13 @@ public struct Properties: Property {
     }
     
     /// Create a new `Properties` from the given `elements`
+    /// - Parameters:
+    ///     - namingStrategy: The `namingStrategy` is called when the framework decides to interact with one of
+    ///         the `Properties`'s elements. By default it assumes the key of this element to be the
+    ///         desired name of the element.
+    ///         This behavior can be changed by providing a different `namingStrategy`. E.g. to expose an internal
+    ///         `@Parameter` using the name that was given to the wrapping `Properties` the
+    ///         `namingStrategy` would be to return `names[names.count-2]`.
     /// - Complexity: O(n)
     public init(_ elements: [(String, Property)], namingStrategy: @escaping ([String]) -> String? = Self.defaultNamingStrategy) {
         self.elements = [:]

--- a/Sources/Apodini/Properties/Property.swift
+++ b/Sources/Apodini/Properties/Property.swift
@@ -16,4 +16,19 @@ public protocol Property { }
 /// you make this `struct`'s properties discoverable to the Apodini runtime framework. This can be used to e.g. combine
 /// two property wrappers provided by the Apodini framework into one that merges their functionality
 /// - Warning: Only structs can be a `DynamicProperty`
-public protocol DynamicProperty: Property { }
+public protocol DynamicProperty: Property {
+    /// The `namingStrategy` is called when the framework decides to interact with one of
+    /// the `DynamicProperty`'s properties. By default it assumes the label of this property to be the
+    /// desired name of the property.
+    /// This behavior can be changed by overriding the `namingStrategy`. E.g. to expose an internal
+    /// `@Parameter` using the name that was given to the wrapping `DynamicProperty` the
+    /// `namingStrategy` would be to return `names[names.count-2]`.
+    func namingStrategy(_ names: [String]) -> String?
+}
+
+public extension DynamicProperty {
+    /// The default `namingStrategy` is to use the target element's label.
+    func namingStrategy(_ names: [String]) -> String? {
+        names.last
+    }
+}

--- a/Sources/Apodini/Semantic Model Builder/Traversable.swift
+++ b/Sources/Apodini/Semantic Model Builder/Traversable.swift
@@ -196,7 +196,7 @@ private func execute<Element, Target>(
         case let target as Target:
             assert(((try? typeInfo(of: property.type).kind) ?? .none) == .struct, "\(Target.self) \(property.name) on element \(info.name) must be a struct")
             
-            try operation(target, property.name)
+            try operation(target, (element as? DynamicProperty)?.namingStrategy(names + [property.name]) ?? property.name)
         case let dynamicProperty as DynamicProperty:
             assert(((try? typeInfo(of: property.type).kind) ?? .none) == .struct, "DynamicProperty \(property.name) on element \(info.name) must be a struct")
 
@@ -244,7 +244,7 @@ private func apply<Element, Target>(
         case var target as Target:
             assert(((try? typeInfo(of: property.type).kind) ?? .none) == .struct, "\(Target.self) \(property.name) on element \(info.name) must be a struct")
             
-            try mutation(&target, property.name)
+            try mutation(&target, (element as? DynamicProperty)?.namingStrategy(names + [property.name]) ?? property.name)
             let elem = element
             property.unsafeSet(
                 value: target,

--- a/Tests/ApodiniTests/EnvironmentTests/ConnectionTests.swift
+++ b/Tests/ApodiniTests/EnvironmentTests/ConnectionTests.swift
@@ -74,16 +74,16 @@ final class ConnectionTests: ApodiniTests {
     }
 
     func testConnectionRemoteAddress() throws {
-        struct TestWebService: WebService {
-            struct TestHandler: Handler {
-                @Apodini.Environment(\.connection)
-                var connection: Connection
+        struct TestHandler: Handler {
+            @Apodini.Environment(\.connection)
+            var connection: Connection
 
-                func handle() -> String {
-                    connection.remoteAddress?.description ?? "no remote"
-                }
+            func handle() -> String {
+                connection.remoteAddress?.description ?? "no remote"
             }
-
+        }
+        
+        struct TestWebService: WebService {
             var content: some Component {
                 TestHandler()
             }
@@ -103,17 +103,17 @@ final class ConnectionTests: ApodiniTests {
     }
 
     func testConnectionEventLoop() throws {
-        struct TestWebService: WebService {
-            struct TestHandler: Handler {
-                @Apodini.Environment(\.connection)
-                var connection: Connection
+        struct TestHandler: Handler {
+            @Apodini.Environment(\.connection)
+            var connection: Connection
 
-                func handle() -> String {
-                    connection.eventLoop.assertInEventLoop()
-                    return "success"
-                }
+            func handle() -> String {
+                connection.eventLoop.assertInEventLoop()
+                return "success"
             }
-
+        }
+        
+        struct TestWebService: WebService {
             var content: some Component {
                 TestHandler()
             }

--- a/Tests/ApodiniTests/PropertiesTests/BindingTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/BindingTests.swift
@@ -38,22 +38,24 @@ final class BindingTests: ApodiniTests, EnvironmentAccessible {
     @PathParameter var selectedCountry: String
     @Environment(\BindingTests.featured) var featuredCountry
     
+    @Parameter var optionallySelectedCountry: String?
+    
     @ComponentBuilder
     var testService: some Component {
-        Greeter(country: .constant(nil))
+        Greeter(country: nil)
         Group("default") {
-            Greeter(country: Binding<String?>(.constant("USA")))
+            Greeter(country: .some("USA"))
         }
         Group("optional") {
-            Greeter(country: Parameter<String?>().projectedValue)
+            Greeter(country: $optionallySelectedCountry)
         }
         Group("featured") {
             Greeter(country: $featuredCountry)
         }
         Group("country", $selectedCountry) {
-            Greeter(country: Binding<String?>($selectedCountry.projectedValue))
+            Greeter(country: _selectedCountry.binding.asOptional)
             Group("optional") {
-                ReallyOptionalGreeter(country: Binding<String??>(Binding<String?>($selectedCountry.projectedValue)))
+                ReallyOptionalGreeter(country: _selectedCountry.binding.asOptional.asOptional)
             }
         }
     }

--- a/Tests/ApodiniTests/PropertiesTests/BindingTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/BindingTests.swift
@@ -1,0 +1,106 @@
+//
+//  BindingTests.swift
+//  
+//
+//  Created by Max Obermeier on 24.02.21.
+//
+
+import Foundation
+
+@testable import Apodini
+import XCTest
+import XCTApodini
+import ApodiniREST
+
+final class BindingTests: ApodiniTests, EnvironmentAccessible {
+    struct Greeter: Handler {
+        @Binding var country: String?
+        
+        func handle() -> String {
+            country ?? "World"
+        }
+    }
+    
+    struct ReallyOptionalGreeter: Handler {
+        @Binding var country: String??
+        
+        func handle() -> String? {
+            if let country = self.country {
+                return country ?? "World"
+            } else {
+                return nil
+            }
+        }
+    }
+        
+    var featured: String? = "Italy"
+    
+    @PathParameter var selectedCountry: String
+    @Environment(\BindingTests.featured) var featuredCountry
+    
+    @ComponentBuilder
+    var testService: some Component {
+        Greeter(country: .constant(nil))
+        Group("default") {
+            Greeter(country: Binding<String?>(.constant("USA")))
+        }
+        Group("optional") {
+            Greeter(country: Parameter<String?>().projectedValue)
+        }
+        Group("featured") {
+            Greeter(country: $featuredCountry)
+        }
+        Group("country", $selectedCountry) {
+            Greeter(country: Binding<String?>($selectedCountry.projectedValue))
+            Group("optional") {
+                ReallyOptionalGreeter(country: Binding<String??>(Binding<String?>($selectedCountry.projectedValue)))
+            }
+        }
+    }
+    
+    func testUsingRESTExporter() throws {
+        let builder = SemanticModelBuilder(app)
+            .with(exporter: RESTInterfaceExporter.self)
+        let visitor = SyntaxTreeVisitor(modelBuilder: builder)
+        testService.accept(visitor)
+        visitor.finishParsing()
+        
+        EnvironmentObject(self.featured, \BindingTests.featured).configure(self.app)
+
+        let selectedCountry = "Germany"
+        try app.vapor.app.testable(method: .inMemory).test(.GET, "country/\(selectedCountry)") { response in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertTrue(response.body.string.contains(selectedCountry))
+        }
+        try app.vapor.app.testable(method: .inMemory).test(.GET, "country/\(selectedCountry)/optional") { response in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertTrue(response.body.string.contains(selectedCountry))
+        }
+        
+        try app.vapor.app.testable(method: .inMemory).test(.GET, "/") { response in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertTrue(response.body.string.contains("World"))
+        }
+        
+        try app.vapor.app.testable(method: .inMemory).test(.GET, "/default") { response in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertTrue(response.body.string.contains("USA"))
+        }
+        
+        try app.vapor.app.testable(method: .inMemory).test(.GET, "/featured") { response in
+            XCTAssertEqual(response.status, .ok)
+            // swiftlint:disable force_unwrapping
+            XCTAssertTrue(response.body.string.contains(featured!))
+        }
+        
+        try app.vapor.app.testable(method: .inMemory).test(.GET, "/optional") { response in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertTrue(response.body.string.contains("World"))
+        }
+        
+        try app.vapor.app.testable(method: .inMemory).test(.GET, "/optional?country=Greece") { response in
+            XCTAssertEqual(response.status, .ok)
+            XCTAssertTrue(response.body.string.contains("Greece"))
+        }
+    }
+}

--- a/Tests/ApodiniTests/PropertiesTests/PathParameterTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/PathParameterTests.swift
@@ -39,6 +39,31 @@ final class PathParameterTests: ApodiniTests {
         }
     }
     
+    struct HelloWorld: Component {
+        @PathParameter
+        var country: String
+        
+        var content: some Component {
+            Greeter()
+            Group("country", $country) {
+                Greeter(country: _country.asOptional)
+            }
+        }
+    }
+    
+    struct Greeter: Handler {
+        @Parameter
+        var country: String?
+        
+        func handle() -> String {
+            "Hello, \(country ?? "World")!"
+        }
+    }
+    
+    func testOptionalParameter() throws {
+        _ = TestComponent()
+    }
+    
     
     func testPrintComponent() throws {
         let testComponent = TestComponent()

--- a/Tests/ApodiniTests/PropertiesTests/PathParameterTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/PathParameterTests.swift
@@ -39,32 +39,6 @@ final class PathParameterTests: ApodiniTests {
         }
     }
     
-    struct HelloWorld: Component {
-        @PathParameter
-        var country: String
-        
-        var content: some Component {
-            Greeter()
-            Group("country", $country) {
-                Greeter(country: _country.asOptional)
-            }
-        }
-    }
-    
-    struct Greeter: Handler {
-        @Parameter
-        var country: String?
-        
-        func handle() -> String {
-            "Hello, \(country ?? "World")!"
-        }
-    }
-    
-    func testOptionalParameter() throws {
-        _ = TestComponent()
-    }
-    
-    
     func testPrintComponent() throws {
         let testComponent = TestComponent()
         let testHandler = try XCTUnwrap(testComponent.content.content as? TestHandler)

--- a/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
@@ -145,4 +145,62 @@ final class TraversableTests: ApodiniTests {
         
         XCTAssertEqual(names.sorted().joined(), "a")
     }
+    
+    struct Container {
+        let wrapperProperties: Properties = [
+            "theName": Param<String>()
+        ]
+        
+        let theNameProperties = Properties(wrappedValue: [
+            "notTheName": Param<String?>()
+        ], namingStrategy: { names in names[names.count - 2] })
+        
+        struct Wrapper: DynamicProperty {
+            let theName = Param<String??>()
+        }
+        
+        struct TransparentWrapper: DynamicProperty {
+            let notTheName = Param<String???>()
+            
+            func namingStrategy(_ names: [String]) -> String? {
+                names[names.count - 2]
+            }
+        }
+        
+        let wrapperDynamicProperty = Wrapper()
+        
+        let theNameDynamicProperty = TransparentWrapper()
+    }
+    
+    func testNamingStragety() throws {
+        var container = Container()
+        
+        exposedExecute({(_: Param<String>, name: String) in
+            XCTAssertEqual("theName", name)
+        }, on: container)
+        exposedApply({(_: inout Param<String>, name: String) in
+            XCTAssertEqual("theName", name)
+        }, to: &container)
+        
+        exposedExecute({(_: Param<String?>, name: String) in
+            XCTAssertEqual("theNameProperties", name)
+        }, on: container)
+        exposedApply({(_: inout Param<String?>, name: String) in
+            XCTAssertEqual("theNameProperties", name)
+        }, to: &container)
+        
+        exposedExecute({(_: Param<String??>, name: String) in
+            XCTAssertEqual("theName", name)
+        }, on: container)
+        exposedApply({(_: inout Param<String??>, name: String) in
+            XCTAssertEqual("theName", name)
+        }, to: &container)
+        
+        exposedExecute({(_: Param<String???>, name: String) in
+            XCTAssertEqual("theNameDynamicProperty", name)
+        }, on: container)
+        exposedApply({(_: inout Param<String???>, name: String) in
+            XCTAssertEqual("theNameDynamicProperty", name)
+        }, to: &container)
+    }
 }

--- a/Tests/ApodiniTests/PublicAPITests/BindingConvenienceTests.swift
+++ b/Tests/ApodiniTests/PublicAPITests/BindingConvenienceTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Apodini
+import XCTApodini
 
 // This file doesn't test functionality, but only that certain expressions, which
 // are considered important use-cases of `Binding`'s public API do compile.
@@ -78,5 +79,12 @@ struct None: Component {
             intOpt: nil,
             uint: 5,
             uintOpt: nil)
+    }
+}
+
+class BindingConvenienceTests: ApodiniTests {
+    func testInitialization() {
+        _ = Some().content
+        _ = None().content
     }
 }

--- a/Tests/ApodiniTests/PublicAPITests/BindingConvenienceTests.swift
+++ b/Tests/ApodiniTests/PublicAPITests/BindingConvenienceTests.swift
@@ -1,0 +1,82 @@
+//
+//  BindingConvenienceTests.swift
+//  
+//
+//  Created by Max Obermeier on 02.03.21.
+//
+
+import Apodini
+
+// This file doesn't test functionality, but only that certain expressions, which
+// are considered important use-cases of `Binding`'s public API do compile.
+
+struct AHandler: Handler {
+    @Binding var string: String
+    @Binding var stringOpt: String?
+    @Binding var bool: Bool
+    // swiftlint:disable:next discouraged_optional_boolean
+    @Binding var boolOpt: Bool?
+    @Binding var array: [String]
+    // swiftlint:disable:next discouraged_optional_collection
+    @Binding var arrayOpt: [Bool]?
+    @Binding var set: Set<String>
+    // swiftlint:disable:next discouraged_optional_collection
+    @Binding var setOpt: Set<Bool>?
+    @Binding var float: Float
+    @Binding var floatOpt: Float?
+    @Binding var double: Double
+    @Binding var doubleOpt: Double?
+    @Binding var int: Int
+    @Binding var intOpt: Int?
+    @Binding var uint: UInt
+    @Binding var uintOpt: UInt?
+    
+    
+    func handle() throws -> Response<String> {
+        .nothing
+    }
+}
+
+struct Some: Component {
+    var content: some Component {
+        AHandler(
+            string: "string",
+            stringOpt: .some("stringOpt"),
+            bool: true,
+            boolOpt: .some(true),
+            array: ["string"],
+            arrayOpt: .some([]),
+            set: ["string"],
+            setOpt: .some([]),
+            float: 1.2,
+            floatOpt: .some(1.0),
+            double: 2.4,
+            doubleOpt: .some(2.0),
+            int: -5,
+            intOpt: .some(-10),
+            uint: 5,
+            uintOpt: .some(10))
+    }
+}
+
+struct None: Component {
+    var content: some Component {
+        AHandler(
+            string: "st\("r")ing",
+            stringOpt: nil,
+            bool: true,
+            boolOpt: nil,
+            array: ["string"],
+            arrayOpt: nil,
+            set: ["string"],
+            setOpt: nil,
+            float: 1.2,
+            floatOpt: nil,
+            double: 2.4,
+            doubleOpt: nil,
+            int: -5,
+            intOpt: nil,
+            uint: 5,
+            uintOpt: nil)
+    }
+}


### PR DESCRIPTION
# Binding

## :recycle: Current situation
Until now, re-using `Handler`s was only possible when the context was exactly the same at two points in your service.

### Problem that is solved
In general a `Handler` doesn't care where the information relevant for generation the output comes from. That is only relevant for your service-definition. A `Handler` doesn't care if it gets a `String` from a `PathParameter`, a normal `Parameter` or the `Environment`.

## :bulb: Proposed solution

```swift
struct HelloWorld: WebService, EnvironmentAccessible {
    struct Greeter: Handler {
        @Binding var country: String?
        
        func handle() -> String {
            country ?? "World"
        }
    }
        
    var featured: String? = "Italy"
    
    @PathParameter var selectedCountry: String
    @Environment(\BindingTests.featured) var featuredCountry
    
    var content: some Component {
        Greeter(country: .constant(nil))
        Group("default") {
            Greeter(country: Binding<String?>(.constant("USA")))
        }
        Group("optional") {
            Greeter(country: Parameter<String?>().projectedValue)
        }
        Group("featured") {
            Greeter(country: $featuredCountry)
        }
        Group("country", $selectedCountry) {
            Greeter(country: Binding<String?>($selectedCountry.projectedValue))
        }
    }
}
```

### Implications
Everything is backwards compatible. The `@Binding` property wrapper was added. `@Parameter` and `@Environment` now have a `projectedValue` returning the respective `Binding`.

## :heavy_plus_sign: Additional Information
In order to implement this I had to adapt `Properties`/`Traversable` and `DynamicProperty`. They now enable the user to define a `namingStrategy` so we can choose which name to the framework should use.

E.g. for the following example the `wrapped` `Parameter` would be exported as `country`, now `wrapped`.
```swift
struct Wrapper: DynamicProperty {
    @Parameter var wrapped: String

    func namingStragegy(_ names: [String]) -> String? {
        names[names.count - 2]
    }
}

let country = Wrapper()
```

### Testing
I added tests for both, `Binding` and `namingStrategy`.