### PR TITLE
Fix issue in Lambda Deployment Provider

### DIFF
--- a/Sources/DeploymentTargetAWSLambda/OpenApiVendorExtensionKey.swift
+++ b/Sources/DeploymentTargetAWSLambda/OpenApiVendorExtensionKey.swift
@@ -41,7 +41,7 @@ extension Dictionary where Key == String, Value == AnyCodable {
     
     /// Access the vendor extension value specified by the key
     public subscript<T>(key: OpenAPIVendorExtensionKey<T>) -> T? {
-        get { self[key.rawValue] as? T }
+        get { self[key.rawValue]?.value as? T }
         set { self[key.rawValue] = newValue.map(AnyCodable.init) }
     }
 }


### PR DESCRIPTION
# Fix issue in Lambda Deployment Provider

Fixes an issue where the lambda deployment provider is unable to read vendor extension values from OpenAPI

Basically, the issue was that we tried to cast the `AnyCodable` object to the expected type of the vendor extension key, rather than the value stored by the `AnyCodable`. This cast would, of course, always fail and we were unable to read the value.

### Reviewer Nudging

Look at the diff, its rather straightforward.
