### PR TITLE
Introduce `async`/`await` Syntax to `Handler`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ import PackageDescription
 /// When set to `true`, a recent commit from the **main** branch of **swift-nio** is used. Furthermore, the
 /// swift compiler is configured to enable this feature. Swift 5.4 is required for this to work. You may need to reset
 /// your package caches for this to take effect.
-let _experimental_async_await = false
+let experimentalAsyncAwait = false
 
 
 // MARK: Package Definition
@@ -65,7 +65,7 @@ let package = Package(
         // We constrain it to the next minor version as it doen't follow semantic versioning.
         .package(url: "https://github.com/OpenCombine/OpenCombine.git", .upToNextMinor(from: "0.11.0")),
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
-        _experimental_async_await
+        experimentalAsyncAwait
                     ? .package(url: "https://github.com/apple/swift-nio.git", .revision("4220c7a16a5ee0abb7da150bd3d4444940a20cc2"))
                     : .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
@@ -108,7 +108,7 @@ let package = Package(
                 .product(name: "Runtime", package: "Runtime"),
                 .product(name: "ConsoleKit", package: "console-kit")
             ] + (
-                _experimental_async_await ? [
+                experimentalAsyncAwait ? [
                     .product(name: "_NIOConcurrency", package: "swift-nio")
                 ] : []
             ),
@@ -117,10 +117,10 @@ let package = Package(
                 "Relationships/RelationshipIdentificationBuilder.swift.gyb"
             ],
             swiftSettings: [
-                .unsafeFlags(_experimental_async_await ? [
+                .unsafeFlags(experimentalAsyncAwait ? [
                     "-Xfrontend",
                     "-enable-experimental-concurrency"
-                    ] : [])
+                ] : [])
             ]
         ),
 

--- a/Sources/Apodini/Components/Handler/Handler.swift
+++ b/Sources/Apodini/Components/Handler/Handler.swift
@@ -32,8 +32,6 @@ extension Handler {
 }
 
 
-
-
 // This extensions provides a helper for evaluating the `Handler`'s `handle` function.
 // The function hides the syntactic difference between the newly introduced `async`
 // version of `handle()` and the traditional, `EventLoopFuture`-based one.

--- a/Sources/Apodini/Components/Handler/Handler.swift
+++ b/Sources/Apodini/Components/Handler/Handler.swift
@@ -5,14 +5,22 @@
 //  Created by Paul Schmiedmayer on 1/11/21.
 //
 
+import NIO
+#if compiler(>=5.4) && $AsyncAwait
+import _NIOConcurrency
+#endif
 
 /// A `Handler` is a `Component` which defines an endpoint and can handle requests.
 public protocol Handler: Component {
     /// The type that is returned from the `handle()` method when the component handles a request. The return type of the `handle` method is encoded into the response send out to the client.
     associatedtype Response: ResponseTransformable
-    
+
     /// A function that is called when a request reaches the `Handler`
+    #if compiler(>=5.4) && $AsyncAwait
+    func handle() async throws -> Response
+    #else
     func handle() throws -> Response
+    #endif
 }
 
 
@@ -21,4 +29,31 @@ extension Handler {
     public var content: some Component {
         EmptyComponent()
     }
+}
+
+
+
+
+// This extensions provides a helper for evaluating the `Handler`'s `handle` function.
+// The function hides the syntactic difference between the newly introduced `async`
+// version of `handle()` and the traditional, `EventLoopFuture`-based one.
+extension Handler {
+    #if compiler(>=5.4) && $AsyncAwait
+    internal func evaluate(using eventLoop: EventLoop) -> EventLoopFuture<Response> {
+        let promise: EventLoopPromise<Response> = eventLoop.makePromise()
+        promise.completeWithAsync(self.handle)
+        return promise.futureResult
+    }
+    #else
+    internal func evaluate(using eventLoop: EventLoop) -> EventLoopFuture<Response> {
+        let promise: EventLoopPromise<Response> = eventLoop.makePromise()
+        do {
+            let result = try self.handle()
+            promise.succeed(result)
+        } catch {
+            promise.fail(error)
+        }
+        return promise.futureResult
+    }
+    #endif
 }

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/RequestHandler.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/RequestHandler.swift
@@ -31,8 +31,8 @@ struct InternalEndpointRequestHandler<I: InterfaceExporter, H: Handler> {
         return EventLoopFuture<Void>
             .whenAllSucceed(guardEventLoopFutures, on: request.eventLoop)
             .flatMapThrowing { _ in
-                try connection.enterConnectionContext(with: self.instance.handler) { handler in
-                    try handler.handle()
+                connection.enterConnectionContext(with: self.instance.handler) { handler in
+                    handler.evaluate(using: request.eventLoop)
                         .transformToResponse(on: request.eventLoop)
                 }
             }


### PR DESCRIPTION
# Introduce `async`/`await` Syntax to `Handler`

## :recycle: Current situation
`Handler.handle()` is not marked as `async`. Asynchronous code has to be written using `EventLoopFuture`s.

## :bulb: Proposed solution
I introduced a configuration option in the `Package.swift` file. If set to true, the package is configured to use experimental flags and versions where necessary.

```swift
/// Configures the Package for usage of the experimental `async`/`await` syntax as introduced by
/// https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md
/// When set to `true`, a recent commit from the **main** branch of **swift-nio** is used. Furthermore, the
/// swift compiler is configured to enable this feature. Swift 5.4 is required for this to work. You may need to reset
/// your package caches for this to take effect.
let _experimental_async_await = false
```

By default it is set to `false`. When set to `true`, `Handler.handle()` becomes `async`:

```swift
/// A function that is called when a request reaches the `Handler`
#if compiler(>=5.4) && $AsyncAwait
func handle() async throws -> Response
#else
func handle() throws -> Response
#endif
```

### Problem that is solved
We can now experiment with the async/await syntax in Apodini.

### Implications
All changes are backwards-compatible. Old `Handler` definitions are still valid even when the `_experimental_async_await` flag is set to `true`.

## :heavy_plus_sign: Additional Information
Swift 5.4 is required for the flag to work. Unfortunately, the Apodini target doesn't compile for the latest snapshot of Swift 5.4. The core `Apodini` package does compile, however the compiler crashes for some other packages and dependencies. I hope this problem will disappear at some point when Swift 5.4 becomes more mature. With Swift 5.3.x and the flag set to `false` everything should work as usual.

### Testing
No tests are included, as the Apodini target doesn't compile yet.

### Reviewer Nudging

Some useful references if you want to go into detail:
https://github.com/apple/swift-evolution/blob/main/proposals/0300-continuation.md

https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md

https://github.com/apple/swift-nio/pull/1701

Here you can get the latest snapshots required for building with the flag set to `true`.
https://swift.org/download/#snapshots

