### PR TITLE
Add default values for HTTPConfiguration

### DIFF
--- a/Sources/Apodini/Configurations/HTTPConfiguration.swift
+++ b/Sources/Apodini/Configurations/HTTPConfiguration.swift
@@ -14,8 +14,11 @@ import NIO
 /// command line arguments --hostname, --port and --bind or via the
 /// function `address`
 public final class HTTPConfiguration: Configuration {
-    private var address: BindAddress?
-
+    enum Defaults {
+        static let hostname = "0.0.0.0"
+        static let port = 8080
+    }
+    
     enum HTTPConfigurationError: LocalizedError {
         case incompatibleFlags
 
@@ -33,6 +36,10 @@ public final class HTTPConfiguration: Configuration {
             }
         }
     }
+    
+    
+    private var address: BindAddress?
+    
 
     /// initalize HTTPConfiguration
     public convenience init() {
@@ -73,7 +80,7 @@ public final class HTTPConfiguration: Configuration {
                 let port = components.last.flatMap { Int($0) }
                 return .hostname(hostname, port: port)
             case let (hostname, port, .none, .none):
-                return .hostname(hostname, port: port)
+                return .hostname(hostname ?? Defaults.hostname, port: port ?? Defaults.port)
             default:
                 throw HTTPConfigurationError.incompatibleFlags
             }

--- a/Sources/Apodini/WebService.swift
+++ b/Sources/Apodini/WebService.swift
@@ -53,6 +53,12 @@ extension WebService {
     static func main(app: Application) {
         let webService = Self()
         webService.configuration.configure(app)
+        
+        // If no specific address hostname is provided we bind to the default address to automatically and correcly bind in Docker containers.
+        if app.http.address == nil {
+            app.http.address = .hostname(HTTPConfiguration.Defaults.hostname, port: HTTPConfiguration.Defaults.port)
+        }
+        
         webService.register(
             app.exporters.semanticModelBuilderBuilder(SemanticModelBuilder(app))
         )

--- a/Tests/ApodiniTests/ConfigurationTests/HTTPConfigurationTests.swift
+++ b/Tests/ApodiniTests/ConfigurationTests/HTTPConfigurationTests.swift
@@ -19,8 +19,24 @@ final class HTTPConfigurationTests: ApodiniTests {
         XCTAssertNotNil(app.http.address)
         XCTAssertEqual(app.http.address, .unixDomainSocket(path: "/tmp/test"))
     }
+    
+    func testCommandLineArguments() throws {
+        HTTPConfiguration(arguments: CommandLine.arguments + ["--port", "56"])
+            .configure(app)
 
+        XCTAssertNotNil(app.http.address)
+        XCTAssertEqual(app.http.address, .hostname("0.0.0.0", port: 56))
+    }
+    
     func testCommandLineArguments1() throws {
+        HTTPConfiguration(arguments: CommandLine.arguments + ["--hostname", "1.2.3.4"])
+            .configure(app)
+
+        XCTAssertNotNil(app.http.address)
+        XCTAssertEqual(app.http.address, .hostname("1.2.3.4", port: 8080))
+    }
+
+    func testCommandLineArguments2() throws {
         HTTPConfiguration(arguments: CommandLine.arguments + ["--hostname", "1.2.3.4", "--port", "56"])
             .configure(app)
 
@@ -28,7 +44,7 @@ final class HTTPConfigurationTests: ApodiniTests {
         XCTAssertEqual(app.http.address, .hostname("1.2.3.4", port: 56))
     }
 
-    func testCommandLineArguments2() throws {
+    func testCommandLineArguments3() throws {
         HTTPConfiguration(arguments: CommandLine.arguments + ["--bind", "1.2.3.4:56"])
             .configure(app)
 
@@ -36,7 +52,7 @@ final class HTTPConfigurationTests: ApodiniTests {
         XCTAssertEqual(app.http.address, .hostname("1.2.3.4", port: 56))
     }
 
-    func testCommandLineArguments3() throws {
+    func testCommandLineArguments4() throws {
         HTTPConfiguration(arguments: CommandLine.arguments + ["--unix-socket", "/tmp/test"])
             .configure(app)
 


### PR DESCRIPTION
# *Add default values for HTTPConfiguration*

## :recycle: Current situation
Currently there is not default value for `HTTPConfiguration` but in docker container not binding to "0.0.0.0" results in an unexpected behavior that a port is not exposed.

## :bulb: Proposed solution
Adds default values for the `HTTPConfiguration`:
```swift
enum Defaults {
    static let hostname = "0.0.0.0"
    static let port = 8080
}
```

### Implications
No implications on running systems. Using `0.0.0.0` has the same behavior outside of a docker container.

### Testing
Added tests for the default values.
