### PR TITLE
Serve Static Files

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "ba845ee93d6ea10671e829ebf273b6f7a0c92ef0",
-          "version": "1.2.4"
+          "revision": "0a8dddbe15cd72f7bb5e47951fb7c1eb0836dfc2",
+          "version": "1.2.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/vapor/async-kit.git",
         "state": {
           "branch": null,
-          "revision": "5760c79afb8ebc24fd3251fdd9724af225fdf1f9",
-          "version": "1.3.0"
+          "revision": "7457413e57dbfac762b32dd30c1caf2c55a02a3d",
+          "version": "1.2.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/vapor/console-kit.git",
         "state": {
           "branch": null,
-          "revision": "08f36a30e0893e6a52fefbf1c2db4a6bc1288ba2",
-          "version": "4.2.5"
+          "revision": "7454e839bc5ae0e75c3946d2613e442fd342fe6b",
+          "version": "4.2.4"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/vapor/fluent.git",
         "state": {
           "branch": null,
-          "revision": "4004e926cdef1fbb937501c8a60554349cced675",
-          "version": "4.2.0"
+          "revision": "855cd81cd129675dcb9adadeca2286281dbc0190",
+          "version": "4.1.0"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-kit.git",
         "state": {
           "branch": null,
-          "revision": "7f1a5fe1effeee258ef0012def798e4bad43303d",
-          "version": "1.10.3"
+          "revision": "b6cd7b93ef45b767041efeb83571457658c4acf7",
+          "version": "1.10.1"
         }
       },
       {
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/vapor/jwt-kit.git",
         "state": {
           "branch": null,
-          "revision": "b50b30b567726b14ac282aa6d3a42a52c1ebc8c0",
-          "version": "4.2.2"
+          "revision": "6055fe8439769aa3646a3c797d573ce7305849c8",
+          "version": "4.2.0"
         }
       },
       {
@@ -168,8 +168,8 @@
         "repositoryURL": "https://github.com/OpenKitten/MongoKitten.git",
         "state": {
           "branch": null,
-          "revision": "42e99850fe5ff213b68a75001ad52d20db47a9dc",
-          "version": "6.6.5"
+          "revision": "a1877877ff173461e6168f57fbf6603628bfbf91",
+          "version": "6.6.4"
         }
       },
       {
@@ -240,8 +240,8 @@
         "repositoryURL": "https://github.com/vapor/postgres-nio.git",
         "state": {
           "branch": null,
-          "revision": "fa93d76b3fcddcd62a996d645a7971f2003c9b84",
-          "version": "1.5.1"
+          "revision": "3cf24967e54e3e63809593273b45b4e8135da6aa",
+          "version": "1.4.0"
         }
       },
       {
@@ -276,8 +276,8 @@
         "repositoryURL": "https://github.com/vapor/sql-kit.git",
         "state": {
           "branch": null,
-          "revision": "6401540d12f5637b5b59707cf86f72504c34010f",
-          "version": "3.8.0"
+          "revision": "ea9928b7f4a801b175a00b982034d9c54ecb6167",
+          "version": "3.7.0"
         }
       },
       {
@@ -312,8 +312,8 @@
         "repositoryURL": "https://github.com/swift-server/swift-backtrace.git",
         "state": {
           "branch": null,
-          "revision": "93b3d9a76454e05379a32a2f3b2a1f5a7794b414",
-          "version": "1.2.1"
+          "revision": "f2fd8c4845a123419c348e0bc4b3839c414077d5",
+          "version": "1.2.0"
         }
       },
       {
@@ -321,8 +321,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "296d3308b4b2fa355cfe0de4ca411bf7a1cd8cf8",
-          "version": "1.1.4"
+          "revision": "9680b7251cd2be22caaed8f1468bd9e8915a62fb",
+          "version": "1.1.2"
         }
       },
       {
@@ -330,8 +330,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
-          "version": "1.4.1"
+          "revision": "173f567a2dfec11d74588eea82cecea555bdc0bc",
+          "version": "1.4.0"
         }
       },
       {
@@ -348,8 +348,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "6d3ca7e54e06a69d0f2612c2ce8bb8b7319085a4",
-          "version": "2.26.0"
+          "revision": "43931b7a7daf8120a487601530c8bc03ce711992",
+          "version": "2.25.1"
         }
       },
       {
@@ -357,8 +357,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
-          "version": "1.8.0"
+          "revision": "e5b5d191a80667a14827bfeb0ae4a511f7677942",
+          "version": "1.7.0"
         }
       },
       {
@@ -366,8 +366,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "f4736a3b78a2bbe3feb7fc0f33f6683a8c27974c",
-          "version": "1.16.3"
+          "revision": "78ddbdfca10f64e4399da37c63372fd8db232152",
+          "version": "1.15.0"
         }
       },
       {
@@ -375,8 +375,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "bbb38fbcbbe9dc4665b2c638dfa5681b01079bfb",
-          "version": "2.10.4"
+          "revision": "eb102ad32add8638410e37a69bc815ea11379813",
+          "version": "2.10.0"
         }
       },
       {
@@ -384,8 +384,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "1d28d48e071727f4558a8a4bb1894472abc47a58",
-          "version": "1.9.2"
+          "revision": "bb56586c4cab9a79dce6ec4738baddb5802c5de7",
+          "version": "1.9.0"
         }
       },
       {
@@ -393,8 +393,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "07478e1edb9376f96c1fd5d797c5f401165d4ec2",
-          "version": "4.41.1"
+          "revision": "bb87dcff4cf6d86d386308b4cb1393cefa4891a4",
+          "version": "4.39.2"
         }
       },
       {
@@ -411,8 +411,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "9003d51672e516cc59297b7e96bff1dfdedcb4ea",
-          "version": "4.0.4"
+          "revision": "138cf1b701cf825233b92ceac919152d5aba8a3f",
+          "version": "4.0.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .library(name: "ApodiniOpenAPI", targets: ["ApodiniOpenAPI"]),
         .library(name: "ApodiniProtobuffer", targets: ["ApodiniProtobuffer"]),
         .library(name: "ApodiniREST", targets: ["ApodiniREST"]),
+        .library(name: "ApodiniStatic", targets: ["ApodiniStatic"]),
         .library(name: "ApodiniTypeReflection", targets: ["ApodiniTypeReflection"]),
         .library(name: "ApodiniVaporSupport", targets: ["ApodiniVaporSupport"]),
         .library(name: "ApodiniWebSocket", targets: ["ApodiniWebSocket"])
@@ -187,6 +188,14 @@ let package = Package(
                 .target(name: "Apodini"),
                 .target(name: "ApodiniVaporSupport"),
                 .product(name: "FluentKit", package: "fluent-kit")
+            ]
+        ),
+
+        .target(
+            name: "ApodiniStatic",
+            dependencies: [
+                .target(name: "Apodini"),
+                .target(name: "ApodiniVaporSupport"),
             ]
         ),
 

