### PR TITLE
[Bug] TLS Configuration not possible when configuring database

### DIFF
--- a/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
+++ b/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
@@ -54,7 +54,6 @@ public final class DatabaseConfiguration: Configuration {
     }
     
     private func databaseFactory(for type: DatabaseType) throws -> Fluent.DatabaseConfigurationFactory {
-        
         switch type {
         case .defaultMongoDB(let conString):
             return try .mongo(connectionString: conString)
@@ -62,7 +61,13 @@ public final class DatabaseConfiguration: Configuration {
             return .sqlite(.apply(config))
         case .defaultPostgreSQL(let conString):
             return try .postgres(url: conString)
-        case let .postgreSQL(hostName, username, password, database):
+        case let .postgreSQL(hostName, port, username, password, database, configuration):
+            let config = PostgresConfiguration(hostname: hostName,
+                                               port: port,
+                                               username: username,
+                                               password: password,
+                                               database: database,
+                                               tlsConfiguration: configuration)
             return .postgres(hostname: hostName, username: username, password: password, database: database)
         case .defaultMySQL(let conString):
             return try .mysql(url: conString)
@@ -72,7 +77,6 @@ public final class DatabaseConfiguration: Configuration {
         }
     }
 }
-
 /// An enum specifying the configuration of the SQLite database type.
 public enum SQLiteConfig {
     /// Creates the database in memory
@@ -96,14 +100,17 @@ public enum DatabaseType {
     /// - Parameters:
         /// - connectionString: The URL-String the database will listen on.
     case defaultPostgreSQL(_ connectionString: String)
+    // swiftlint:disable enum_case_associated_values_count
     /// A database type for a specified postreSQL configuration
     ///
     /// - Parameters:
         /// - hostname: The name of the database host.
         /// - username: The username of the database user.
+        /// - port:     The port of the database.
         /// - password: The password of the database user.
         /// - database: The name of the database
-    case postgreSQL(hostname: String, username: String, password: String, database: String)
+        /// - configuration: The `TLSConfiguration` object  that should be used
+    case postgreSQL(hostname: String, port: Int, username: String, password: String, database: String, configuration: TLSConfiguration)
     /// A database type for a specified sqLite configuration
     ///
     /// - Parameters:

--- a/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
+++ b/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
@@ -67,8 +67,9 @@ public final class DatabaseConfiguration: Configuration {
         case .defaultMySQL(let conString):
             return try .mysql(url: conString)
         case let .mySQL(hostname, username, password):
-//            let tlsConfig = TLSConfiguration()
-            let config = MySQLConfiguration(hostname: hostname, username: username, password: password, tlsConfiguration: TLSConfiguration.forClient())
+            let tlsConfig = TLSConfiguration.clientDefault
+            tlsConfig.certificateVerification = .none
+            let config = MySQLConfiguration(hostname: hostname, username: username, password: password, tlsConfiguration: tlsConfig)
             return .mysql(configuration: config)
 //            return .mysql(hostname: hostname, port: 8080, username: username, password: password, database: "Test", tlsConfiguration: TLSConfiguration.forClient(), maxConnectionsPerEventLoop: 5, connectionPoolTimeout: .seconds(60), encoder: .init(json: JSONEncoder()), decoder: .init(json: JSONDecoder()))
 //            return .mysql(hostname: hostname, username: username, password: password)

--- a/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
+++ b/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
@@ -40,7 +40,6 @@ public final class DatabaseConfiguration: Configuration {
             app.migrations.add(migrations)
             try app.autoMigrate().wait()
         } catch {
-            print(error)
             fatalError("An error occured while configuring the database. Error: \(error.localizedDescription)")
         }
     }

--- a/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
+++ b/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
@@ -4,6 +4,7 @@ import Apodini
 @_implementationOnly import FluentMySQLDriver
 @_implementationOnly import FluentPostgresDriver
 @_implementationOnly import FluentMongoDriver
+@_implementationOnly import Foundation
 
 /// A `Configuration` used for Database Access
 public final class DatabaseConfiguration: Configuration {
@@ -53,6 +54,7 @@ public final class DatabaseConfiguration: Configuration {
     }
     
     private func databaseFactory(for type: DatabaseType) throws -> Fluent.DatabaseConfigurationFactory {
+        
         switch type {
         case .defaultMongoDB(let conString):
             return try .mongo(connectionString: conString)
@@ -65,7 +67,11 @@ public final class DatabaseConfiguration: Configuration {
         case .defaultMySQL(let conString):
             return try .mysql(url: conString)
         case let .mySQL(hostname, username, password):
-            return .mysql(hostname: hostname, username: username, password: password)
+//            let tlsConfig = TLSConfiguration()
+            let config = MySQLConfiguration(hostname: hostname, port: 8080, username: username, password: password, database: "Test", tlsConfiguration: TLSConfiguration.forClient())
+            
+            return .mysql(hostname: hostname, port: 8080, username: username, password: password, database: "Test", tlsConfiguration: TLSConfiguration.forClient(), maxConnectionsPerEventLoop: 5, connectionPoolTimeout: .seconds(60), encoder: .init(json: JSONEncoder()), decoder: .init(json: JSONDecoder()))
+//            return .mysql(hostname: hostname, username: username, password: password)
         }
     }
 }

--- a/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
+++ b/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
@@ -67,7 +67,7 @@ public final class DatabaseConfiguration: Configuration {
         case .defaultMySQL(let conString):
             return try .mysql(url: conString)
         case let .mySQL(hostname, username, password):
-            let tlsConfig = TLSConfiguration.clientDefault
+            var tlsConfig = TLSConfiguration.clientDefault
             tlsConfig.certificateVerification = .none
             let config = MySQLConfiguration(hostname: hostname, username: username, password: password, tlsConfiguration: tlsConfig)
             return .mysql(configuration: config)

--- a/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
+++ b/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
@@ -38,7 +38,8 @@ public final class DatabaseConfiguration: Configuration {
             app.migrations.add(migrations)
             try app.autoMigrate().wait()
         } catch {
-            fatalError("An error occured while configuring the database.")
+            print(error)
+            fatalError("An error occured while configuring the database. \(error.localizedDescription)")
         }
     }
     

--- a/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
+++ b/Sources/ApodiniDatabase/Context/DatabaseConfiguration.swift
@@ -68,9 +68,9 @@ public final class DatabaseConfiguration: Configuration {
             return try .mysql(url: conString)
         case let .mySQL(hostname, username, password):
 //            let tlsConfig = TLSConfiguration()
-            let config = MySQLConfiguration(hostname: hostname, port: 8080, username: username, password: password, database: "Test", tlsConfiguration: TLSConfiguration.forClient())
-            
-            return .mysql(hostname: hostname, port: 8080, username: username, password: password, database: "Test", tlsConfiguration: TLSConfiguration.forClient(), maxConnectionsPerEventLoop: 5, connectionPoolTimeout: .seconds(60), encoder: .init(json: JSONEncoder()), decoder: .init(json: JSONDecoder()))
+            let config = MySQLConfiguration(hostname: hostname, username: username, password: password, tlsConfiguration: TLSConfiguration.forClient())
+            return .mysql(configuration: config)
+//            return .mysql(hostname: hostname, port: 8080, username: username, password: password, database: "Test", tlsConfiguration: TLSConfiguration.forClient(), maxConnectionsPerEventLoop: 5, connectionPoolTimeout: .seconds(60), encoder: .init(json: JSONEncoder()), decoder: .init(json: JSONDecoder()))
 //            return .mysql(hostname: hostname, username: username, password: password)
         }
     }


### PR DESCRIPTION
# Allow TLS configuration in the database configuration

## :recycle: Current situation
Currently there is no way to set a `TLSConfiguration` for mysql or Postgres databases. This can crash the database configuration because of not-provided certificates 

## :bulb: Proposed solution
Adjust the enums of `DatabaseType` to allow to pass a `TLSConfiguration` object. This allows the user to pass the wanted config.

### Problem that is solved
This should fix connection issues for mysql and Postgres databases.

### Testing
No test cases were added or modified.

### Reviewer Nudging
Pretty straight forward
