### PR TITLE
Update Experimental Async/Await Features to not Break Build on Xcode13

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,7 +2,7 @@
   "object": {
     "pins": [
       {
-        "package": "apnswift",
+        "package": "APNSwift",
         "repositoryURL": "https://github.com/kylebrowning/APNSwift.git",
         "state": {
           "branch": null,
@@ -200,7 +200,7 @@
         }
       },
       {
-        "package": "DNSClient",
+        "package": "NioDNS",
         "repositoryURL": "https://github.com/OpenKitten/NioDNS.git",
         "state": {
           "branch": null,

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ import PackageDescription
 /// Configures the Package for usage of the experimental `async`/`await` syntax as introduced by
 /// https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md
 /// When set to `true`, a recent commit from the **main** branch of **swift-nio** is used. Furthermore, the
-/// swift compiler is configured to enable this feature. Swift 5.4 is required for this to work. You may need to reset
+/// swift compiler is configured to enable this feature. Swift 5.5 is required for this to work. You may need to reset
 /// your package caches for this to take effect.
 let experimentalAsyncAwait = false
 
@@ -17,7 +17,8 @@ var apodiniSwiftSettings: [SwiftSetting] {
             .unsafeFlags(
                 [
                     "-Xfrontend",
-                    "-enable-experimental-concurrency"
+                    "-enable-experimental-concurrency",
+                    "-DAPODINI_EXPERIMENTAL_ASYNC_AWAIT"
                 ]
             )
         ]
@@ -85,7 +86,7 @@ let package = Package(
         .package(url: "https://github.com/OpenCombine/OpenCombine.git", .upToNextMinor(from: "0.11.0")),
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
         experimentalAsyncAwait
-                    ? .package(url: "https://github.com/apple/swift-nio.git", .revision("4220c7a16a5ee0abb7da150bd3d4444940a20cc2"))
+                    ? .package(url: "https://github.com/apple/swift-nio.git", .revision("67f084365315b8470cd22eb161d855755b3e2748"))
                     : .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),

--- a/Sources/Apodini/Components/Handler/Handler.swift
+++ b/Sources/Apodini/Components/Handler/Handler.swift
@@ -6,7 +6,7 @@
 //
 
 import NIO
-#if compiler(>=5.4) && $AsyncAwait
+#if compiler(>=5.5) && $APODINI_EXPERIMENTAL_ASYNC_AWAIT
 import _NIOConcurrency
 #endif
 
@@ -18,7 +18,8 @@ public protocol Handler: HandlerMetadataNamespace, Component {
     typealias Metadata = AnyHandlerMetadata
 
     /// A function that is called when a request reaches the `Handler`
-    #if compiler(>=5.4) && $AsyncAwait
+    #if compiler(>=5.5) && $APODINI_EXPERIMENTAL_ASYNC_AWAIT
+    @available(macOS 12, *)
     func handle() async throws -> Response
     #else
     func handle() throws -> Response
@@ -44,7 +45,8 @@ extension Handler {
 // The function hides the syntactic difference between the newly introduced `async`
 // version of `handle()` and the traditional, `EventLoopFuture`-based one.
 extension Handler {
-    #if compiler(>=5.4) && $AsyncAwait
+    #if compiler(>=5.5) && $APODINI_EXPERIMENTAL_ASYNC_AWAIT
+    @available(macOS 12, *)
     internal func evaluate(using eventLoop: EventLoop) -> EventLoopFuture<Response> {
         let promise: EventLoopPromise<Response> = eventLoop.makePromise()
         promise.completeWithAsync(self.handle)


### PR DESCRIPTION
# Update Experimental Async/Await Features to not Break Build on Xcode13

## :recycle: Current situation
As the Xcode 13 beta ships with Swift 5.5 and $AsyncAwait enabled by default, the previous mechanism for disabling experimental async await functionality in Apodini did no longer function when using Xcode13 beta, even with `experimentalAsyncAwait = false`.

## :bulb: Proposed solution

I added a custom compiler-flag `APODINI_EXPERIMENTAL_ASYNC_AWAIT`.

### Problem that is solved

When working with DocC we need Xcode 13, so that should now be possible.

### Implications
Nothing changes for Xcode 12 /  <Swift 5.5 users. For Xcode 13 users the project compiles with `experimentalAsyncAwait = false`. With `experimentalAsyncAwait = true`, the project does not compile, as I could not find a version of swift-nio's _NIOConcurrency that actually compiles with Xcode13.

## :heavy_plus_sign: Additional Information
I also adapted `Handler.swift` so that it should compile with `experimentalAsyncAwait = true` once _NIOConcurrency does.

### Related PRs
#265 introduced the async/await syntax to `Handler`.

### Testing
I did not add any tests. Functionality for Xcode 12 is covered by existing tests and the rest is experimental.