--- a/Package.swift
+++ b/Package.swift
@@ -195,7 +195,7 @@ let package = Package(
             name: "ApodiniStatic",
             dependencies: [
                 .target(name: "Apodini"),
-                .target(name: "ApodiniVaporSupport"),
+                .target(name: "ApodiniVaporSupport")
             ]
         ),
 

--- a/Sources/ApodiniStatic/StaticFiles.swift
+++ b/Sources/ApodiniStatic/StaticFiles.swift
@@ -1,0 +1,19 @@
+
+import Foundation
+import Vapor
+import Apodini
+import ApodiniVaporSupport
+
+public struct StaticFiles : Configuration {
+    private let fileMiddleware: Middleware
+
+    public init(publicDirectory: String, at path: String..., ownerFile: StaticString = #file) {
+        fileMiddleware = StaticFilesMiddleware(prefix: path.isEmpty ? nil : path.joined(separator: "/"),
+                                               publicDirectory: publicDirectory,
+                                               ownerFile: ownerFile)
+    }
+
+    public func configure(_ app: Apodini.Application) {
+        app.vapor.app.middleware.use(fileMiddleware)
+    }
+}

--- a/Sources/ApodiniStatic/StaticFiles.swift
+++ b/Sources/ApodiniStatic/StaticFiles.swift
@@ -1,10 +1,13 @@
+//
+// Created by Mathias Quintro on 14.03.21.
+//
 
 import Foundation
 import Vapor
 import Apodini
 import ApodiniVaporSupport
 
