### PR TITLE
Run Tests in release configuration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,7 +50,7 @@ jobs:
       run: swift build -c release
     - name: Release Build & Test
       if: matrix.configuration == 'release_testing'
-      run: swift test -c release --enable-test-discovery -Xswiftc -enable-testing -Xswiftc -DDEBUG
+      run: swift test -c release --enable-test-discovery -Xswiftc -enable-testing -Xswiftc -DRELEASE_TESTING
     - name: Debug Build & Test
       if: matrix.configuration == 'debug'
       run: swift test -c debug --enable-test-discovery

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,13 +45,13 @@ jobs:
     - name: Check Swift version
       run: swift --version
 
-    - name: Build Release # Ensuring release build runs successfully without -enable-testing flag
+    - name: Release Build # Ensuring release build runs successfully without -enable-testing flag
       if: matrix.configuration == 'release'
       run: swift build --configuration ${{ matrix.configuration }}
-    - name: Build & Test
+    - name: Release Build & Test
       if: matrix.configuration == 'release'
       run: swift test --configuration ${{ matrix.configuration }} --enable-test-discovery -Xswiftc -enable-testing -Xswiftc -DDEBUG
-    - name: Build & Test
+    - name: Debug Build & Test
       if: matrix.configuration == 'debug'
       run: swift test --configuration ${{ matrix.configuration }} --enable-test-discovery
     - name: Run Deployment Provider Tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,7 +50,7 @@ jobs:
       run: swift build --configuration ${{ matrix.configuration }}
     - name: Build & Test
       if: matrix.configuration == 'release'
-      run: swift test --configuration ${{ matrix.configuration }} --enable-test-discovery -Xswiftc -enable-testing
+      run: swift test --configuration ${{ matrix.configuration }} --enable-test-discovery -Xswiftc -enable-testing -Xswiftc -DDEBUG
     - name: Build & Test
       if: matrix.configuration == 'debug'
       run: swift test --configuration ${{ matrix.configuration }} --enable-test-discovery

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   linux:
-    name: Linux ${{ matrix.linux }} ${{ matrix.configuration }} test build
+    name: Linux ${{ matrix.linux }} ${{ matrix.configuration }}
     container:
       image: swift:5.3-${{ matrix.linux }}
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         linux: [bionic, xenial, focal, amazonlinux2, centos8]
-        configuration: [debug, release]
+        configuration: [debug, release, release_testing]
     steps:
     - uses: actions/checkout@v2
     - name: Install libsqlite3, lsof and zsh
@@ -47,18 +47,19 @@ jobs:
 
     - name: Release Build # Ensuring release build runs successfully without -enable-testing flag
       if: matrix.configuration == 'release'
-      run: swift build --configuration ${{ matrix.configuration }}
+      run: swift build -c release
     - name: Release Build & Test
-      if: matrix.configuration == 'release'
-      run: swift test --configuration ${{ matrix.configuration }} --enable-test-discovery -Xswiftc -enable-testing -Xswiftc -DDEBUG
+      if: matrix.configuration == 'release_testing'
+      run: swift test -c release --enable-test-discovery -Xswiftc -enable-testing -Xswiftc -DDEBUG
     - name: Debug Build & Test
       if: matrix.configuration == 'debug'
-      run: swift test --configuration ${{ matrix.configuration }} --enable-test-discovery
-    - name: Run Deployment Provider Tests
+      run: swift test -c debug --enable-test-discovery
+
+    - name: Run Deployment Provider Tests DEBUG
       if: ${{ github.event.inputs.runDeploymentProviderTests && matrix.linux == 'focal' && matrix.configuration == 'debug' }}
       run: |
-        swift test --configuration ${{ matrix.configuration }} --enable-test-discovery --filter ApodiniDeployTests.LocalhostDeploymentProviderTests
-        swift test --configuration ${{ matrix.configuration }} --enable-test-discovery --filter ApodiniDeployTests.LambdaDeploymentProviderTests
+        swift test -c debug --enable-test-discovery --filter ApodiniDeployTests.LocalhostDeploymentProviderTests
+        swift test -c debug --enable-test-discovery --filter ApodiniDeployTests.LambdaDeploymentProviderTests
       env:
         ENABLE_DEPLOYMENT_PROVIDER_TESTS: YES
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,9 +44,13 @@ jobs:
         key: ${{ runner.os }}-${{matrix.linux}}-spm-${{ hashFiles('Package.resolved') }}
     - name: Check Swift version
       run: swift --version
-    - name: Build
+
+    - name: Build Release # Ensuring release build runs successfully without -enable-testing flag
       if: matrix.configuration == 'release'
       run: swift build --configuration ${{ matrix.configuration }}
+    - name: Build & Test
+      if: matrix.configuration == 'release'
+      run: swift test --configuration ${{ matrix.configuration }} --enable-test-discovery -Xswiftc -enable-testing
     - name: Build & Test
       if: matrix.configuration == 'debug'
       run: swift test --configuration ${{ matrix.configuration }} --enable-test-discovery

