### PR TITLE
API Renaming (and other changes)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .library(name: "ApodiniDeployRuntimeSupport", targets: ["ApodiniDeployRuntimeSupport"]),
         .executable(name: "DeploymentTargetLocalhost", targets: ["DeploymentTargetLocalhost"]),
         .executable(name: "DeploymentTargetAWSLambda", targets: ["DeploymentTargetAWSLambda"]),
-        .library(name: "DeploymentTargetLocalhostRuntimeSupport", targets: ["DeploymentTargetLocalhostRuntimeSupport"]),
+        .library(name: "DeploymentTargetLocalhostRuntime", targets: ["DeploymentTargetLocalhostRuntime"]),
         .library(name: "DeploymentTargetAWSLambdaRuntime", targets: ["DeploymentTargetAWSLambdaRuntime"])
     ],
     dependencies: [
@@ -290,7 +290,7 @@ let package = Package(
             dependencies: [
                 .target(name: "Apodini"),
                 .target(name: "ApodiniDeployBuildSupport"),
-                .target(name: "DeploymentTargetLocalhostRuntimeSupport"),
+                .target(name: "DeploymentTargetLocalhostRuntime"),
                 .target(name: "DeploymentTargetAWSLambdaRuntime"),
                 .target(name: "ApodiniREST"),
                 .target(name: "ApodiniGRPC"),
@@ -367,7 +367,7 @@ let package = Package(
             ]
         ),
         .target(
-            name: "DeploymentTargetLocalhostRuntimeSupport",
+            name: "DeploymentTargetLocalhostRuntime",
             dependencies: [
                 .target(name: "DeploymentTargetLocalhostCommon"),
                 .target(name: "ApodiniDeployRuntimeSupport")

--- a/Sources/ApodiniDeploy/ApodiniDeployConfiguration.swift
+++ b/Sources/ApodiniDeploy/ApodiniDeployConfiguration.swift
@@ -17,11 +17,11 @@ public struct ApodiniDeployConfiguration: Apodini.Configuration {
         typealias Value = ApodiniDeployConfiguration
     }
     
-    let runtimes: [DeploymentProviderRuntimeSupport.Type]
+    let runtimes: [DeploymentProviderRuntime.Type]
     let config: DeploymentConfig
     
     public init(
-        runtimes: [DeploymentProviderRuntimeSupport.Type] = [],
+        runtimes: [DeploymentProviderRuntime.Type] = [],
         config: DeploymentConfig = .init()
     ) {
         self.runtimes = runtimes

--- a/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter+ExportWebServiceStructure.swift
+++ b/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter+ExportWebServiceStructure.swift
@@ -15,7 +15,8 @@ import OpenAPIKit
 
 
 extension ApodiniDeployInterfaceExporter {
-    func exportWebServiceStructure(to outputUrl: URL, deploymentConfig: DeploymentConfig) throws {
+    func exportWebServiceStructure(to outputUrl: URL, apodiniDeployConfiguration: ApodiniDeployConfiguration) throws {
+        let deploymentConfig = apodiniDeployConfiguration.config
         guard let openApiDocument = app.storage.get(OpenAPIStorageKey.self)?.document else {
             throw ApodiniDeployError(message: "Unable to get OpenAPI document")
         }
@@ -37,7 +38,8 @@ extension ApodiniDeployInterfaceExporter {
                 defaultGrouping: deploymentConfig.defaultGrouping,
                 deploymentGroups: allDeploymentGroups
             ),
-            openApiDocument: openApiDocument
+            openApiDocument: openApiDocument,
+            enabledDeploymentProviders: apodiniDeployConfiguration.runtimes.map { $0.identifier }
         )
         try webServiceStructure.writeJSON(
             to: outputUrl,

--- a/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter+ExportWebServiceStructure.swift
+++ b/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter+ExportWebServiceStructure.swift
@@ -19,7 +19,7 @@ extension ApodiniDeployInterfaceExporter {
         guard let openApiDocument = app.storage.get(OpenAPIStorageKey.self)?.document else {
             throw ApodiniDeployError(message: "Unable to get OpenAPI document")
         }
-        var allDeploymentGroups: Set<DeploymentGroup> = deploymentConfig.deploymentGroups.groups
+        var allDeploymentGroups: Set<DeploymentGroup> = deploymentConfig.deploymentGroups
         allDeploymentGroups += explicitlyCreatedDeploymentGroups.map { groupId, handlerIds in
             DeploymentGroup(id: groupId, handlerTypes: [], handlerIds: handlerIds)
         }
@@ -34,10 +34,8 @@ extension ApodiniDeployInterfaceExporter {
                 )
             }),
             deploymentConfig: DeploymentConfig(
-                deploymentGroups: DeploymentGroupsConfig(
-                    defaultGrouping: deploymentConfig.deploymentGroups.defaultGrouping,
-                    groups: allDeploymentGroups
-                )
+                defaultGrouping: deploymentConfig.defaultGrouping,
+                deploymentGroups: allDeploymentGroups
             ),
             openApiDocument: openApiDocument
         )

--- a/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter.swift
+++ b/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter.swift
@@ -134,7 +134,7 @@ public class ApodiniDeployInterfaceExporter: InterfaceExporter {
             do {
                 try self.exportWebServiceStructure(
                     to: outputUrl,
-                    deploymentConfig: self.app.storage.get(ApodiniDeployConfiguration.StorageKey.self)?.config ?? .init()
+                    apodiniDeployConfiguration: app.storage.get(ApodiniDeployConfiguration.StorageKey.self) ?? .init()
                 )
             } catch {
                 fatalError("Error exporting web service structure: \(error)")
@@ -149,7 +149,7 @@ public class ApodiniDeployInterfaceExporter: InterfaceExporter {
             do {
                 let deployedSystem = try DeployedSystem(decodingJSONAt: configUrl)
                 guard
-                    let runtimes = self.app.storage.get(ApodiniDeployConfiguration.StorageKey.self)?.runtimes,
+                    let runtimes = app.storage.get(ApodiniDeployConfiguration.StorageKey.self)?.runtimes,
                     let DPRSType = runtimes.first(where: { $0.identifier == deployedSystem.deploymentProviderId })
                 else {
                     throw ApodiniDeployError(

--- a/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter.swift
+++ b/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter.swift
@@ -185,12 +185,12 @@ public class ApodiniDeployInterfaceExporter: InterfaceExporter {
     
     
     public func retrieveParameter<Type: Codable>(_ endpointParameter: EndpointParameter<Type>, for request: ExporterRequest) throws -> Type?? {
-        guard let paramValueContainer = request.getValueOfCollectedParameter(for: endpointParameter) else {
+        guard let argumentValueContainer = request.collectedArgumentValue(for: endpointParameter) else {
             return Optional<Type?>.none // this should be a "top-level" nil value (ie `.none` instead of `.some(.none)`)
         }
         
         if endpointParameter.nilIsValidValue {
-            switch paramValueContainer {
+            switch argumentValueContainer {
             case .value(let value):
                 if let value: Type? = dynamicCast(value, to: Type?.self) {
                     return .some(value)
@@ -199,7 +199,7 @@ public class ApodiniDeployInterfaceExporter: InterfaceExporter {
                 return try .some(JSONDecoder().decode(Type?.self, from: data))
             }
         } else {
-            switch paramValueContainer {
+            switch argumentValueContainer {
             case .value(let value):
                 if let value = value as? Type {
                     return .some(.some(value))
@@ -209,7 +209,7 @@ public class ApodiniDeployInterfaceExporter: InterfaceExporter {
             }
         }
         throw ApodiniDeployError(
-            message: "Unable to cast parameter value (\(paramValueContainer)) to expected type '\(Type.self)'"
+            message: "Unable to cast argument (container: \(argumentValueContainer)) to expected type '\(Type.self)'"
         )
     }
 }
@@ -219,31 +219,31 @@ public class ApodiniDeployInterfaceExporter: InterfaceExporter {
 
 extension ApodiniDeployInterfaceExporter {
     public struct ExporterRequest: Apodini.ExporterRequest {
-        enum Param {
+        enum Argument {
             case value(Any)    // the value, as-is
             case encoded(Data) // the value, encoded
         }
         
-        private let parameterValues: [String: Param] // key: stable endpoint param identity
+        private let argumentValues: [String: Argument] // key: stable endpoint param identity
         
-        init<H: Handler>(endpoint: Endpoint<H>, collectedParameters: [CollectedParameter<H>]) {
-            parameterValues = .init(uniqueKeysWithValues: collectedParameters.map { param -> (String, Param) in
-                guard let paramId = Apodini.Internal.getParameterId(ofBinding: endpoint.handler[keyPath: param.handlerKeyPath]) else {
-                    fatalError("Unable to get @Parameter id from collected parameter with key path \(param.handlerKeyPath)")
+        init<H: Handler>(endpoint: Endpoint<H>, collectedArguments: [CollectedArgument<H>]) {
+            argumentValues = .init(uniqueKeysWithValues: collectedArguments.map { argument -> (String, Argument) in
+                guard let paramId = Apodini.Internal.getParameterId(ofBinding: endpoint.handler[keyPath: argument.handlerKeyPath]) else {
+                    fatalError("Unable to get @Parameter id from collected parameter with key path \(argument.handlerKeyPath)")
                 }
                 let endpointParam = endpoint.parameters.first { $0.id == paramId }!
-                return (endpointParam.stableIdentity, .value(param.value))
+                return (endpointParam.stableIdentity, .value(argument.value))
             })
         }
         
-        init(encodedParameters: [(String, Data)]) {
-            parameterValues = Dictionary(
-                uniqueKeysWithValues: encodedParameters.map { ($0.0, .encoded($0.1)) }
+        init(encodedArguments: [(String, Data)]) {
+            argumentValues = Dictionary(
+                uniqueKeysWithValues: encodedArguments.map { ($0.0, .encoded($0.1)) }
             )
         }
         
-        func getValueOfCollectedParameter(for endpointParameter: AnyEndpointParameter) -> Param? {
-            parameterValues[endpointParameter.stableIdentity]
+        func collectedArgumentValue(for endpointParameter: AnyEndpointParameter) -> Argument? {
+            argumentValues[endpointParameter.stableIdentity]
         }
     }
 }

--- a/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter.swift
+++ b/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter.swift
@@ -79,7 +79,7 @@ public class ApodiniDeployInterfaceExporter: InterfaceExporter {
     private(set) var collectedEndpoints: [CollectedEndpointInfo] = []
     private(set) var explicitlyCreatedDeploymentGroups: [DeploymentGroup.ID: Set<AnyHandlerIdentifier>] = [:]
     
-    private(set) var deploymentProviderRuntime: DeploymentProviderRuntimeSupport?
+    private(set) var deploymentProviderRuntime: DeploymentProviderRuntime?
     
     
     public required init(_ app: Apodini.Application) {

--- a/Sources/ApodiniDeploy/DeploymentOptions/ConditionalOption.swift
+++ b/Sources/ApodiniDeploy/DeploymentOptions/ConditionalOption.swift
@@ -30,10 +30,10 @@ final class ConditionalOption<OuterNS: OuterNamespace>: AnyOption<OuterNS> {
     private let underlyingOption: AnyOption<OuterNS>
     
     init<InnerNS, Value>(
-        key: OptionKey<OuterNS, InnerNS, Value>,
+        key: OptionKey<InnerNS, Value>,
         value: Value,
         condition: AnyHandlerCondition
-    ) {
+    ) where InnerNS.OuterNS == OuterNS {
         self.condition = condition
         self.underlyingOption = ResolvedOption(key: key, value: value)
         super.init(key: key)

--- a/Sources/ApodiniDeploy/InternalInvocationResponder.swift
+++ b/Sources/ApodiniDeploy/InternalInvocationResponder.swift
@@ -40,7 +40,7 @@ struct InternalInvocationResponder<H: Handler>: Vapor.Responder {
         }
         return endpoint.invokeImp(
             withRequest: ApodiniDeployInterfaceExporter.ExporterRequest(
-                encodedParameters: request.parameters.map { param -> (String, Data) in
+                encodedArguments: request.parameters.map { param -> (String, Data) in
                     (param.stableIdentity, param.encodedValue)
                 }
             ),

--- a/Sources/ApodiniDeployBuildSupport/BuiltinOptions.swift
+++ b/Sources/ApodiniDeployBuildSupport/BuiltinOptions.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 
-public final class DeploymentOptionsNamespace: OuterNamespace {
-    public static let id: String = "DeploymentOptions"
+public struct DeploymentOptionsNamespace: OuterNamespace {
+    public static let identifier: String = "DeploymentOptions"
 }
 
 
@@ -19,9 +19,9 @@ public typealias DeploymentOptions = CollectedOptions<DeploymentOptionsNamespace
 public typealias AnyDeploymentOption = AnyOption<DeploymentOptionsNamespace>
 
 
-public final class BuiltinDeploymentOptionsNamespace: InnerNamespace {
+public struct BuiltinDeploymentOptionsNamespace: InnerNamespace {
     public typealias OuterNS = DeploymentOptionsNamespace
-    public static let id: String = "org.apodini"
+    public static let identifier: String = "org.apodini"
 }
 
 

--- a/Sources/ApodiniDeployBuildSupport/BuiltinOptions.swift
+++ b/Sources/ApodiniDeployBuildSupport/BuiltinOptions.swift
@@ -69,7 +69,7 @@ public struct TimeoutValue: OptionValue, RawRepresentable {
 
 public extension OptionKey where InnerNS == BuiltinDeploymentOptionsNamespace, Value == MemorySize {
     /// The option key used to specify a memory size option
-    static let memorySize = OptionKeyWithDefaultValue<DeploymentOptionsNamespace, BuiltinDeploymentOptionsNamespace, MemorySize>(
+    static let memorySize = OptionKeyWithDefaultValue<BuiltinDeploymentOptionsNamespace, MemorySize>(
         key: "memorySize",
         defaultValue: .mb(128)
     )
@@ -78,7 +78,7 @@ public extension OptionKey where InnerNS == BuiltinDeploymentOptionsNamespace, V
 
 public extension OptionKey where InnerNS == BuiltinDeploymentOptionsNamespace, Value == TimeoutValue {
     /// The option key used to specify a timeout option
-    static let timeout = OptionKeyWithDefaultValue<DeploymentOptionsNamespace, BuiltinDeploymentOptionsNamespace, TimeoutValue>(
+    static let timeout = OptionKeyWithDefaultValue<BuiltinDeploymentOptionsNamespace, TimeoutValue>(
         key: "timeout",
         defaultValue: .seconds(4)
     )

--- a/Sources/ApodiniDeployBuildSupport/DSLDeploymentConfig.swift
+++ b/Sources/ApodiniDeployBuildSupport/DSLDeploymentConfig.swift
@@ -58,7 +58,7 @@ public struct DeploymentGroup: Codable, Hashable, Equatable {
 }
 
 
-public struct DeploymentGroupsConfig: Codable {
+public struct DeploymentConfig: Codable {
     public enum DefaultGrouping: Int, Codable {
         /// Every handler which is not explicitly put in a group will get its own group
         case separateNodes
@@ -66,19 +66,10 @@ public struct DeploymentGroupsConfig: Codable {
         case singleNode
     }
     public let defaultGrouping: DefaultGrouping
-    public let groups: Set<DeploymentGroup>
+    public let deploymentGroups: Set<DeploymentGroup>
     
-    public init(defaultGrouping: DefaultGrouping = .separateNodes, groups: Set<DeploymentGroup> = []) {
+    public init(defaultGrouping: DefaultGrouping = .separateNodes, deploymentGroups: Set<DeploymentGroup> = []) {
         self.defaultGrouping = defaultGrouping
-        self.groups = groups
-    }
-}
-
-
-public struct DeploymentConfig: Codable {
-    public let deploymentGroups: DeploymentGroupsConfig
-    
-    public init(deploymentGroups: DeploymentGroupsConfig = .init()) {
         self.deploymentGroups = deploymentGroups
     }
 }

--- a/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
+++ b/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
@@ -90,8 +90,8 @@ extension DeploymentProvider {
     }
     
     
-    /// Generate a `WebServiceStructure` for this web service
-    public func generateDefaultWebServiceStructure() throws -> WebServiceStructure {
+    /// Read the web service's structure, and return it encoded as a `WebServiceStructure` object
+    public func readWebServiceStructure() throws -> WebServiceStructure {
         let fileManager = FileManager.default
         let logger = Logger(label: "ApodiniDeployCLI.Localhost")
         

--- a/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
+++ b/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
@@ -144,6 +144,15 @@ extension DeploymentProvider {
         from wsStructure: WebServiceStructure,
         nodeIdProvider: (Set<ExportedEndpoint>) -> String = { _ in UUID().uuidString }
     ) throws -> Set<DeployedSystem.Node> {
+        guard wsStructure.enabledDeploymentProviders.contains(Self.identifier) else {
+            throw ApodiniDeployBuildSupportError(
+                message: """
+                Identifier of current deployment provider ('\(Self.identifier.rawValue)') not found in set of enabled deployment providers.
+                This means that the web service, once deployed, will not be able to load and initialise this deployment provider's runtime.
+                """
+            )
+        }
+        
         // a mapping from all user-defined deployment groups, to the set of
         var endpointsByDeploymentGroup = [DeploymentGroup: Set<ExportedEndpoint>](
             uniqueKeysWithValues: wsStructure.deploymentConfig.deploymentGroups.map { ($0, []) }

--- a/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
+++ b/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
@@ -146,7 +146,7 @@ extension DeploymentProvider {
     ) throws -> Set<DeployedSystem.Node> {
         // a mapping from all user-defined deployment groups, to the set of
         var endpointsByDeploymentGroup = [DeploymentGroup: Set<ExportedEndpoint>](
-            uniqueKeysWithValues: wsStructure.deploymentConfig.deploymentGroups.groups.map { ($0, []) }
+            uniqueKeysWithValues: wsStructure.deploymentConfig.deploymentGroups.map { ($0, []) }
         )
         // all endpoints which didn't match any of the user-defined deployment groups
         var remainingEndpoints: Set<ExportedEndpoint> = []
@@ -178,24 +178,27 @@ extension DeploymentProvider {
             try DeployedSystem.Node(
                 id: deploymentGroup.id,
                 exportedEndpoints: endpoints,
-                userInfo: Null()
+                userInfo: nil,
+                userInfoType: Null.self
             )
         }
         
-        switch wsStructure.deploymentConfig.deploymentGroups.defaultGrouping {
+        switch wsStructure.deploymentConfig.defaultGrouping {
         case .separateNodes:
             nodes += try remainingEndpoints.map { endpoint in
                 try DeployedSystem.Node(
                     id: nodeIdProvider([endpoint]),
                     exportedEndpoints: [endpoint],
-                    userInfo: Null()
+                    userInfo: nil,
+                    userInfoType: Null.self
                 )
             }
         case .singleNode:
             nodes.insert(try DeployedSystem.Node(
                 id: nodeIdProvider(remainingEndpoints),
                 exportedEndpoints: remainingEndpoints,
-                userInfo: Null()
+                userInfo: nil,
+                userInfoType: Null.self
             ))
         }
         

--- a/Sources/ApodiniDeployBuildSupport/InvocableHandler.swift
+++ b/Sources/ApodiniDeployBuildSupport/InvocableHandler.swift
@@ -12,50 +12,50 @@ import Apodini
 /// An `InvocableHandler` is a `Handler` which can be invoked from within another handler's `handle()` function.
 /// - [Reference](https://github.com/Apodini/Apodini/blob/develop/Documentation/Components/Inter-Component%20Communication.md)
 public protocol InvocableHandler: IdentifiableHandler where Self.Response.Content: Decodable {
-    /// The protocol a custom parameters storage type has to conform to
-    typealias ParametersStorageProtocol = InvocableHandlerParametersStorageProtocol
-    /// The type of this handler's parameters storage object
-    associatedtype ParametersStorage: ParametersStorageProtocol
-        = InvocableHandlerEmptyParametersStorage<Self> where ParametersStorage.HandlerType == Self
+    /// The protocol a custom arguments storage type has to conform to
+    typealias ArgumentsStorageProtocol = InvocableHandlerArgumentsStorageProtocol
+    /// The type of this handler's arguments storage object
+    associatedtype ArgumentsStorage: ArgumentsStorageProtocol
+        = InvocableHandlerEmptyArgumentsStorage<Self> where ArgumentsStorage.HandlerType == Self
 }
 
 
 // MARK: Supporting Types
 
 
-/// The protocol used to define an `InvocableHandler`'s parameters type
-public protocol InvocableHandlerParametersStorageProtocol {
-    /// The type of the handler for which this parameters storage object stores parameters
+/// The protocol used to define an `InvocableHandler`'s arguments type
+public protocol InvocableHandlerArgumentsStorageProtocol {
+    /// The type of the handler for which this arguments storage object stores arguments
     associatedtype HandlerType: InvocableHandler
     /// Type of the `mapping` array's elements
-    typealias MappingEntry = HandlerParametersStorageMappingEntry<Self, HandlerType>
+    typealias MappingEntry = HandlerArgumentsStorageMappingEntry<Self, HandlerType>
     
     /// `MappingEntry` objects for each mapping from one of this type's properties to the corresponding `@Parameter` property in `HandlerType`
     static var mapping: [MappingEntry] { get }
 }
 
 
-/// A default parameters storage for `InvocableHandler`s which do not specify their own storage type.
-public struct InvocableHandlerEmptyParametersStorage<HandlerType: InvocableHandler>: InvocableHandler.ParametersStorageProtocol {
+/// A default arguments storage for `InvocableHandler`s which do not specify their own storage type.
+public struct InvocableHandlerEmptyArgumentsStorage<HandlerType: InvocableHandler>: InvocableHandler.ArgumentsStorageProtocol {
     public typealias HandlerType = HandlerType
     public static var mapping: [MappingEntry] { [] }
     private init() {}
 }
 
 
-/// Helper type which is used for mapping a parameter value in an `InvocableHandler`'s parameter storage type to the handler's `@Parameter` object this parameter belongs to.
-public struct HandlerParametersStorageMappingEntry<ParamsStruct: InvocableHandler.ParametersStorageProtocol, Handler: InvocableHandler> {
-    /// key path into the `Handler.Prameters` struct, to this parameter's value
-    public let paramsStructKeyPath: PartialKeyPath<ParamsStruct>
-    /// key path into the `Handler` struct, to this parameter's `Parameter<>.ID`
+/// Helper type which is used for mapping an argument value in an `InvocableHandler`'s argument storage type to the handler's `@Parameter` object this argument belongs to.
+public struct HandlerArgumentsStorageMappingEntry<ArgsStruct: InvocableHandler.ArgumentsStorageProtocol, Handler: InvocableHandler> {
+    /// key path into the `Handler.ArgumentsStorage` struct, to this argument's value
+    public let argsStructKeyPath: PartialKeyPath<ArgsStruct>
+    /// key path into the `Handler` struct, to this argument's `Parameter<>.ID`
     public let handlerKeyPath: PartialKeyPath<Handler>
 
-    /// Create a mapping entry from a property in an `InvocableHandler`'s parameter storage type to the handler's corresponding `@Parameter` property
+    /// Create a mapping entry from a property in an `InvocableHandler`'s arguments storage type to the handler's corresponding `@Parameter` property
     public init<Value>(
-        from paramsStructKeyPath: KeyPath<ParamsStruct, Value>,
+        from argsStructKeyPath: KeyPath<ArgsStruct, Value>,
         to handlerKeyPath: KeyPath<Handler, Binding<Value>>
     ) {
-        self.paramsStructKeyPath = paramsStructKeyPath
+        self.argsStructKeyPath = argsStructKeyPath
         self.handlerKeyPath = handlerKeyPath
     }
 }

--- a/Sources/ApodiniDeployBuildSupport/Options/CollectedOptions.swift
+++ b/Sources/ApodiniDeployBuildSupport/Options/CollectedOptions.swift
@@ -37,7 +37,7 @@ public struct CollectedOptions<OuterNS: OuterNamespace>: Codable, ExpressibleByA
     }
     
     
-    public func containsEntry<InnerNS, Value>(forKey optionKey: OptionKey<OuterNS, InnerNS, Value>) -> Bool {
+    public func containsEntry<InnerNS, Value>(forKey optionKey: OptionKey<InnerNS, Value>) -> Bool where InnerNS.OuterNS == OuterNS {
         options.contains { $0.key == optionKey }
     }
     
@@ -57,13 +57,13 @@ public struct CollectedOptions<OuterNS: OuterNamespace>: Codable, ExpressibleByA
     
     /// - returns: the value specified for this option key, if a matching entry exists. if no matching entry exists, `nil` is returned
     /// - throws: if an entry does exist but there was an erorr reading (ie decoding) it/
-    public func getValue<InnerNS, Value>(forKey optionKey: OptionKey<OuterNS, InnerNS, Value>) throws -> Value? {
+    public func getValue<InnerNS, Value>(forKey optionKey: OptionKey<InnerNS, Value>) throws -> Value? where InnerNS.OuterNS == OuterNS {
         try getValue_imp(forKey: optionKey)
     }
     
     /// - returns: the value specified for this option key, if a matching entry exists. if no matching entry exists, the default value specified in the option key is returned.
     /// - throws: if an entry does exist but there was an erorr reading (ie decoding) it/
-    public func getValue<InnerNS, Value>(forKey optionKey: OptionKeyWithDefaultValue<OuterNS, InnerNS, Value>) throws -> Value {
+    public func getValue<InnerNS, Value>(forKey optionKey: OptionKeyWithDefaultValue<InnerNS, Value>) throws -> Value where InnerNS.OuterNS == OuterNS {
         switch try getValue_imp(forKey: optionKey) {
         case Optional<Value>.some(let value): // swiftlint:disable:this syntactic_sugar
             return value
@@ -80,7 +80,7 @@ public struct CollectedOptions<OuterNS: OuterNamespace>: Codable, ExpressibleByA
     }
     
     
-    private func getValue_imp<InnerNS, Value>(forKey optionKey: OptionKey<OuterNS, InnerNS, Value>) throws -> Value? {
+    private func getValue_imp<InnerNS, Value>(forKey optionKey: OptionKey<InnerNS, Value>) throws -> Value? where InnerNS.OuterNS == OuterNS {
         try options
             .filter { $0.key == optionKey }
             .map { try $0.readValue(as: Value.self) }

--- a/Sources/ApodiniDeployBuildSupport/Options/CollectedOptions.swift
+++ b/Sources/ApodiniDeployBuildSupport/Options/CollectedOptions.swift
@@ -63,7 +63,9 @@ public struct CollectedOptions<OuterNS: OuterNamespace>: Codable, ExpressibleByA
     
     /// - returns: the value specified for this option key, if a matching entry exists. if no matching entry exists, the default value specified in the option key is returned.
     /// - throws: if an entry does exist but there was an erorr reading (ie decoding) it/
-    public func getValue<InnerNS, Value>(forKey optionKey: OptionKeyWithDefaultValue<InnerNS, Value>) throws -> Value where InnerNS.OuterNS == OuterNS {
+    public func getValue<InnerNS, Value>(
+        forKey optionKey: OptionKeyWithDefaultValue<InnerNS, Value>
+    ) throws -> Value where InnerNS.OuterNS == OuterNS {
         switch try getValue_imp(forKey: optionKey) {
         case Optional<Value>.some(let value): // swiftlint:disable:this syntactic_sugar
             return value

--- a/Sources/ApodiniDeployBuildSupport/Options/Namespace.swift
+++ b/Sources/ApodiniDeployBuildSupport/Options/Namespace.swift
@@ -27,6 +27,10 @@ public protocol OuterNamespace {
 }
 
 
+/// A namespace which is nested within an `OuterNamespace`.
+/// Inner namespaces allow defining sets of options in a way that collisions are avoided, and the correct option is
+/// retrieved when fetching an option.
+/// See the `OuterNamespace` type for more information.
 public protocol InnerNamespace {
     /// The outer namespace inside which this inner namespace resides
     associatedtype OuterNS: OuterNamespace

--- a/Sources/ApodiniDeployBuildSupport/Options/Namespace.swift
+++ b/Sources/ApodiniDeployBuildSupport/Options/Namespace.swift
@@ -6,11 +6,31 @@
 //
 
 
-public protocol OuterNamespace: AnyObject {
-    static var id: String { get }
+/// A namespace which can be used with the Options API.
+/// - Note: You cannot define any options directly within the outer namespace.
+///         Instead, you define an inner namespace, which can then be used to define options.
+/// The outer namespace allows using the Options API for different, unrelated, use cases, in a way
+/// that mixing these unrelated options will result in a compile-time error.
+/// - Note: Example: Let's say you have two places in your codebase where you want to use the Options API:
+///         Specifying handler parameter options, and specifying deployment options.
+///         There's two things now which are important to us:
+///         - The user should not be able to pass a deployment option where a parameter option is expected
+///           (because it would be unrelated, and couldn't be used in any meaningful way)
+///         - We need to be able to differentiate between options based on who defined them
+///           (ex: multiple deployment providers, each of which may define its own options.
+///           They do not know of each other beforehand, and therefore cannot guarantee that there's no collisions.)
+///         The outer namespace takes care of the first problem, by defining an "options domain" (eg: parameter options),
+///         while the inner namespace addresses the second problem, by defining "sub-domains" within an outer namespace.
+public protocol OuterNamespace {
+    /// The identifier of this namespace
+    static var identifier: String { get }
 }
 
-public protocol InnerNamespace: AnyObject {
+
+public protocol InnerNamespace {
+    /// The outer namespace inside which this inner namespace resides
     associatedtype OuterNS: OuterNamespace
-    static var id: String { get }
+    
+    /// The identifier of this inner namespace
+    static var identifier: String { get }
 }

--- a/Sources/ApodiniDeployBuildSupport/Options/OptionKey.swift
+++ b/Sources/ApodiniDeployBuildSupport/Options/OptionKey.swift
@@ -12,7 +12,7 @@ public class AnyOptionKey<OuterNS: OuterNamespace>: Codable, Hashable, Equatable
     public let rawValue: String
     
     public init(key rawValue: String) {
-        self.rawValue = "\(OuterNS.id):\(rawValue)"
+        self.rawValue = "\(OuterNS.identifier):\(rawValue)"
     }
     
     public var description: String {
@@ -31,7 +31,7 @@ public class AnyOptionKey<OuterNS: OuterNamespace>: Codable, Hashable, Equatable
 
 public class OptionKey<InnerNS: InnerNamespace, Value: OptionValue>: AnyOptionKey<InnerNS.OuterNS> {
     override public init(key rawValue: String) {
-        super.init(key: "\(InnerNS.id).\(rawValue)")
+        super.init(key: "\(InnerNS.identifier).\(rawValue)")
     }
     
     public required init(from decoder: Decoder) throws {

--- a/Sources/ApodiniDeployBuildSupport/Options/OptionKey.swift
+++ b/Sources/ApodiniDeployBuildSupport/Options/OptionKey.swift
@@ -29,7 +29,7 @@ public class AnyOptionKey<OuterNS: OuterNamespace>: Codable, Hashable, Equatable
 }
 
 
-public class OptionKey<OuterNS, InnerNS: InnerNamespace, Value: OptionValue>: AnyOptionKey<OuterNS> where InnerNS.OuterNS == OuterNS {
+public class OptionKey<InnerNS: InnerNamespace, Value: OptionValue>: AnyOptionKey<InnerNS.OuterNS> {
     override public init(key rawValue: String) {
         super.init(key: "\(InnerNS.id).\(rawValue)")
     }
@@ -44,8 +44,7 @@ public class OptionKey<OuterNS, InnerNS: InnerNamespace, Value: OptionValue>: An
 }
 
 
-public final class OptionKeyWithDefaultValue<OuterNS, InnerNS: InnerNamespace, Value: OptionValue>: OptionKey<OuterNS, InnerNS, Value>
-where InnerNS.OuterNS == OuterNS {
+public final class OptionKeyWithDefaultValue<InnerNS: InnerNamespace, Value: OptionValue>: OptionKey<InnerNS, Value> {
     public let defaultValue: Value
     
     public init(key rawValue: String, defaultValue: Value) {

--- a/Sources/ApodiniDeployBuildSupport/Options/OptionValue.swift
+++ b/Sources/ApodiniDeployBuildSupport/Options/OptionValue.swift
@@ -54,7 +54,7 @@ public final class ResolvedOption<OuterNS: OuterNamespace>: AnyOption<OuterNS> {
     private let reduceOptionsImp: (_ other: ResolvedOption<OuterNS>) -> ResolvedOption<OuterNS>
     
     
-    public init<InnerNS, Value>(key: OptionKey<OuterNS, InnerNS, Value>, value: Value) {
+    public init<InnerNS, Value>(key: OptionKey<InnerNS, Value>, value: Value) where InnerNS.OuterNS == OuterNS {
         self.valueStorage = .unencoded(value: value, encodingFn: { try JSONEncoder().encode(value) })
         self.reduceOptionsImp = { otherOption in
             precondition(key == otherOption.key)

--- a/Sources/ApodiniDeployBuildSupport/WebServiceStructure.swift
+++ b/Sources/ApodiniDeployBuildSupport/WebServiceStructure.swift
@@ -50,15 +50,18 @@ public struct WebServiceStructure: Codable {
     public let endpoints: Set<ExportedEndpoint>
     public let deploymentConfig: DeploymentConfig
     public let openApiDocument: OpenAPI.Document
+    public let enabledDeploymentProviders: [DeploymentProviderID]
     
     public init(
         endpoints: Set<ExportedEndpoint>,
         deploymentConfig: DeploymentConfig,
-        openApiDocument: OpenAPI.Document
+        openApiDocument: OpenAPI.Document,
+        enabledDeploymentProviders: [DeploymentProviderID]
     ) {
         self.endpoints = endpoints
         self.deploymentConfig = deploymentConfig
         self.openApiDocument = openApiDocument
+        self.enabledDeploymentProviders = enabledDeploymentProviders
     }
 }
 

--- a/Sources/ApodiniDeployRuntimeSupport/DeploymentProviderRuntime.swift
+++ b/Sources/ApodiniDeployRuntimeSupport/DeploymentProviderRuntime.swift
@@ -1,5 +1,5 @@
 //
-//  DeploymentProviderRuntimeSupport.swift
+//  DeploymentProviderRuntime.swift
 //  
 //
 //  Created by Lukas Kollmer on 2021-01-01.
@@ -34,7 +34,7 @@ public enum RemoteHandlerInvocationRequestResponse<Response: Decodable> {
 /// 3. When the remote handler invocation API was used to invoke a handler, and the dispatcher determined that the handler
 ///   should be invoked remotely (i.e. not in the current process).
 ///   In this case the runtime is given the option to simply forward the invocation to some url, or implement and perform the invocation manually.
-public protocol DeploymentProviderRuntimeSupport: AnyObject {
+public protocol DeploymentProviderRuntime: AnyObject {
     /// The unique identifier of the deployment provider this runtime belongs to.
     /// - Note: This property is used to locate the correct runtime based on the deployment provider
     ///         used to create the deployment, so it has to match the corresponding CLI's `identifier` exactly.
@@ -57,7 +57,7 @@ public protocol DeploymentProviderRuntimeSupport: AnyObject {
 }
 
 
-extension DeploymentProviderRuntimeSupport {
+extension DeploymentProviderRuntime {
     /// The identifier of the deployment provider
     public var identifier: DeploymentProviderID {
         Self.identifier

--- a/Sources/ApodiniDeployTestWebService/main.swift
+++ b/Sources/ApodiniDeployTestWebService/main.swift
@@ -68,7 +68,7 @@ struct Greeter: Handler {
         return RHI.invoke(
             RandomNumberGenerator.self,
             identifiedBy: .main,
-            parameters: [
+            arguments: [
                 .init(\.$lowerBound, age),
                 .init(\.$upperBound, age * 2)
             ]

--- a/Sources/ApodiniDeployTestWebService/main.swift
+++ b/Sources/ApodiniDeployTestWebService/main.swift
@@ -12,9 +12,9 @@ import Foundation
 import NIO
 import Apodini
 //import ApodiniDeployBuildSupport
-import DeploymentTargetLocalhostRuntimeSupport
-import DeploymentTargetAWSLambdaRuntime
 import ApodiniDeploy
+import DeploymentTargetLocalhostRuntime
+import DeploymentTargetAWSLambdaRuntime
 import ApodiniREST
 import ApodiniOpenAPI
 
@@ -119,7 +119,7 @@ struct WebService: Apodini.WebService {
             .exporter(OpenAPIInterfaceExporter.self)
             .exporter(ApodiniDeployInterfaceExporter.self)
         ApodiniDeployConfiguration(
-            runtimes: [LocalhostRuntimeSupport.self, LambdaRuntime.self],
+            runtimes: [LocalhostRuntime.self, LambdaRuntime.self],
             config: DeploymentConfig(deploymentGroups: DeploymentGroupsConfig(defaultGrouping: .singleNode, groups: []))
         )
     }

--- a/Sources/ApodiniDeployTestWebService/main.swift
+++ b/Sources/ApodiniDeployTestWebService/main.swift
@@ -120,7 +120,7 @@ struct WebService: Apodini.WebService {
             .exporter(ApodiniDeployInterfaceExporter.self)
         ApodiniDeployConfiguration(
             runtimes: [LocalhostRuntime.self, LambdaRuntime.self],
-            config: DeploymentConfig(deploymentGroups: DeploymentGroupsConfig(defaultGrouping: .singleNode, groups: []))
+            config: DeploymentConfig(defaultGrouping: .singleNode, deploymentGroups: [])
         )
     }
 }

--- a/Sources/DeploymentTargetAWSLambdaCommon/LambdaCommon.swift
+++ b/Sources/DeploymentTargetAWSLambdaCommon/LambdaCommon.swift
@@ -33,9 +33,9 @@ extension LambdaDeployedSystemContext {
 }
 
 
-public final class LambdaDeploymentOptionsNamespace: InnerNamespace {
+public struct LambdaDeploymentOptionsNamespace: InnerNamespace {
     public typealias OuterNS = DeploymentOptionsNamespace
-    public static let id = lambdaDeploymentProviderId.rawValue
+    public static let identifier = lambdaDeploymentProviderId.rawValue
 }
 
 

--- a/Sources/DeploymentTargetAWSLambdaCommon/LambdaCommon.swift
+++ b/Sources/DeploymentTargetAWSLambdaCommon/LambdaCommon.swift
@@ -59,7 +59,7 @@ public struct LambdaDescriptionOption: OptionValue, RawRepresentable, Expressibl
 public extension OptionKey where InnerNS == LambdaDeploymentOptionsNamespace, Value == LambdaDescriptionOption {
     /// Lambda description option key.
     static let lambdaDescription =
-        OptionKey<DeploymentOptionsNamespace, LambdaDeploymentOptionsNamespace, LambdaDescriptionOption>(key: "description")
+        OptionKey<LambdaDeploymentOptionsNamespace, LambdaDescriptionOption>(key: "description")
 }
 
 

--- a/Sources/DeploymentTargetAWSLambdaRuntime/LambdaRuntime.swift
+++ b/Sources/DeploymentTargetAWSLambdaRuntime/LambdaRuntime.swift
@@ -14,7 +14,7 @@ import DeploymentTargetAWSLambdaCommon
 import VaporAWSLambdaRuntime
 
 
-public class LambdaRuntime: DeploymentProviderRuntimeSupport {
+public class LambdaRuntime: DeploymentProviderRuntime {
     public static let identifier = lambdaDeploymentProviderId
     
     public let deployedSystem: DeployedSystem

--- a/Sources/DeploymentTargetLocalhost/main.swift
+++ b/Sources/DeploymentTargetLocalhost/main.swift
@@ -71,7 +71,7 @@ struct LocalhostDeploymentProvider: DeploymentProvider {
         logger.notice("Target executable url: \(executableUrl.path)")
         
         logger.notice("Invoking target to generate web service structure")
-        let wsStructure = try generateDefaultWebServiceStructure()
+        let wsStructure = try readWebServiceStructure()
         
         
         let nodes = Set(try computeDefaultDeployedSystemNodes(from: wsStructure).enumerated().map { idx, node in

--- a/Sources/DeploymentTargetLocalhost/main.swift
+++ b/Sources/DeploymentTargetLocalhost/main.swift
@@ -81,7 +81,8 @@ struct LocalhostDeploymentProvider: DeploymentProvider {
         let deployedSystem = try DeployedSystem(
             deploymentProviderId: Self.identifier,
             nodes: nodes,
-            userInfo: Null()
+            userInfo: nil,
+            userInfoType: Null.self
         )
         
         let deployedSystemFileUrl = fileManager.getTemporaryFileUrl(fileExtension: "json")

--- a/Sources/DeploymentTargetLocalhostRuntime/LocalhostRuntimeSupport.swift
+++ b/Sources/DeploymentTargetLocalhostRuntime/LocalhostRuntimeSupport.swift
@@ -11,7 +11,7 @@ import ApodiniDeployRuntimeSupport
 import DeploymentTargetLocalhostCommon
 
 
-public class LocalhostRuntimeSupport: DeploymentProviderRuntimeSupport {
+public class LocalhostRuntime: DeploymentProviderRuntime {
     public static let identifier = localhostDeploymentProviderId
     
     public let deployedSystem: DeployedSystem

--- a/Tests/ApodiniDeployTests/DeploymentOptionsTests.swift
+++ b/Tests/ApodiniDeployTests/DeploymentOptionsTests.swift
@@ -96,7 +96,9 @@ private struct TestWebService: Apodini.WebService {
             .exporter(ApodiniDeployInterfaceExporter.self)
         ApodiniDeployConfiguration(
             runtimes: [],
-            config: DeploymentConfig(deploymentGroups: .init(defaultGrouping: .singleNode, groups: []))
+            config: DeploymentConfig(defaultGrouping: .singleNode, deploymentGroups: [
+                .allHandlers(ofType: Text.self)
+            ])
         )
     }
 }

--- a/Tests/ApodiniDeployTests/DeploymentOptionsTests.swift
+++ b/Tests/ApodiniDeployTests/DeploymentOptionsTests.swift
@@ -12,9 +12,9 @@ import XCTest
 import XCTApodini
 
 
-class TestOptionsNamespace: InnerNamespace {
+struct TestOptionsNamespace: InnerNamespace {
     typealias OuterNS = DeploymentOptionsNamespace
-    static let id: String = "testOptionsNS"
+    static let identifier: String = "testOptionsNS"
 }
 
 

--- a/Tests/ApodiniDeployTests/DeploymentOptionsTests.swift
+++ b/Tests/ApodiniDeployTests/DeploymentOptionsTests.swift
@@ -29,7 +29,7 @@ struct TestOption1: OptionValue, RawRepresentable {
 
 extension OptionKey where InnerNS == TestOptionsNamespace, Value == TestOption1 {
     /// The option key used to specify a memory size option
-    static let testOption1 = OptionKey<DeploymentOptionsNamespace, TestOptionsNamespace, TestOption1>(
+    static let testOption1 = OptionKey<TestOptionsNamespace, TestOption1>(
         key: "testOption1"
     )
 }
@@ -140,9 +140,9 @@ class DeploymentOptionsTests: ApodiniDeployTestCase {
         typealias MaxOption = ComposableOption<MaxOptionImpl>
         typealias SumOption = ComposableOption<SumOptionImpl>
         
-        let minOptionKey = OptionKey<DeploymentOptionsNamespace, TestOptionsNamespace, MinOption>(key: "min")
-        let maxOptionKey = OptionKey<DeploymentOptionsNamespace, TestOptionsNamespace, MaxOption>(key: "max")
-        let sumOptionKey = OptionKey<DeploymentOptionsNamespace, TestOptionsNamespace, SumOption>(key: "sum")
+        let minOptionKey = OptionKey<TestOptionsNamespace, MinOption>(key: "min")
+        let maxOptionKey = OptionKey<TestOptionsNamespace, MaxOption>(key: "max")
+        let sumOptionKey = OptionKey<TestOptionsNamespace, SumOption>(key: "sum")
         
         let options: [ResolvedOption<DeploymentOptionsNamespace>] = [
             ResolvedOption(key: minOptionKey, value: MinOption(rawValue: 0)),

--- a/Tests/ApodiniDeployTests/InvocableHandlerTests.swift
+++ b/Tests/ApodiniDeployTests/InvocableHandlerTests.swift
@@ -105,12 +105,12 @@ private struct TestWebService: Apodini.WebService {
             // we use the presence of the transformation parameter to test whether the RHI properly handles default parameter values
             let nameFuture = { () -> EventLoopFuture<String> in
                 if let transformation = transformation {
-                    return RHI.invoke(TextTransformer.self, identifiedBy: .main, parameters: [
+                    return RHI.invoke(TextTransformer.self, identifiedBy: .main, arguments: [
                         .init(\.$transformation, transformation),
                         .init(\.$input, name)
                     ])
                 } else {
-                    return RHI.invoke(TextTransformer.self, identifiedBy: .main, parameters: [
+                    return RHI.invoke(TextTransformer.self, identifiedBy: .main, arguments: [
                         .init(\.$input, name)
                     ])
                 }
@@ -121,7 +121,7 @@ private struct TestWebService: Apodini.WebService {
     
     
     struct Adder: InvocableHandler {
-        struct ParametersStorage: ParametersStorageProtocol {
+        struct ArgumentsStorage: ArgumentsStorageProtocol {
             typealias HandlerType = Adder
             let x: Double
             let y: Double
@@ -166,7 +166,7 @@ private struct TestWebService: Apodini.WebService {
         func handle() throws -> EventLoopFuture<Int> {
             switch operation {
             default:
-                return RHI.invoke(Adder.self, identifiedBy: .main, parameters: .init(x: lhs, y: rhs)).map(Int.init)
+                return RHI.invoke(Adder.self, identifiedBy: .main, arguments: .init(x: lhs, y: rhs)).map(Int.init)
             }
         }
     }


### PR DESCRIPTION
# API Renaming (and other changes)

## :recycle: Current situation
Some of the ApodiniDeploy-related APIs could be named better.
For example, the Remote Handler Invocation API always refers to the input sent to an invokes handler as "parameters", even though the term "argument" would be a better fit in this specific case.

## :bulb: Proposed solution
We rename some of the APIs, so that they better fit their actual use cases.

### Problem that is solved
The APIs hopefully become clearer and easier to use.

### Other changes in this PR
- Removed an unused type
- Simplified the deployment config API by merging the two types into one
- Added some documentation to the options API namespaces
- Simplified the options API by removing a generic parameter in a lot of places (and inferring it from context instead)


### Reviewer Nudging
No functionality was changed. I'd recommend having a look at the diff to see the renamed APIs.