-public struct StaticFiles : Configuration {
+public struct StaticFiles: Configuration {
     private let fileMiddleware: Middleware
 
     public init(publicDirectory: String, at path: String..., ownerFile: StaticString = #file) {

--- a/Sources/ApodiniStatic/StaticFilesMiddleware.swift
+++ b/Sources/ApodiniStatic/StaticFilesMiddleware.swift
@@ -1,0 +1,74 @@
+import Vapor
+
+/// Modified version of FileMiddleWare from Vapor with the intention of allowing us to set multiple files
+/// https://github.com/vapor/vapor/blob/main/Sources/Vapor/Middleware/FileMiddleware.swift
+final class StaticFilesMiddleware: Middleware {
+    private let prefix: String?
+    private let publicDirectory: String
+
+    init(prefix: String?, publicDirectory: String, ownerFile: StaticString) {
+        self.prefix = prefix
+        let directory: String
+
+        var url = URL(fileURLWithPath: ownerFile.description)
+        if FileManager.default.fileExists(atPath: url.path) {
+            url.deleteLastPathComponent()
+            while !FileManager.default.fileExists(atPath: url.appendingPathComponent("Package.swift").path) {
+                url.deleteLastPathComponent()
+            }
+
+            let directoryCandidate = url.appendingPathComponent(publicDirectory).path
+            if FileManager.default.fileExists(atPath: directoryCandidate) {
+                directory = directoryCandidate
+            } else {
+                directory = publicDirectory
+            }
+        } else {
+            directory = publicDirectory
+        }
+
+        self.publicDirectory = directory.hasSuffix("/") ? directory : directory + "/"
+    }
+
+    func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
+        // make a copy of the percent-decoded path
+        guard var path = request.url.path.removingPercentEncoding else {
+            return request.eventLoop.makeFailedFuture(Abort(.badRequest))
+        }
+
+        // protect against relative paths
+        guard !path.contains("../") else {
+            return request.eventLoop.makeFailedFuture(Abort(.forbidden))
+        }
+
+        // path must be relative.
+        while path.hasPrefix("/") {
+            path.removeFirst()
+        }
+
+        if let prefix = prefix {
+            if path.hasPrefix("\(prefix)/") {
+                path.removeFirst(prefix.count + 1)
+            } else {
+                return next.respond(to: request)
+            }
+        }
+
+        while path.hasPrefix("/") {
+            path.removeFirst()
+        }
+
+        // create absolute file path
+        let filePath = self.publicDirectory + path
+
+        // check if file exists and is not a directory
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: filePath, isDirectory: &isDir), !isDir.boolValue else {
+            return next.respond(to: request)
+        }
+
+        // stream the file
+        let res = request.fileio.streamFile(at: filePath)
+        return request.eventLoop.makeSucceededFuture(res)
+    }
+}

--- a/Sources/ApodiniStatic/StaticFilesMiddleware.swift
+++ b/Sources/ApodiniStatic/StaticFilesMiddleware.swift
@@ -1,3 +1,7 @@
+//
+// Created by Mathias Quintro on 14.03.21.
+//
+
 import Vapor
 
 /// Modified version of FileMiddleWare from Vapor with the intention of allowing us to set multiple files

--- a/TestWebService/Package.resolved
+++ b/TestWebService/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "apns",
-        "repositoryURL": "https://github.com/vapor/apns.git",
-        "state": {
-          "branch": null,
-          "revision": "a8bc863a718eb23e05b2ae3bfc7de66407b6b85d",
-          "version": "1.0.1"
-        }
-      },
-      {
         "package": "apnswift",
         "repositoryURL": "https://github.com/kylebrowning/APNSwift.git",
         "state": {
           "branch": null,
-          "revision": "ce8213a3e0ec0581c4c39a155e7778401ec5e24a",
-          "version": "2.2.0"
+          "revision": "03e83e2332d13a3c06d5cd70948166e5724c43c7",
+          "version": "3.0.0"
         }
       },
       {
@@ -33,8 +24,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "ba845ee93d6ea10671e829ebf273b6f7a0c92ef0",
-          "version": "1.2.4"
+          "revision": "0dda95cffcdf3d96ca551e5701efd1661cf31374",
+          "version": "1.2.5"
         }
       },
       {
@@ -69,8 +60,8 @@
         "repositoryURL": "https://github.com/MihaelIsaev/FCM.git",
         "state": {
           "branch": null,
-          "revision": "937c4f3967181cdcf5dceaf2d9d49491eaf667ee",
-          "version": "2.10.0"
+          "revision": "3e0645f7897a570568e66029a1bb97dde965bdeb",
+          "version": "2.10.1"
         }
       },
       {
@@ -96,8 +87,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-kit.git",
         "state": {
           "branch": null,
-          "revision": "7f1a5fe1effeee258ef0012def798e4bad43303d",
-          "version": "1.10.3"
+          "revision": "9d47c328bf83999968c12a3bc94ead1d706ad4a9",
+          "version": "1.11.0"
         }
       },
       {
@@ -267,8 +258,8 @@
         "repositoryURL": "https://github.com/vapor/sql-kit.git",
         "state": {
           "branch": null,
-          "revision": "6401540d12f5637b5b59707cf86f72504c34010f",
-          "version": "3.8.0"
+          "revision": "2e1ffbfa5ec6c87f6c932ecebbc11c7a5bc0115d",
+          "version": "3.8.1"
         }
       },
       {
@@ -312,8 +303,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "296d3308b4b2fa355cfe0de4ca411bf7a1cd8cf8",
-          "version": "1.1.4"
+          "revision": "0141f53dd525706c803b0c20aa8ad36f9ecd45e5",
+          "version": "1.1.5"
         }
       },
       {
@@ -321,8 +312,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
-          "version": "1.4.1"
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
         }
       },
       {
@@ -384,8 +375,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "07478e1edb9376f96c1fd5d797c5f401165d4ec2",
-          "version": "4.41.1"
+          "revision": "062a4088a26ff9e41daacb8aa311f0289232d814",
+          "version": "4.41.4"
         }
       },
       {

--- a/TestWebService/Package.swift
+++ b/TestWebService/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
                 .product(name: "ApodiniOpenAPI", package: "Apodini"),
                 .product(name: "ApodiniWebSocket", package: "Apodini"),
                 .product(name: "ApodiniNotifications", package: "Apodini"),
-                .product(name: "ApodiniStatic", package: "Apodini"),
+                .product(name: "ApodiniStatic", package: "Apodini")
             ]
         ),
         .testTarget(

--- a/TestWebService/Package.swift
+++ b/TestWebService/Package.swift
@@ -25,7 +25,8 @@ let package = Package(
                 .product(name: "ApodiniProtobuffer", package: "Apodini"),
                 .product(name: "ApodiniOpenAPI", package: "Apodini"),
                 .product(name: "ApodiniWebSocket", package: "Apodini"),
-                .product(name: "ApodiniNotifications", package: "Apodini")
+                .product(name: "ApodiniNotifications", package: "Apodini"),
+                .product(name: "ApodiniStatic", package: "Apodini"),
             ]
         ),
         .testTarget(

--- a/TestWebService/Public/index.html
+++ b/TestWebService/Public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Hello World</title>
+</head>
+<body>
+
+<h1>Hello World</h1>
+<p>This file was served from the ./Public folder</p>
+
+</body>
+</html>
+

--- a/TestWebService/Sources/TestWebService/main.swift
+++ b/TestWebService/Sources/TestWebService/main.swift
@@ -6,6 +6,7 @@
 //
 
 import Apodini
+import ApodiniStatic
 import ApodiniREST
 import ApodiniGRPC
 import ApodiniProtobuffer
@@ -41,6 +42,8 @@ struct TestWebService: Apodini.WebService {
             .exporter(ProtobufferInterfaceExporter.self)
             .exporter(OpenAPIInterfaceExporter.self)
             .exporter(WebSocketInterfaceExporter.self)
+
+        StaticFiles(publicDirectory: "Public", at: "files", "public")
     }
 }
 