--- a/Package.swift
+++ b/Package.swift
@@ -324,6 +324,7 @@ let package = Package(
             dependencies: [
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
                 .product(name: "CwlPreconditionTesting", package: "CwlPreconditionTesting", condition: .when(platforms: [.macOS])),
+                .product(name: "CwlPosixPreconditionTesting", package: "CwlPreconditionTesting", condition: .when(platforms: [.linux])),
                 .target(name: "Apodini"),
                 .target(name: "ApodiniDatabase"),
                 .target(name: "ApodiniUtils")

--- a/Package.swift
+++ b/Package.swift
@@ -324,7 +324,6 @@ let package = Package(
             dependencies: [
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
                 .product(name: "CwlPreconditionTesting", package: "CwlPreconditionTesting", condition: .when(platforms: [.macOS])),
-                .product(name: "CwlPosixPreconditionTesting", package: "CwlPreconditionTesting", condition: .when(platforms: [.linux])),
                 .target(name: "Apodini"),
                 .target(name: "ApodiniDatabase"),
                 .target(name: "ApodiniUtils")

--- a/Sources/Apodini/Properties/Binding.swift
+++ b/Sources/Apodini/Properties/Binding.swift
@@ -58,7 +58,7 @@ public struct Binding<Value>: DynamicProperty, PotentiallyParameterIdentifyingBi
 extension Binding: PathComponent & _PathComponent where Value: Codable {
     func append<Parser: PathComponentParser>(to parser: inout Parser) {
         guard let parameter = store.wrappedValue["parameter"] as? Parameter<Value> else {
-            assertionFailure("Only bindings created from a `Parameter` or `PathParameter` can be used as a path component")
+            preconditionFailure("Only bindings created from a `Parameter` or `PathParameter` can be used as a path component")
             return
         }
         

--- a/Sources/Apodini/Semantic Model Builder/Traversable.swift
+++ b/Sources/Apodini/Semantic Model Builder/Traversable.swift
@@ -421,7 +421,7 @@ private extension Runtime.PropertyInfo {
     }
 }
 
-#if DEBUG
+#if DEBUG || RELEASE_TESTING
     func exposedExecute<Element, Target>(_ operation: (Target, _ name: String) throws -> Void, on element: Element) rethrows {
         try execute(operation, on: element)
     }

--- a/Sources/Apodini/Semantic Model Builder/Traversable.swift
+++ b/Sources/Apodini/Semantic Model Builder/Traversable.swift
@@ -421,7 +421,7 @@ private extension Runtime.PropertyInfo {
     }
 }
 
-
+#if DEBUG
     func exposedExecute<Element, Target>(_ operation: (Target, _ name: String) throws -> Void, on element: Element) rethrows {
         try execute(operation, on: element)
     }
@@ -437,3 +437,4 @@ private extension Runtime.PropertyInfo {
     func exposedApply<Element, Target>(_ mutation: (inout Target) throws -> Void, to element: inout Element) rethrows {
         try apply(mutation, to: &element)
     }
+#endif

--- a/Sources/Apodini/Semantic Model Builder/Traversable.swift
+++ b/Sources/Apodini/Semantic Model Builder/Traversable.swift
@@ -421,7 +421,7 @@ private extension Runtime.PropertyInfo {
     }
 }
 
-#if DEBUG
+
     func exposedExecute<Element, Target>(_ operation: (Target, _ name: String) throws -> Void, on element: Element) rethrows {
         try execute(operation, on: element)
     }
@@ -437,4 +437,3 @@ private extension Runtime.PropertyInfo {
     func exposedApply<Element, Target>(_ mutation: (inout Target) throws -> Void, to element: inout Element) rethrows {
         try apply(mutation, to: &element)
     }
-#endif

--- a/Sources/Apodini/WebService.swift
+++ b/Sources/Apodini/WebService.swift
@@ -63,7 +63,7 @@ extension WebService {
         let webService = Self()
         webService.configuration.configure(app)
         
-        // If no specific address hostname is provided we bind to the default address to automatically and correcly bind in Docker containers.
+        // If no specific address hostname is provided we bind to the default address to automatically and correctly bind in Docker containers.
         if app.http.address == nil {
             app.http.address = .hostname(HTTPConfiguration.Defaults.hostname, port: HTTPConfiguration.Defaults.port)
         }

--- a/Sources/ApodiniDatabase/FileHandlers/DownloadConfiguration.swift
+++ b/Sources/ApodiniDatabase/FileHandlers/DownloadConfiguration.swift
@@ -28,7 +28,7 @@ public struct DownloadConfiguration {
         let searchableDirectories: [String] = directories.map { $0.path(for: directory) }
         
         for dir in searchableDirectories {
-            #if Xcode || DEBUG
+            #if Xcode || DEBUG || RELEASE_TESTING
             // For an explanation, see below
             guard fileManager.fileExists(atPath: dir) else {
                 continue
@@ -58,7 +58,7 @@ public struct DownloadConfiguration {
         var infos: [FileInfo] = []
         
         for dir in searchableDirectories {
-            #if Xcode || DEBUG
+            #if Xcode || DEBUG || RELEASE_TESTING
             // As we are in Xcode, we created only a dummy public directory.
             // See Application+Directory.swift
             // This means that `resource` and `working` are missing.

--- a/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter.swift
+++ b/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter.swift
@@ -258,16 +258,6 @@ private protocol HandlerWithDeploymentOptionsATRVisitorHelper: AssociatedTypeReq
     func callAsFunction<T: HandlerWithDeploymentOptions>(_ value: T) -> Output
 }
 
-/*
- extension IdentifiableHandlerATRVisitorHelper {
-    @inline(never)
-    @_optimize(none)
-    fileprivate func _test() {
-        _ = self(TestHandlerType())
-    }
-}
- */
-
 private struct TestHandlerWithDeploymentOptions: HandlerWithDeploymentOptions {
     typealias Response = Never
     static var deploymentOptions: [AnyDeploymentOption] { [] }

--- a/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter.swift
+++ b/Sources/ApodiniDeploy/ApodiniDeployInterfaceExporter.swift
@@ -258,20 +258,33 @@ private protocol HandlerWithDeploymentOptionsATRVisitorHelper: AssociatedTypeReq
     func callAsFunction<T: HandlerWithDeploymentOptions>(_ value: T) -> Output
 }
 
+/*
+ extension IdentifiableHandlerATRVisitorHelper {
+    @inline(never)
+    @_optimize(none)
+    fileprivate func _test() {
+        _ = self(TestHandlerType())
+    }
+}
+ */
+
+private struct TestHandlerWithDeploymentOptions: HandlerWithDeploymentOptions {
+    typealias Response = Never
+    static var deploymentOptions: [AnyDeploymentOption] { [] }
+}
+
+extension HandlerWithDeploymentOptionsATRVisitorHelper {
+    @inline(never)
+    @_optimize(none)
+    fileprivate func _test() {
+        _ = self(TestHandlerWithDeploymentOptions())
+    }
+}
+
 
 private struct HandlerWithDeploymentOptionsATRVisitor: HandlerWithDeploymentOptionsATRVisitorHelper {
     func callAsFunction<H: HandlerWithDeploymentOptions>(_: H) -> [AnyDeploymentOption] {
         H.deploymentOptions
-    }
-    
-    @inline(never)
-    @_optimize(none)
-    fileprivate func _test() {
-        struct TestHandler: HandlerWithDeploymentOptions {
-            typealias Response = Never
-            static var deploymentOptions: [AnyDeploymentOption] { [] }
-        }
-        _ = self(TestHandler())
     }
 }
 

--- a/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
+++ b/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
@@ -156,7 +156,7 @@ extension DeploymentProvider {
         logger.notice("Invoking child process `\(exportWebServiceModelTask.description)`")
         let terminationInfo = try exportWebServiceModelTask.launchSync()
         guard terminationInfo.exitCode == EXIT_SUCCESS else {
-            throw ApodiniDeployBuildSupportError(message: "Unable to generate model structure: \(terminationInfo.exitCode)") // TODO throws in release builds
+            throw ApodiniDeployBuildSupportError(message: "Unable to generate model structure: \(terminationInfo.exitCode)")
         }
         
         logger.notice("model written to '\(modelFileUrl)'")

--- a/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
+++ b/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
@@ -153,10 +153,10 @@ extension DeploymentProvider {
             )
         }
         
-        logger.notice("Invoking child process `\(exportWebServiceModelTask)`")
+        logger.notice("Invoking child process `\(exportWebServiceModelTask.description)`")
         let terminationInfo = try exportWebServiceModelTask.launchSync()
         guard terminationInfo.exitCode == EXIT_SUCCESS else {
-            throw ApodiniDeployBuildSupportError(message: "Unable to generate model structure")
+            throw ApodiniDeployBuildSupportError(message: "Unable to generate model structure: \(terminationInfo.exitCode)") // TODO throws in release builds
         }
         
         logger.notice("model written to '\(modelFileUrl)'")

--- a/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
+++ b/Sources/ApodiniDeployBuildSupport/DeploymentProvider.swift
@@ -153,7 +153,7 @@ extension DeploymentProvider {
             )
         }
         
-        logger.notice("Invoking child process `\(exportWebServiceModelTask.description)`")
+        logger.notice("Invoking child process `\(exportWebServiceModelTask)`")
         let terminationInfo = try exportWebServiceModelTask.launchSync()
         guard terminationInfo.exitCode == EXIT_SUCCESS else {
             throw ApodiniDeployBuildSupportError(message: "Unable to generate model structure: \(terminationInfo.exitCode)")

--- a/Sources/XCTApodini/Mocks/MockBlackboard.swift
+++ b/Sources/XCTApodini/Mocks/MockBlackboard.swift
@@ -5,7 +5,7 @@
 //  Created by Max Obermeier on 10.05.21.
 //
 
-#if DEBUG
+#if DEBUG || RELEASE_TESTING
 import Foundation
 @testable import Apodini
 

--- a/Sources/XCTApodini/Mocks/MockBlackboard.swift
+++ b/Sources/XCTApodini/Mocks/MockBlackboard.swift
@@ -5,6 +5,7 @@
 //  Created by Max Obermeier on 10.05.21.
 //
 
+#if DEBUG
 import Foundation
 @testable import Apodini
 
@@ -41,3 +42,4 @@ public extension WebServiceModel {
         self.init(mockBlackboard)
     }
 }
+#endif

--- a/Sources/XCTApodini/Mocks/MockBlackboard.swift
+++ b/Sources/XCTApodini/Mocks/MockBlackboard.swift
@@ -5,7 +5,6 @@
 //  Created by Max Obermeier on 10.05.21.
 //
 
-#if DEBUG
 import Foundation
 @testable import Apodini
 
@@ -42,4 +41,3 @@ public extension WebServiceModel {
         self.init(mockBlackboard)
     }
 }
-#endif

--- a/Sources/XCTApodini/Mocks/MockEndpoint.swift
+++ b/Sources/XCTApodini/Mocks/MockEndpoint.swift
@@ -2,7 +2,7 @@
 // Created by Andreas Bauer on 25.12.20.
 //
 
-#if DEBUG
+#if DEBUG || RELEASE_TESTING
 @testable import Apodini
 import struct Foundation.UUID
 

--- a/Sources/XCTApodini/Mocks/MockEndpoint.swift
+++ b/Sources/XCTApodini/Mocks/MockEndpoint.swift
@@ -2,7 +2,6 @@
 // Created by Andreas Bauer on 25.12.20.
 //
 
-#if DEBUG
 @testable import Apodini
 import struct Foundation.UUID
 
@@ -46,4 +45,3 @@ public extension Handler {
         )
     }
 }
-#endif

--- a/Sources/XCTApodini/Mocks/MockEndpoint.swift
+++ b/Sources/XCTApodini/Mocks/MockEndpoint.swift
@@ -2,6 +2,7 @@
 // Created by Andreas Bauer on 25.12.20.
 //
 
+#if DEBUG
 @testable import Apodini
 import struct Foundation.UUID
 
@@ -45,3 +46,4 @@ public extension Handler {
         )
     }
 }
+#endif

--- a/Sources/XCTApodini/Mocks/MockExporter.swift
+++ b/Sources/XCTApodini/Mocks/MockExporter.swift
@@ -2,7 +2,6 @@
 // Created by Andreas Bauer on 25.12.20.
 //
 
-#if DEBUG
 import Foundation
 import class Vapor.Application
 import class Vapor.Request
@@ -75,4 +74,3 @@ open class MockExporter<Request: ExporterRequest>: InterfaceExporter {
         return casted
     }
 }
-#endif

--- a/Sources/XCTApodini/Mocks/MockExporter.swift
+++ b/Sources/XCTApodini/Mocks/MockExporter.swift
@@ -5,7 +5,7 @@
 import Foundation
 import class Vapor.Application
 import class Vapor.Request
-@testable import Apodini
+import Apodini
 
 extension String: ExporterRequest {}
 

--- a/Sources/XCTApodini/Mocks/MockQuery.swift
+++ b/Sources/XCTApodini/Mocks/MockQuery.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if DEBUG || RELEASE_TESTING
 import XCTest
 @testable import Apodini
 

--- a/Sources/XCTApodini/Mocks/MockQuery.swift
+++ b/Sources/XCTApodini/Mocks/MockQuery.swift
@@ -1,4 +1,3 @@
-#if DEBUG
 import XCTest
 @testable import Apodini
 
@@ -18,4 +17,3 @@ public func mockQuery<Value: Encodable, H: Handler>(
     
     return try XCTUnwrap(response.typed(value))
 }
-#endif

--- a/Sources/XCTApodini/Mocks/MockQuery.swift
+++ b/Sources/XCTApodini/Mocks/MockQuery.swift
@@ -1,3 +1,4 @@
+#if DEBUG
 import XCTest
 @testable import Apodini
 
@@ -17,3 +18,4 @@ public func mockQuery<Value: Encodable, H: Handler>(
     
     return try XCTUnwrap(response.typed(value))
 }
+#endif

--- a/Sources/XCTApodini/Mocks/MockRequest.swift
+++ b/Sources/XCTApodini/Mocks/MockRequest.swift
@@ -2,7 +2,7 @@
 // Created by Andreas Bauer on 25.12.20.
 //
 
-#if DEBUG
+#if DEBUG || RELEASE_TESTING
 import XCTest
 import Foundation
 @testable import Apodini

--- a/Sources/XCTApodini/Mocks/MockRequest.swift
+++ b/Sources/XCTApodini/Mocks/MockRequest.swift
@@ -2,7 +2,6 @@
 // Created by Andreas Bauer on 25.12.20.
 //
 
-#if DEBUG
 import XCTest
 import Foundation
 @testable import Apodini
@@ -46,4 +45,3 @@ public enum MockRequest {
         }
     }
 }
-#endif

--- a/Sources/XCTApodini/Mocks/MockRequest.swift
+++ b/Sources/XCTApodini/Mocks/MockRequest.swift
@@ -2,6 +2,7 @@
 // Created by Andreas Bauer on 25.12.20.
 //
 
+#if DEBUG
 import XCTest
 import Foundation
 @testable import Apodini
@@ -45,3 +46,4 @@ public enum MockRequest {
         }
     }
 }
