### PR TITLE
Allow Apodini to be used with semantic versioning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,20 @@ import PackageDescription
 /// your package caches for this to take effect.
 let experimentalAsyncAwait = false
 
+var apodiniSwiftSettings: [SwiftSetting] {
+    guard experimentalAsyncAwait else {
+        return []
+    }
+    return [
+        .unsafeFlags(
+            [
+                "-Xfrontend",
+                "-enable-experimental-concurrency"
+            ]
+        )
+    ]
+}
+
 
 // MARK: Package Definition
 
@@ -116,12 +130,7 @@ let package = Package(
             exclude: [
                 "Components/ComponentBuilder.swift.gyb"
             ],
-            swiftSettings: [
-                .unsafeFlags(experimentalAsyncAwait ? [
-                    "-Xfrontend",
-                    "-enable-experimental-concurrency"
-                ] : [])
-            ]
+            swiftSettings: apodiniSwiftSettings
         ),
 
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -12,17 +12,18 @@ import PackageDescription
 let experimentalAsyncAwait = false
 
 var apodiniSwiftSettings: [SwiftSetting] {
-    guard experimentalAsyncAwait else {
+    if experimentalAsyncAwait {
+        return [
+            .unsafeFlags(
+                [
+                    "-Xfrontend",
+                    "-enable-experimental-concurrency"
+                ]
+            )
+        ]
+    } else {
         return []
     }
-    return [
-        .unsafeFlags(
-            [
-                "-Xfrontend",
-                "-enable-experimental-concurrency"
-            ]
-        )
-    ]
 }
 
 

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,10 @@ var apodiniSwiftSettings: [SwiftSetting] {
             )
         ]
     } else {
-        return []
+        return [
+            // We can not pass an empty array to SwiftSetting in Swift 5.3
+            .define("PLACEHOLDER")
+        ]
     }
 }
 


### PR DESCRIPTION
# Allow Apodini to be used with semantic versioning

## :recycle: Current situation
The checkout fails with the error message `The target 'Apodini' in product 'Apodini' contains unsafe build flags` when using Apodini as a dependency using semantic versioning.

## :bulb: Proposed solution
Moves the conditional flags to a top level definition to only use unsafe build flags if `experimentalAsyncAwait` is set to true.

### Problem that is solved
Solves the `The target 'Apodini' in product 'Apodini' contains unsafe build flags` when using Apodini as a dependency using semantic versioning.

### Implications
Allows dependencies to use the version tags without error messages when using the Apodini target.