### PR DESCRIPTION
# Serve Static Files

## :recycle: Current situation
There's currently no way to serve files via HTTP while using Apodini

## :bulb: Proposed solution
We should allow the developer to make any directory of static files public. Available options:
- Which directory is public
- Is there an http path prefix (for serving multiple different folders)

Due to the fact that serving files is http specific and not protocol specific, my proposed solution is to add this functionality as a configuration:

```swift
struct TestWebService: Apodini.WebService {
    var content: some Component {
        ...
    }
    
    var configuration: Configuration {
        ...
        StaticFiles(publicDirectory: "Public", at: "files", "public")
    }
}
```

### Problem that is solved
The configuration struct allows the developer to serve the directory via http, regardless of whether or not they're using REST, gRPC or GraphQL 

### Implications
No particular implication

## :heavy_plus_sign: Additional Information

### Related PRs
None

### Testing
I tested with the Test Web Service both the case with and without a prefix

### Reviewer Nudging
- In all honesty I'm not super happy with the naming so far. I'm happy to discuss better naming.
- Also the current implementation checks if the folder you're making public resides in the folder of the Swift Package, and then checks in the CWD. I did this since Xcode will set the CWD to the derived data folder with the executable. I thought this would be a great default especially for the dev environment, but feel free to tell me why it's a bad idea
