### PR TITLE
assert unique handler identifiers

### DIFF
--- a/Sources/Apodini/Components/Handler/HandlerIdentifier.swift
+++ b/Sources/Apodini/Components/Handler/HandlerIdentifier.swift
@@ -36,7 +36,7 @@ private struct AllAnyHandlerIdentifiers: KnowledgeSource {
                 if ident1 == ident2 {
                     rawValue = ident1.rawValue
                 } else {
-                    fatalError("""
+                    preconditionFailure("""
                         Handler '\(blackboard[HandlerName.self].name)' has multiple explicitly specified identifiers ('\(ident1)' and '\(ident2)').
                         A handler may only have one explicitly specified identifier.
                         This is caused by using both the 'IdentifiableHandler.handlerId' property as well as the '.identified(by:)' modifier.

--- a/Sources/Apodini/Components/Handler/HandlerIdentifier.swift
+++ b/Sources/Apodini/Components/Handler/HandlerIdentifier.swift
@@ -11,7 +11,7 @@ import Foundation
 private struct AllAnyHandlerIdentifiersAnchor: TruthAnchor {}
 
 /// A `KnowledgeSource` that initializes and holds all `AnyHandlerIdenfier`, by also asserting the uniqueness of them.
-struct AllAnyHandlerIdentifiers: KnowledgeSource {
+private struct AllAnyHandlerIdentifiers: KnowledgeSource {
     static var preference: LocationPreference { .global }
     
     /// All registered `AnyHandlerIdentifer`'s of the web service

--- a/Sources/Apodini/Components/Handler/HandlerIdentifier.swift
+++ b/Sources/Apodini/Components/Handler/HandlerIdentifier.swift
@@ -8,35 +8,66 @@
 
 import Foundation
 
+private struct AllAnyHandlerIdentifiersAnchor: TruthAnchor {}
+
+/// A `KnowledgeSource` that initializes and holds all `AnyHandlerIdenfier`, by also asserting the uniqueness of them.
+struct AllAnyHandlerIdentifiers: KnowledgeSource {
+    static var preference: LocationPreference { .global }
+    
+    /// All registered `AnyHandlerIdentifer`'s of the web service
+    var anyHandlerIdentifiers: Set<AnyHandlerIdentifier>
+    
+    /// `KnowledgeSource` initializer
+    init<B>(_ blackboard: B) throws where B: Blackboard {
+        var anyHandlerIdentifiers: Set<AnyHandlerIdentifier> = []
+        
+        for blackboard in blackboard[Blackboards.self][for: AllAnyHandlerIdentifiersAnchor.self] {
+            let dslSpecifiedIdentifier = blackboard[DSLSpecifiedIdentifier.self].value
+            let handlerSpecifiedIdentifier = blackboard[ExplicitlySpecifiedIdentifier.self].value
+            
+            let rawValue: String
+            
+            switch (dslSpecifiedIdentifier, handlerSpecifiedIdentifier) {
+            case (.some(let identifier), .none):
+                rawValue = identifier.rawValue
+            case (.none, .some(let identifier)):
+                rawValue = identifier.rawValue
+            case let (.some(ident1), .some(ident2)):
+                if ident1 == ident2 {
+                    rawValue = ident1.rawValue
+                } else {
+                    fatalError("""
+                        Handler '\(blackboard[HandlerName.self].name)' has multiple explicitly specified identifiers ('\(ident1)' and '\(ident2)').
+                        A handler may only have one explicitly specified identifier.
+                        This is caused by using both the 'IdentifiableHandler.handlerId' property as well as the '.identified(by:)' modifier.
+                        """
+                    )
+                }
+            case (.none, .none):
+                let handlerIndexPath = blackboard[HandlerIndexPath.self]
+                rawValue = handlerIndexPath.rawValue
+            }
+            
+            let anyHandlerIdentifier = AnyHandlerIdentifier(rawValue)
+            let storage = anyHandlerIdentifiers.count
+            
+            anyHandlerIdentifiers.insert(anyHandlerIdentifier)
+            
+            Swift.assert(anyHandlerIdentifiers.count > storage, "Encountered a duplicated handler identifier: '\(rawValue)'. The explicitly specified identifiers must be unique")
+            blackboard[AnyHandlerIdentifier.self] = anyHandlerIdentifier
+        }
+        
+        self.anyHandlerIdentifiers = anyHandlerIdentifiers
+    }
+}
 
 /// An `AnyHandlerIdentifier` object identifies a `Handler` regardless of its concrete type.
-open class AnyHandlerIdentifier: Codable, RawRepresentable, Hashable, Equatable, CustomStringConvertible, KnowledgeSource {
+open class AnyHandlerIdentifier: Codable, RawRepresentable, Hashable, CustomStringConvertible, KnowledgeSource {
     public let rawValue: String
     
     public required init<B>(_ blackboard: B) throws where B: Blackboard {
-        let dslSpecifiedIdentifier = blackboard[DSLSpecifiedIdentifier.self].value
-        let handlerSpecifiedIdentifier = blackboard[ExplicitlySpecifiedIdentifier.self].value
-        
-        switch (dslSpecifiedIdentifier, handlerSpecifiedIdentifier) {
-        case (.some(let identifier), .none):
-            self.rawValue = identifier.rawValue
-        case (.none, .some(let identifier)):
-            self.rawValue = identifier.rawValue
-        case let (.some(ident1), .some(ident2)):
-            if ident1 == ident2 {
-                self.rawValue = ident1.rawValue
-            } else {
-                fatalError("""
-                    Handler '\(blackboard[HandlerName.self].name)' has multiple explicitly specified identifiers ('\(ident1)' and '\(ident2)').
-                    A handler may only have one explicitly specified identifier.
-                    This is caused by using both the 'IdentifiableHandler.handlerId' property as well as the '.identified(by:)' modifier.
-                    """
-                )
-            }
-        case (.none, .none):
-            let handlerIndexPath = blackboard[HandlerIndexPath.self]
-            self.rawValue = handlerIndexPath.rawValue
-        }
+        _ = blackboard[AllAnyHandlerIdentifiers.self]
+        throw KnowledgeError.instancePresent
     }
     
     public required init(rawValue: String) {

--- a/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
@@ -77,7 +77,11 @@ class SemanticModelBuilder: InterfaceExporterVisitor {
         // We first only build the blackboards. The rest is executed at the beginning of `finishedRegistration`.
         // This way `.global` `KnowledgeSource`s get a complete view of the web service even when accessed from
         // an `Endpoint`.
-        onRegistrationDone.append { [weak self] in guard let self = self else { return }
+        onRegistrationDone.append { [weak self] in
+            guard let self = self else {
+                return
+            }
+            
             let paths = context.get(valueFor: PathComponentContextKey.self)
             
 

--- a/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
@@ -21,8 +21,6 @@ class SemanticModelBuilder: InterfaceExporterVisitor {
     var relationshipBuilder: RelationshipBuilder
     var typeIndexBuilder: TypeIndexBuilder
     
-    private var uniqueHandlerIdentifiers: Set<AnyHandlerIdentifier> = []
-    
     private var onRegistrationDone: [() -> Void] = []
 
     init(_ app: Application) {
@@ -96,8 +94,6 @@ class SemanticModelBuilder: InterfaceExporterVisitor {
                 responseTransformers: responseTransformers
             )
 
-            self.assertUniqueIdentifier(for: endpoint)
-            
             self.webService.addEndpoint(&endpoint, at: paths)
             // The `ReferenceModule` and `EndpointPathModule` cannot be implemented using one of the standard
             // `KnowledgeSource` protocols as they depend on the `WebServiceModel`. This should change
@@ -179,16 +175,6 @@ class SemanticModelBuilder: InterfaceExporterVisitor {
 
         for child in node.children {
             call(exporter: exporter, for: child)
-        }
-    }
-    
-    private func assertUniqueIdentifier<H: Handler>(for endpoint: Endpoint<H>) {
-        let identifier = endpoint[AnyHandlerIdentifier.self]
-        let currentCount = uniqueHandlerIdentifiers.count
-        uniqueHandlerIdentifiers.insert(identifier)
-        
-        if currentCount == uniqueHandlerIdentifiers.count {
-            fatalError("Encountered a duplicated handler identifier: '\(identifier.rawValue)'. The explicitly specified identifiers must be unique")
         }
     }
 }

--- a/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
@@ -21,6 +21,8 @@ class SemanticModelBuilder: InterfaceExporterVisitor {
     var relationshipBuilder: RelationshipBuilder
     var typeIndexBuilder: TypeIndexBuilder
     
+    private var uniqueHandlerIdentifiers: Set<AnyHandlerIdentifier> = []
+    
     private var onRegistrationDone: [() -> Void] = []
 
     init(_ app: Application) {
@@ -75,7 +77,7 @@ class SemanticModelBuilder: InterfaceExporterVisitor {
         // We first only build the blackboards. The rest is executed at the beginning of `finishedRegistration`.
         // This way `.global` `KnowledgeSource`s get a complete view of the web service even when accessed from
         // an `Endpoint`.
-        onRegistrationDone.append {
+        onRegistrationDone.append { [weak self] in guard let self = self else { return }
             let paths = context.get(valueFor: PathComponentContextKey.self)
             
 
@@ -90,6 +92,8 @@ class SemanticModelBuilder: InterfaceExporterVisitor {
                 responseTransformers: responseTransformers
             )
 
+            self.assertUniqueIdentifier(for: endpoint)
+            
             self.webService.addEndpoint(&endpoint, at: paths)
             // The `ReferenceModule` and `EndpointPathModule` cannot be implemented using one of the standard
             // `KnowledgeSource` protocols as they depend on the `WebServiceModel`. This should change
@@ -171,6 +175,16 @@ class SemanticModelBuilder: InterfaceExporterVisitor {
 
         for child in node.children {
             call(exporter: exporter, for: child)
+        }
+    }
+    
+    private func assertUniqueIdentifier<H: Handler>(for endpoint: Endpoint<H>) {
+        let identifier = endpoint[AnyHandlerIdentifier.self]
+        let currentCount = uniqueHandlerIdentifiers.count
+        uniqueHandlerIdentifiers.insert(identifier)
+        
+        if currentCount == uniqueHandlerIdentifiers.count {
+            fatalError("Encountered a duplicated handler identifier: '\(identifier.rawValue)'. The explicitly specified identifiers must be unique")
         }
     }
 }

--- a/Tests/ApodiniTests/OpenAPITests/OpenAPIDocumentBuilderTests.swift
+++ b/Tests/ApodiniTests/OpenAPITests/OpenAPIDocumentBuilderTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import ApodiniOpenAPI
 @testable import ApodiniVaporSupport
 
-final class OpenAPIDocumentBuilderTests: XCTestCase {
+final class OpenAPIDocumentBuilderTests: ApodiniTests {
     struct SomeStruct: Apodini.Content {
         var someProp = 4
     }
@@ -24,7 +24,7 @@ final class OpenAPIDocumentBuilderTests: XCTestCase {
     func testAddEndpoint() {
         let comp = SomeComp()
         let webService = WebServiceModel()
-        var endpoint = comp.mockEndpoint()
+        var endpoint = comp.mockEndpoint(app: app)
         webService.addEndpoint(&endpoint, at: ["test"])
 
         let configuration = OpenAPIConfiguration()

--- a/Tests/ApodiniTests/OpenAPITests/OpenAPIPathsObjectBuilderTests.swift
+++ b/Tests/ApodiniTests/OpenAPITests/OpenAPIPathsObjectBuilderTests.swift
@@ -6,9 +6,8 @@ import XCTest
 @_implementationOnly import OpenAPIKit
 @testable import Apodini
 @testable import ApodiniOpenAPI
-import ApodiniTests
 
-final class OpenAPIPathsObjectBuilderTests: XCTestCase {
+final class OpenAPIPathsObjectBuilderTests: ApodiniTests {
     struct SomeStruct: Codable {
         var id = 1
         var someProp = "somesome"
@@ -32,7 +31,7 @@ final class OpenAPIPathsObjectBuilderTests: XCTestCase {
 
     func testPathBuilder() {
         let handler = HandlerParam(pathParam: $param)
-        let endpoint = handler.mockEndpoint()
+        let endpoint = handler.mockEndpoint(app: app)
         var pathParameter = EndpointPathParameter<String>(id: _param.id)
         pathParameter.scoped(on: endpoint)
 
@@ -44,7 +43,7 @@ final class OpenAPIPathsObjectBuilderTests: XCTestCase {
     
     func testDefaultTagWithPathParameter() {
         let handler = HandlerParam(pathParam: $param)
-        var endpoint = handler.mockEndpoint()
+        var endpoint = handler.mockEndpoint(app: app)
         let webService = WebServiceModel()
         webService.addEndpoint(&endpoint, at: ["first", "second", $param, "third"])
         
@@ -58,7 +57,7 @@ final class OpenAPIPathsObjectBuilderTests: XCTestCase {
     
     func testDefaultTagWithSinglePathParameter() {
         let handler = HandlerParam(pathParam: $param)
-        var endpoint = handler.mockEndpoint()
+        var endpoint = handler.mockEndpoint(app: app)
         let webService = WebServiceModel()
         webService.addEndpoint(&endpoint, at: [$param, "first"])
         
@@ -87,7 +86,7 @@ final class OpenAPIPathsObjectBuilderTests: XCTestCase {
         let webService = WebServiceModel()
 
         let comp = SomeComp()
-        var endpoint = comp.mockEndpoint()
+        var endpoint = comp.mockEndpoint(app: app)
         webService.addEndpoint(&endpoint, at: ["test/{pathParam}"])
 
         pathsObjectBuilder.addPathItem(from: endpoint)
@@ -118,7 +117,7 @@ final class OpenAPIPathsObjectBuilderTests: XCTestCase {
         let webService = WebServiceModel()
 
         let comp = WrappingParamsComp()
-        var endpoint = comp.mockEndpoint()
+        var endpoint = comp.mockEndpoint(app: app)
         webService.addEndpoint(&endpoint, at: ["test"])
 
         pathsObjectBuilder.addPathItem(from: endpoint)
@@ -160,7 +159,7 @@ final class OpenAPIPathsObjectBuilderTests: XCTestCase {
         let webService = WebServiceModel()
 
         let comp = ArrayParamsComp()
-        var endpoint = comp.mockEndpoint()
+        var endpoint = comp.mockEndpoint(app: app)
         webService.addEndpoint(&endpoint, at: ["test"])
 
         pathsObjectBuilder.addPathItem(from: endpoint)
@@ -221,7 +220,7 @@ final class OpenAPIPathsObjectBuilderTests: XCTestCase {
         let webService = WebServiceModel()
 
         let comp = ComplexComp()
-        var endpoint = comp.mockEndpoint()
+        var endpoint = comp.mockEndpoint(app: app)
         webService.addEndpoint(&endpoint, at: ["test"])
 
         pathsObjectBuilder.addPathItem(from: endpoint)

--- a/Tests/ApodiniTests/UniqueIdentifierTests.swift
+++ b/Tests/ApodiniTests/UniqueIdentifierTests.swift
@@ -1,0 +1,46 @@
+//
+//  UniqueIdentifierTests.swift
+//  
+//
+//  Created by Eldi Cano on 15.05.21.
+//
+
+import XCTest
+@testable import Apodini
+import XCTApodini
+
+final class UniqueIdentifierTests: ApodiniTests {
+    private static let first = AnyHandlerIdentifier("first")
+    private static let second = AnyHandlerIdentifier("second")
+    
+    struct SomeIdentifiableHandler: IdentifiableHandler {
+        var handlerId = UniqueIdentifierTests.first
+        
+        func handle() throws -> String {
+            ""
+        }
+    }
+    
+    func testUniqueIdentifiers() {
+        struct TestWebService: WebService {
+            var content: some Component {
+                Group("ok") {
+                    SomeIdentifiableHandler()
+                        .identified(by: UniqueIdentifierTests.first)
+                }
+                Group("fail") {
+                    SomeIdentifiableHandler()
+                        .identified(by: UniqueIdentifierTests.second)
+                }
+            }
+        }
+        
+        weak var weakApp = app
+        
+        guard let app = weakApp else {
+            return XCTFail("App deallocated")
+        }
+        
+        XCTAssertRuntimeFailure(TestWebService.main(app: app))
+    }
+}


### PR DESCRIPTION
# *Asserting unique handler identifier*

## :recycle: Current situation
In case that the handler identifier is specified via `.identified(by:)` modifier, current implementation does not check for uniqueness of the specified identifier.

## :bulb: Proposed solution
Insert a unique id check in `SemanticModelBuilder`

### Problem that is solved
Deployment Provider implementation and my work relies on unique identifiers

### Implications

## :heavy_plus_sign: Additional Information

### Related PRs

### Testing

### Reviewer Nudging