+#endif

--- a/Sources/XCTApodini/TestingRelationshipFormatter.swift
+++ b/Sources/XCTApodini/TestingRelationshipFormatter.swift
@@ -2,7 +2,6 @@
 // Created by Andreas Bauer on 23.01.21.
 //
 
-#if DEBUG
 import Apodini
 
 public struct TestingRelationshipFormatter: RelationshipFormatter {
@@ -24,4 +23,3 @@ public struct TestingRelationshipFormatter: RelationshipFormatter {
         into[of.name + ":\(of.operation)"] = representation
     }
 }
-#endif

--- a/Sources/XCTApodini/XCTApodiniTest.swift
+++ b/Sources/XCTApodini/XCTApodiniTest.swift
@@ -1,4 +1,3 @@
-#if DEBUG
 import FluentSQLiteDriver
 @testable import Apodini
 import XCTest
@@ -40,4 +39,3 @@ open class XCTApodiniTest: XCTestCase {
         try app.autoMigrate().wait()
     }
 }
-#endif

--- a/Sources/XCTApodini/XCTApodiniTest.swift
+++ b/Sources/XCTApodini/XCTApodiniTest.swift
@@ -1,5 +1,5 @@
 import FluentSQLiteDriver
-@testable import Apodini
+import Apodini
 import XCTest
 import ApodiniDatabase
 import ApodiniUtils

--- a/Sources/XCTApodini/XCTAssertApodiniApplicationNotRunning.swift
+++ b/Sources/XCTApodini/XCTAssertApodiniApplicationNotRunning.swift
@@ -5,7 +5,6 @@
 //  Created by Paul Schmiedmayer on 5/10/21.
 //
 
-#if DEBUG
 import XCTest
 import ApodiniUtils
 
@@ -41,4 +40,3 @@ public func XCTAssertApodiniApplicationNotRunning(
         runShellCommand(.killPort(8080))
     }
 }
-#endif

--- a/Sources/XCTApodini/XCTAssertRuntimeFailure.swift
+++ b/Sources/XCTApodini/XCTAssertRuntimeFailure.swift
@@ -7,13 +7,8 @@
 
 
 import XCTest
-#if canImport(CwlPreconditionTesting) || canImport(CwlPosixPreconditionTesting)
 #if canImport(CwlPreconditionTesting)
 @_implementationOnly import CwlPreconditionTesting
-#elseif canImport(CwlPosixPreconditionTesting)
-@_implementationOnly import CwlPosixPreconditionTesting
-#endif
-// TODO CwlPOSIXPreconditioNTesting
 
 /// Asserts that an expression leads to a runtime failure.
 public func XCTAssertRuntimeFailure<T>(
@@ -34,6 +29,6 @@ public func XCTAssertRuntimeFailure<T>(
     file: StaticString = #filePath,
     line: UInt = #line) {
     // Empty implementation for Linux Tests
-    print("[WARN] XCTAssertRuntimeFailure unsupported!") // TODO remove
+    print("[NOTICE] XCTAssertRuntimeFailure unsupported on platform!")
 }
 #endif

--- a/Sources/XCTApodini/XCTAssertRuntimeFailure.swift
+++ b/Sources/XCTApodini/XCTAssertRuntimeFailure.swift
@@ -6,10 +6,14 @@
 //
 
 
-#if DEBUG
 import XCTest
+#if canImport(CwlPreconditionTesting) || canImport(CwlPosixPreconditionTesting)
 #if canImport(CwlPreconditionTesting)
 @_implementationOnly import CwlPreconditionTesting
+#elseif canImport(CwlPosixPreconditionTesting)
+@_implementationOnly import CwlPosixPreconditionTesting
+#endif
+// TODO CwlPOSIXPreconditioNTesting
 
 /// Asserts that an expression leads to a runtime failure.
 public func XCTAssertRuntimeFailure<T>(
@@ -30,6 +34,6 @@ public func XCTAssertRuntimeFailure<T>(
     file: StaticString = #filePath,
     line: UInt = #line) {
     // Empty implementation for Linux Tests
+    print("[WARN] XCTAssertRuntimeFailure unsupported!") // TODO remove
 }
-#endif
 #endif

--- a/Sources/XCTApodini/XCTCheckResponse.swift
+++ b/Sources/XCTApodini/XCTCheckResponse.swift
@@ -5,7 +5,7 @@
 //  Created by Paul Schmiedmayer on 2/3/21.
 //
 
-#if DEBUG
+#if DEBUG || RELEASE_TESTING
 @testable import Apodini
 import XCTest
 

--- a/Sources/XCTApodini/XCTCheckResponse.swift
+++ b/Sources/XCTApodini/XCTCheckResponse.swift
@@ -5,7 +5,10 @@
 //  Created by Paul Schmiedmayer on 2/3/21.
 //
 
+#if DEBUG
 @testable import Apodini
+#endif
+
 import XCTest
 
 extension Empty: Equatable {
@@ -13,6 +16,8 @@ extension Empty: Equatable {
         true
     }
 }
+
+#if DEBUG
 
 /// Adds the possibility to easily check the `Response<T>` of a `Handler` by investigating the `Response`
 /// - Parameters:
@@ -169,3 +174,4 @@ private func _XCTCheckResponse<C, T: Encodable & Equatable>(
     
     return content
 }
+#endif

--- a/Sources/XCTApodini/XCTCheckResponse.swift
+++ b/Sources/XCTApodini/XCTCheckResponse.swift
@@ -7,8 +7,6 @@
 
 #if DEBUG
 @testable import Apodini
-#endif
-
 import XCTest
 
 extension Empty: Equatable {
@@ -16,8 +14,6 @@ extension Empty: Equatable {
         true
     }
 }
-
-#if DEBUG
 
 /// Adds the possibility to easily check the `Response<T>` of a `Handler` by investigating the `Response`
 /// - Parameters:

--- a/Sources/XCTApodini/XCTCheckResponse.swift
+++ b/Sources/XCTApodini/XCTCheckResponse.swift
@@ -5,7 +5,6 @@
 //  Created by Paul Schmiedmayer on 2/3/21.
 //
 
-#if DEBUG
 @testable import Apodini
 import XCTest
 
@@ -170,4 +169,3 @@ private func _XCTCheckResponse<C, T: Encodable & Equatable>(
     
     return content
 }
-#endif

--- a/Sources/XCTApodini/XCTUnwrap+Response.swift
+++ b/Sources/XCTApodini/XCTUnwrap+Response.swift
@@ -2,7 +2,6 @@
 // Created by Andreas Bauer on 02.02.21.
 //
 
-#if DEBUG
 import XCTest
 @testable import Apodini
 
@@ -15,4 +14,3 @@ public func XCTUnwrap<T: Encodable>(
 ) throws -> T {
     try XCTUnwrap(try expression().content, message(), file: file, line: line)
 }
-#endif

--- a/Sources/XCTApodini/XCTUnwrap+Response.swift
+++ b/Sources/XCTApodini/XCTUnwrap+Response.swift
@@ -3,7 +3,7 @@
 //
 
 import XCTest
-@testable import Apodini
+import Apodini
 
 /// Overload for force unwrapping `Response` types.
 public func XCTUnwrap<T: Encodable>(

--- a/Tests/ApodiniDeployTests/ApodiniDeployTestCase.swift
+++ b/Tests/ApodiniDeployTests/ApodiniDeployTestCase.swift
@@ -109,7 +109,7 @@ class ApodiniDeployTestCase: XCTestCase {
 
 extension XCTestCase {
     static func isRunningOnLinuxDebug() -> Bool {
-        #if os(Linux) && DEBUG
+        #if os(Linux) && (DEBUG || RELEASE_TESTING)
         return true
         #else
         return false

--- a/Tests/ApodiniTests/DatabaseTests/FileHandlerTests/DownloadConfigTests.swift
+++ b/Tests/ApodiniTests/DatabaseTests/FileHandlerTests/DownloadConfigTests.swift
@@ -39,22 +39,33 @@ final class DownloadConfigTests: FileHandlerTests {
         let result = try XCTUnwrap(mockQuery(handler: uploader, value: String.self, app: app, queued: file))
         
         XCTAssert(result == file.filename)
+        print("Test1")
         
         // Upload second file
         uploader = Uploader(UploadConfiguration(.default, subPath: "Misc/MoreMisc/"))
         let file2 = File(data: data, filename: "Testfile123.jpeg")
+        print("Test2")
         
         let result2 = try XCTUnwrap(mockQuery(handler: uploader, value: String.self, app: app, queued: file2))
-        
+
+        print("Test3")
+
         XCTAssert(result2 == file2.filename)
+
+        print("Test4")
         
         let directory = app.directory
         let config = DownloadConfiguration(.default)
         let fileInfos = try config.retrieveFileInfos(".jpeg", in: directory)
-        
+
+        print("Test5")
+
         XCTAssertNotNil(fileInfos)
         let infos = try XCTUnwrap(fileInfos)
+        print("Test6")
         XCTAssert(infos[0].fileName == file.filename || infos[0].fileName == file2.filename)
+        print("Test7")
         XCTAssert(infos[1].fileName == file.filename || infos[1].fileName == file2.filename)
+        print("Test8")
     }
 }

--- a/Tests/ApodiniTests/DatabaseTests/FileHandlerTests/DownloadConfigTests.swift
+++ b/Tests/ApodiniTests/DatabaseTests/FileHandlerTests/DownloadConfigTests.swift
@@ -39,33 +39,22 @@ final class DownloadConfigTests: FileHandlerTests {
         let result = try XCTUnwrap(mockQuery(handler: uploader, value: String.self, app: app, queued: file))
         
         XCTAssert(result == file.filename)
-        print("Test1")
         
         // Upload second file
         uploader = Uploader(UploadConfiguration(.default, subPath: "Misc/MoreMisc/"))
         let file2 = File(data: data, filename: "Testfile123.jpeg")
-        print("Test2")
         
         let result2 = try XCTUnwrap(mockQuery(handler: uploader, value: String.self, app: app, queued: file2))
 
-        print("Test3")
-
         XCTAssert(result2 == file2.filename)
-
-        print("Test4")
         
         let directory = app.directory
         let config = DownloadConfiguration(.default)
         let fileInfos = try config.retrieveFileInfos(".jpeg", in: directory)
 
-        print("Test5")
-
         XCTAssertNotNil(fileInfos)
         let infos = try XCTUnwrap(fileInfos)
-        print("Test6")
         XCTAssert(infos[0].fileName == file.filename || infos[0].fileName == file2.filename)
-        print("Test7")
         XCTAssert(infos[1].fileName == file.filename || infos[1].fileName == file2.filename)
-        print("Test8")
     }
 }

--- a/Tests/ApodiniTests/MetadataTests/ComponentMetadataTests.swift
+++ b/Tests/ApodiniTests/MetadataTests/ComponentMetadataTests.swift
@@ -46,7 +46,7 @@ private struct TestIntComponentMetadata: ComponentMetadataDefinition {
 private struct GenericTestStringComponentMetadata<C: Component>: ComponentMetadataDefinition {
     typealias Key = TestStringMetadataContextKey
 
-    var value: String = "\(C.self)"
+    var value: String = String(describing: C.self)
 }
 
 private struct ReusableTestComponentMetadata: ComponentMetadataBlock {

--- a/Tests/ApodiniTests/MetadataTests/ComponentMetadataTests.swift
+++ b/Tests/ApodiniTests/MetadataTests/ComponentMetadataTests.swift
@@ -46,7 +46,7 @@ private struct TestIntComponentMetadata: ComponentMetadataDefinition {
 private struct GenericTestStringComponentMetadata<C: Component>: ComponentMetadataDefinition {
     typealias Key = TestStringMetadataContextKey
 
-    var value: String = String(describing: C.self)
+    var value = String(describing: C.self)
 }
 
 private struct ReusableTestComponentMetadata: ComponentMetadataBlock {

--- a/Tests/ApodiniTests/MetadataTests/ComponentOnlyMetadataTests.swift
+++ b/Tests/ApodiniTests/MetadataTests/ComponentOnlyMetadataTests.swift
@@ -46,7 +46,7 @@ private struct TestIntComponentOnlyMetadata: ComponentOnlyMetadataDefinition {
 private struct GenericTestStringComponentOnlyMetadata<C: Component>: ComponentOnlyMetadataDefinition {
     typealias Key = TestStringMetadataContextKey
 
-    var value: String = String(describing: C.self)
+    var value = String(describing: C.self)
 }
 
 

--- a/Tests/ApodiniTests/MetadataTests/ComponentOnlyMetadataTests.swift
+++ b/Tests/ApodiniTests/MetadataTests/ComponentOnlyMetadataTests.swift
@@ -46,7 +46,7 @@ private struct TestIntComponentOnlyMetadata: ComponentOnlyMetadataDefinition {
 private struct GenericTestStringComponentOnlyMetadata<C: Component>: ComponentOnlyMetadataDefinition {
     typealias Key = TestStringMetadataContextKey
 
-    var value: String = "\(C.self)"
+    var value: String = String(describing: C.self)
 }
 
 

--- a/Tests/ApodiniTests/MetadataTests/ContentMetadataTests.swift
+++ b/Tests/ApodiniTests/MetadataTests/ContentMetadataTests.swift
@@ -46,7 +46,7 @@ private struct TestIntContentMetadata: ContentMetadataDefinition {
 private struct GenericTestStringContentMetadata<C: Content>: ContentMetadataDefinition {
     typealias Key = TestStringMetadataContextKey
 
-    var value: String = "\(C.self)"
+    var value: String = String(describing: C.self)
 }
 
 

--- a/Tests/ApodiniTests/MetadataTests/ContentMetadataTests.swift
+++ b/Tests/ApodiniTests/MetadataTests/ContentMetadataTests.swift
@@ -46,7 +46,7 @@ private struct TestIntContentMetadata: ContentMetadataDefinition {
 private struct GenericTestStringContentMetadata<C: Content>: ContentMetadataDefinition {
     typealias Key = TestStringMetadataContextKey
 
-    var value: String = String(describing: C.self)
+    var value = String(describing: C.self)
 }
 
 

--- a/Tests/ApodiniTests/MetadataTests/HandlerMetadataTests.swift
+++ b/Tests/ApodiniTests/MetadataTests/HandlerMetadataTests.swift
@@ -46,7 +46,7 @@ private struct TestIntHandlerMetadata: HandlerMetadataDefinition {
 private struct GenericTestStringHandlerMetadata<H: Handler>: HandlerMetadataDefinition {
     typealias Key = TestStringMetadataContextKey
 
-    var value: String = "\(H.self)"
+    var value: String = String(describing: H.self)
 }
 
 private struct ReusableTestHandlerMetadata: HandlerMetadataBlock {

--- a/Tests/ApodiniTests/MetadataTests/HandlerMetadataTests.swift
+++ b/Tests/ApodiniTests/MetadataTests/HandlerMetadataTests.swift
@@ -46,7 +46,7 @@ private struct TestIntHandlerMetadata: HandlerMetadataDefinition {
 private struct GenericTestStringHandlerMetadata<H: Handler>: HandlerMetadataDefinition {
     typealias Key = TestStringMetadataContextKey
 
-    var value: String = String(describing: H.self)
+    var value = String(describing: H.self)
 }
 
 private struct ReusableTestHandlerMetadata: HandlerMetadataBlock {

--- a/Tests/ApodiniTests/MetadataTests/WebServiceMetadataTests.swift
+++ b/Tests/ApodiniTests/MetadataTests/WebServiceMetadataTests.swift
@@ -46,7 +46,7 @@ private struct TestIntWebServiceMetadata: WebServiceMetadataDefinition {
 private struct GenericTestStringWebServiceMetadata<W: WebService>: WebServiceMetadataDefinition {
     typealias Key = TestStringMetadataContextKey
 
-    var value: String = "\(W.self)"
+    var value: String = String(describing: W.self)
 }
 
 

--- a/Tests/ApodiniTests/MetadataTests/WebServiceMetadataTests.swift
+++ b/Tests/ApodiniTests/MetadataTests/WebServiceMetadataTests.swift
@@ -46,7 +46,7 @@ private struct TestIntWebServiceMetadata: WebServiceMetadataDefinition {
 private struct GenericTestStringWebServiceMetadata<W: WebService>: WebServiceMetadataDefinition {
     typealias Key = TestStringMetadataContextKey
 
-    var value: String = String(describing: W.self)
+    var value = String(describing: W.self)
 }
 
 

--- a/Tests/NegativeCompileTestsRunner/NegativeTestRunner.swift
+++ b/Tests/NegativeCompileTestsRunner/NegativeTestRunner.swift
@@ -270,9 +270,16 @@ class NegativeTestRunner {
         #if !DEBUG
         arguments += " -c release -Xswiftc -enable-testing"
         #endif
+
+        #if RELEASE_TESTING
+        precondition(arguments.contains("-c release"))
+        arguments += " -Xswiftc -DRELEASE_TESTING"
+        #endif
+
         #if os(Linux)
         arguments += " --enable-test-discovery"
         #endif
+
         #if COVERAGE // custom defined Active Compilation Condition which we set when we enable code coverage collection
         arguments += " --enable-code-coverage -Xswiftc -DCOVERAGE"
         #endif


### PR DESCRIPTION
# Run Tests in release configuration

## :recycle: Current situation

As of now, our test targets all run in `debug` configuration, running without any compiler optimizations. This is of course wanted in development to easily debug those tests.
However, Apodini has some logic (mainly anything that is based on the AssociatedTypesRequirementsKit) which can break release builds if not used properly. As shown below there are also other use cases besides logic surrounding AssociatedTypesRequirementsKit.

## :bulb: Proposed solution

This PR proposes to execute our unit test with release configuration.

### Problem that is solved

We added another test vector, ensuring that everything what is tested in debug builds, works as expected in released builds as well.

### Implications

In order to run tests in release configuration, you have to pass the `-c release` argument to the `swift test` command.
Further, in order to be able to use `@testable` we have to pass the `-Xswiftc -enable-testing` compiler flag.
Lastly, we define the custom Active Compilation Condition `RELEASE_TESTING` using `-Xswiftc -DRELEASE_TESTING` in order to compile `#if` conditional compilation blocks.

#### Discussion: Active Compilation Condition: `DEBUG` vs custom `RELEASE_TESTING`

In order for `XCTApodini` to compile properly in release configuration, we need to wrap code which depends on `@testable` into `#if` conditional compilation blocks. Previously this was done using `#if DEBUG` statements, relying on the `DEBUG` condition which is automatically handled by spm in debug configuration.

This condition is not set in release configuration, therefore we have to specify it manually.

Now we have to the choice between manually specifying the existing `DEBUG` condition or creating a separate one (like `RELEASE_TESTING`) representing that exact state: testing with release configuration.

You can argue for either way. Using `DEBUG` would reduce the need to always write both: `#if DEBUG || RELEASE_TESTING`.
In some cases we have added further debug statements inside the `#if DEBUG` blocks, this would perfectly fit, to print those extended debug logging in release test builds as well.

However, one might also use `DEBUG` to add differing logic, meaning using a `#else` branch to do execute slightly different logic than in the `DEBUG` case. Those cases are still not executed when running tests in release configuration, therefore not setting `DEBUG` and creating a custom `RELEASE_TESTING` condition would make sense in those cases.

As we don't have a lot of those cases, I currently went with just setting `DEBUG` condition in release tests as well.

But I'm happy to hear about your opinion on this.

## :heavy_plus_sign: Additional Information

This PR already demonstrates why this additional test vector is helpful:
* The ApodiniDeployInterfaceExporter would crash in release builds, as it used an `AssociatedTypeRequirementsVisitor` visitor in its export method which wasn't setup properly (see https://github.com/Apodini/Apodini/pull/171#discussion_r563343324)
* When using `Binding` as PathParameters without encapsulating a `@Parameter` Apodini would just silently ignore them in release configuration only printing a proper error message in debug configuration.

### Related PRs
--

### Testing
This PR doesn't add any additional test cases

The Bamboo jobs currently do not execute tests in release configuration. Though I have verified locally that running them on macOS works as well. My plan would be to adjust those jobs after the PR has merged. If you can make branch dependent changes to the Bamboo Jobs I would also be happy to make those changes before merging.

