### PR TITLE
Binary Large Objects

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,7 +2,7 @@
   "object": {
     "pins": [
       {
-        "package": "apnswift",
+        "package": "APNSwift",
         "repositoryURL": "https://github.com/kylebrowning/APNSwift.git",
         "state": {
           "branch": null,
@@ -200,7 +200,7 @@
         }
       },
       {
-        "package": "DNSClient",
+        "package": "NioDNS",
         "repositoryURL": "https://github.com/OpenKitten/NioDNS.git",
         "state": {
           "branch": null,

--- a/Package.swift
+++ b/Package.swift
@@ -122,6 +122,7 @@ let package = Package(
                 .target(name: "ApodiniUtils"),
                 .product(name: "AssociatedTypeRequirementsKit", package: "AssociatedTypeRequirementsKit"),
                 .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "NIOHTTP2", package: "swift-nio-http2"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "Logging", package: "swift-log"),
@@ -264,8 +265,7 @@ let package = Package(
             name: "ApodiniREST",
             dependencies: [
                 .target(name: "Apodini"),
-                .target(name: "ApodiniVaporSupport"),
-                .product(name: "FluentKit", package: "fluent-kit")
+                .target(name: "ApodiniVaporSupport")
             ]
         ),
 

--- a/Sources/Apodini/Application/Application.swift
+++ b/Sources/Apodini/Application/Application.swift
@@ -62,6 +62,22 @@ extension Application {
 
 /// Configuration and state of the application
 public final class Application {
+    private static var latestApplicationLogger: Logger?
+    /// A global loggerr that can be used when no  `Application` instance is available.
+    ///
+    /// - Note: In `Handler`s you shpuld rely on the `Logger` injected in the `@Environment`.
+    public static var logger: Logger {
+        latestApplicationLogger ?? {
+            var newLogger = Logger(label: "Pre-startup")
+            #if DEBUG
+            newLogger.logLevel = .debug
+            #endif
+            latestApplicationLogger = newLogger
+            return newLogger
+        }()
+    }
+    
+    
     /// Decides how EventLoopGroups are created
     public let eventLoopGroupProvider: EventLoopGroupProvider
     /// The EventLoopGroup for the application
@@ -142,10 +158,13 @@ public final class Application {
         }
         self.locks = .init()
         self.didShutdown = false
+        
         self.logger = .init(label: "org.apodini.application")
         #if DEBUG
         self.logger.logLevel = .debug
         #endif
+        Application.latestApplicationLogger = self.logger
+        
         self.storage = .init(logger: self.logger)
         self.lifecycle = .init()
         self.isBooted = false

--- a/Sources/Apodini/Application/Application.swift
+++ b/Sources/Apodini/Application/Application.swift
@@ -63,7 +63,7 @@ extension Application {
 /// Configuration and state of the application
 public final class Application {
     private static var latestApplicationLogger: Logger?
-    /// A global loggerr that can be used when no  `Application` instance is available.
+    /// A global logger that can be used when no  `Application` instance is available.
     ///
     /// - Note: In `Handler`s you shpuld rely on the `Logger` injected in the `@Environment`.
     public static var logger: Logger {

--- a/Sources/Apodini/Response/Blob.swift
+++ b/Sources/Apodini/Response/Blob.swift
@@ -28,8 +28,7 @@ public struct Blob: Encodable, ResponseTransformable {
     ///   - data: The `Data` representation of the `Blob`
     ///   - type: The MIME type associated with the `Blob`
     public init(_ data: Data, type: MimeType? = nil) {
-        self.byteBuffer = ByteBuffer(data: data)
-        self.type = type
+        self.init(ByteBuffer(data: data), type: type)
     }
     
     
@@ -43,7 +42,7 @@ public struct Blob: Encodable, ResponseTransformable {
     
     
     public func encode(to encoder: Encoder) throws {
-        print(
+        Application.logger.debug(
             """
             Information: The used Exporter currently doesn't support Blob's as a content of an Apodini Reponse.
             The data and mime type will be encoded according to the data encoding strategy passed by the Encoder.

--- a/Sources/Apodini/Response/Blob.swift
+++ b/Sources/Apodini/Response/Blob.swift
@@ -1,0 +1,57 @@
+//
+//  Blob.swift
+//  
+//
+//  Created by Paul Schmiedmayer on 5/26/21.
+//
+
+import NIO
+import Foundation
+import NIOFoundationCompat
+
+
+/// A binary large object (blob) that can be used to return binary data from a `Handler`
+public struct Blob: Encodable, ResponseTransformable {
+    enum CodingKeys: String, CodingKey {
+        case byteBuffer
+        case type
+    }
+    
+    
+    /// The `ByteBuffer` representation of the `Blob`
+    public let byteBuffer: ByteBuffer
+    /// The MIME type associated with the `Blob`
+    public let type: MimeType?
+    
+    
+    /// - Parameters:
+    ///   - data: The `Data` representation of the `Blob`
+    ///   - type: The MIME type associated with the `Blob`
+    public init(_ data: Data, type: MimeType? = nil) {
+        self.byteBuffer = ByteBuffer(data: data)
+        self.type = type
+    }
+    
+    
+    /// - Parameters:
+    ///   - byteBuffer: The `ByteBuffer` representation of the `Blob`
+    ///   - type: The MIME type associated with the `Blob`
+    public init(_ byteBuffer: ByteBuffer, type: MimeType? = nil) {
+        self.byteBuffer = byteBuffer
+        self.type = type
+    }
+    
+    
+    public func encode(to encoder: Encoder) throws {
+        print(
+            """
+            Information: The used Exporter currently doesn't support Blob's as a content of an Apodini Reponse.
+            The data and mime type will be encoded according to the data encoding strategy passed by the Encoder.
+            """
+        )
+        
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(byteBuffer.getData(at: byteBuffer.readerIndex, length: byteBuffer.readableBytes), forKey: .byteBuffer)
+        try container.encode(type, forKey: .type)
+    }
+}

--- a/Sources/Apodini/Response/Empty.swift
+++ b/Sources/Apodini/Response/Empty.swift
@@ -1,0 +1,11 @@
+//
+//  Empfy.swift
+//  
+//
+//  Created by Paul Schmiedmayer on 5/26/21.
+//
+
+
+public struct Empty: Encodable {
+    fileprivate init() {}
+}

--- a/Sources/Apodini/Response/MimeType.swift
+++ b/Sources/Apodini/Response/MimeType.swift
@@ -1,0 +1,122 @@
+//
+//  MimeType.swift
+//  
+//
+//  Created by Paul Schmiedmayer on 5/26/21.
+//
+
+
+/// MIME type (Multipurpose Internet Mail Extensions) that expresses the format of a `Blob`
+public enum MimeType: Codable, Equatable {
+    enum CodingKeys: CodingKey {
+        case type
+        case subtype
+        case parameters
+    }
+    
+    /// Text-only data (https://www.iana.org/assignments/media-types/media-types.xhtml#text)
+    public enum TextSubtype: String, Codable, Hashable {
+        case csv
+        case html
+        case plain
+        case css
+        case javascript
+        case xml
+        case php
+    }
+    
+    /// Any kind of binary data (https://www.iana.org/assignments/media-types/media-types.xhtml#application)
+    public enum ApplicationSubtype: String, Codable, Hashable {
+        case pdf
+        case zip
+        case json
+        case octetstream = "octet-stream"
+        case graphql
+        case sql
+        case xml
+    }
+    
+    /// Any kind of image data (https://www.iana.org/assignments/media-types/media-types.xhtml#image)
+    public enum ImageSubtype: String, Codable, Hashable {
+        case png
+        case jpeg
+        case gif
+        case svg = "svg+html"
+    }
+    
+    case text(TextSubtype, parameters: [String: String] = [:])
+    case application(ApplicationSubtype, parameters: [String: String] = [:])
+    case image(ImageSubtype, parameters: [String: String] = [:])
+    
+    
+    var type: String {
+        switch self {
+        case .text:
+            return "text"
+        case .application:
+            return "application"
+        case .image:
+            return "image"
+        }
+    }
+    
+    var subtype: String {
+        switch self {
+        case let .text(subtype, _):
+            return subtype.rawValue
+        case let .application(subtype, _):
+            return subtype.rawValue
+        case let .image(subtype, _):
+            return subtype.rawValue
+        }
+    }
+    
+    var parameters: [String: String] {
+        switch self {
+        case let .text(_, parameters):
+            return parameters
+        case let .application(_, parameters):
+            return parameters
+        case let .image(_, parameters):
+            return parameters
+        }
+    }
+    
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "text":
+            self = .text(
+                try container.decode(TextSubtype.self, forKey: .subtype),
+                parameters: try container.decodeIfPresent([String: String].self, forKey: .parameters) ?? [:]
+            )
+        case "application":
+            self = .application(
+                try container.decode(ApplicationSubtype.self, forKey: .subtype),
+                parameters: try container.decodeIfPresent([String: String].self, forKey: .parameters) ?? [:]
+            )
+        case "image":
+            self = .image(
+                try container.decode(ImageSubtype.self, forKey: .subtype),
+                parameters: try container.decodeIfPresent([String: String].self, forKey: .parameters) ?? [:]
+            )
+        default:
+            var codingPath = decoder.codingPath
+            codingPath.append(CodingKeys.type)
+            throw DecodingError.valueNotFound(
+                Status.self,
+                DecodingError.Context(codingPath: codingPath, debugDescription: "Could not find a correct Mime Type, found: \(type)")
+            )
+        }
+    }
+    
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(subtype, forKey: .subtype)
+        try container.encode(parameters, forKey: .parameters)
+    }
+}

--- a/Sources/Apodini/Response/Response.swift
+++ b/Sources/Apodini/Response/Response.swift
@@ -9,11 +9,6 @@ import NIO
 import ApodiniUtils
 
 
-public struct Empty: Encodable {
-    fileprivate init() {}
-}
-
-
 public struct Response<Content: Encodable>: ResponseTransformable {
     public static var nothing: Response<Content> {
         Response<Content>(connectionEffect: .open)

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporterVisitor.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporterVisitor.swift
@@ -74,11 +74,7 @@ private struct StandardStaticExporterVisitableVisitor: StaticExporterVisitableVi
 
 // MARK: AssociatedKit workaround
 
-private struct TestRequest: ExporterRequest {
-    var remoteAddress: SocketAddress? {
-        nil
-    }
-}
+private struct TestRequest: ExporterRequest {}
 
 private struct TestExporter: InterfaceExporter {
     init() {}

--- a/Sources/ApodiniDatabase/Handlers/Update/Updater.swift
+++ b/Sources/ApodiniDatabase/Handlers/Update/Updater.swift
@@ -50,8 +50,7 @@ internal struct Updater<Model: DatabaseModel> {
                 do {
                     try visitable.accept(ConcreteUpdatableFieldPropertyVisitor(updater: value))
                 } catch {
-                    print(error.localizedDescription + "\n" +
-                        "An error occurred while trying to update the property \(visitable) of the model \(model) with the new value \(value)")
+                    Application.logger.error("Trying to update the property \(visitable) of the model \(model) with \(value): \(error.localizedDescription)")
                 }
             }
         }

--- a/Sources/ApodiniOpenAPI/Document/OpenAPIComponentsObjectBuilder.swift
+++ b/Sources/ApodiniOpenAPI/Document/OpenAPIComponentsObjectBuilder.swift
@@ -45,18 +45,22 @@ class OpenAPIComponentsObjectBuilder {
     /// Therefore `ResponseContainer`'s CodingKeys are reused.
     /// The resulting JSONSchema is stored in the componentsObject.
     func buildResponse(for type: Encodable.Type) throws -> JSONSchema {
-        let (schema, title) = try buildSchemaWithTitle(for: type)
-        let schemaName = "\(title)Response"
-        let schemaObject: JSONSchema = .object(
-            title: schemaName,
-            properties: [
-                ResponseContainer.CodingKeys.data.rawValue: schema,
-                ResponseContainer.CodingKeys.links.rawValue: try buildSchema(for: ResponseContainer.Links.self)
-            ])
-        if !schemaExists(for: schemaName) {
-            saveSchema(name: schemaName, schema: schemaObject)
+        if type == Blob.self {
+            return .string(format: .binary, required: true)
+        } else {
+            let (schema, title) = try buildSchemaWithTitle(for: type)
+            let schemaName = "\(title)Response"
+            let schemaObject: JSONSchema = .object(
+                title: schemaName,
+                properties: [
+                    ResponseContainer.CodingKeys.data.rawValue: schema,
+                    ResponseContainer.CodingKeys.links.rawValue: try buildSchema(for: ResponseContainer.Links.self)
+                ])
+            if !schemaExists(for: schemaName) {
+                saveSchema(name: schemaName, schema: schemaObject)
+            }
+            return .reference(.component(named: schemaName))
         }
-        return .reference(.component(named: schemaName))
     }
 
     /// In case there is more than one type in HTTP body, a wrapper schema needs to be built.

--- a/Sources/ApodiniREST/RESTEndpointHandler.swift
+++ b/Sources/ApodiniREST/RESTEndpointHandler.swift
@@ -7,6 +7,7 @@ import Apodini
 import ApodiniVaporSupport
 import Vapor
 
+
 struct RESTEndpointHandler<H: Handler> {
     let configuration: RESTConfiguration
     let endpoint: Endpoint<H>
@@ -36,6 +37,17 @@ struct RESTEndpointHandler<H: Handler> {
             guard let enrichedContent = response.content else {
                 return ResponseContainer(Empty.self, status: response.status)
                     .encodeResponse(for: request)
+            }
+            
+            if let blob = response.content?.response.typed(Blob.self) {
+                let vaporResponse = Vapor.Response()
+                
+                if let status = response.status {
+                    vaporResponse.status = HTTPStatus(status)
+                }
+                vaporResponse.body = Vapor.Response.Body(buffer: blob.byteBuffer)
+                
+                return request.eventLoop.makeSucceededFuture(vaporResponse)
             }
             
             let formatter = LinksFormatter(configuration: self.configuration)

--- a/Sources/ApodiniREST/ResponseContainer.swift
+++ b/Sources/ApodiniREST/ResponseContainer.swift
@@ -53,7 +53,7 @@ struct ResponseContainer: Encodable, ResponseEncodable {
             // If there is any content in the HTTP body (data or links) we must not return an status code .noContent
             response.status = .ok
         case let .some(status):
-            response.status = httpStatusCode(fromStatus: status)
+            response.status = HTTPStatus(status)
         default:
             if containsNoContent {
                 response.status = .noContent
@@ -70,16 +70,5 @@ struct ResponseContainer: Encodable, ResponseEncodable {
             return request.eventLoop.makeFailedFuture(error)
         }
         return request.eventLoop.makeSucceededFuture(response)
-    }
-    
-    private func httpStatusCode(fromStatus status: Status) -> HTTPStatus {
-        switch status {
-        case .ok:
-            return HTTPStatus.ok
-        case .created:
-            return HTTPStatus.created
-        case .noContent:
-            return HTTPStatus.noContent
-        }
     }
 }

--- a/Sources/ApodiniVaporSupport/Application+Vapor.swift
+++ b/Sources/ApodiniVaporSupport/Application+Vapor.swift
@@ -8,6 +8,7 @@
 import Apodini
 import Vapor
 
+
 extension Vapor.Application {
     struct LifecycleHandlery: Apodini.LifecycleHandler {
         var app: Vapor.Application

--- a/Sources/ApodiniVaporSupport/HTTPStatus+Status.swift
+++ b/Sources/ApodiniVaporSupport/HTTPStatus+Status.swift
@@ -1,24 +1,15 @@
 //
-//  File.swift
-//  
+//  HTTPStatus+Status.swift
 //
-//  Created by Paul Schmiedmayer on 6/16/21.
+//
+//  Created by Paul Schmiedmayer on 5/26/21.
 //
 
-import Foundation
-
-//
- //  HTTPStatus+Status.swift
- //
- //
- //  Created by Paul Schmiedmayer on 5/26/21.
- //
-
- import Apodini
- import Vapor
+import Apodini
+import Vapor
 
 
- extension Vapor.HTTPStatus {
+extension Vapor.HTTPStatus {
     /// Creates a `Vapor``HTTPStatus` based on an `Apodini` `Status`.
     /// - Parameter status: The `Apodini` `Status` that should be transformed in a `Vapor``HTTPStatus`
     public init(_ status: Apodini.Status) {

--- a/Sources/ApodiniVaporSupport/HTTPStatus+Status.swift
+++ b/Sources/ApodiniVaporSupport/HTTPStatus+Status.swift
@@ -1,0 +1,34 @@
+//
+//  File.swift
+//  
+//
+//  Created by Paul Schmiedmayer on 6/16/21.
+//
+
+import Foundation
+
+//
+ //  HTTPStatus+Status.swift
+ //
+ //
+ //  Created by Paul Schmiedmayer on 5/26/21.
+ //
+
+ import Apodini
+ import Vapor
+
+
+ extension Vapor.HTTPStatus {
+    /// Creates a `Vapor``HTTPStatus` based on an `Apodini` `Status`.
+    /// - Parameter status: The `Apodini` `Status` that should be transformed in a `Vapor``HTTPStatus`
+    public init(_ status: Apodini.Status) {
+        switch status {
+        case .ok:
+            self = .ok
+        case .created:
+            self = .created
+        case .noContent:
+            self = .noContent
+        }
+    }
+}

--- a/Sources/XCTApodini/Mocks/MockExporter.swift
+++ b/Sources/XCTApodini/Mocks/MockExporter.swift
@@ -56,7 +56,7 @@ open class MockExporter<Request: ExporterRequest>: InterfaceExporter {
 
     public func retrieveParameter<Type: Decodable>(_ parameter: EndpointParameter<Type>, for request: Request) throws -> Type?? {
         guard let first = parameterValues.first else {
-            print("WARN: MockExporter failed to retrieve next parameter for '\(parameter.description)'. Queue is empty")
+            Apodini.Application.logger.warning("MockExporter failed to retrieve next parameter for '\(parameter.description)'. Queue is empty")
             return nil // non existence
         }
         parameterValues.removeFirst()

--- a/Sources/XCTApodini/XCTAssertRuntimeFailure.swift
+++ b/Sources/XCTApodini/XCTAssertRuntimeFailure.swift
@@ -29,6 +29,6 @@ public func XCTAssertRuntimeFailure<T>(
     file: StaticString = #filePath,
     line: UInt = #line) {
     // Empty implementation for Linux Tests
-    print("[NOTICE] XCTAssertRuntimeFailure unsupported on platform!")
+    print("[NOTICE] XCTAssertRuntimeFailure unsupported on this platform!")
 }
 #endif

--- a/Tests/ApodiniTests/ApplicationTests/ApplicationTests.swift
+++ b/Tests/ApodiniTests/ApplicationTests/ApplicationTests.swift
@@ -1,0 +1,20 @@
+//
+//  ApplicationTests.swift
+//  
+//
+//  Created by Paul Schmiedmayer on 6/17/21.
+//
+
+import XCTest
+import Apodini
+
+
+class ApplicationTests: XCTestCase {
+    func testLogger() {
+        let logger = Application.logger
+        #if DEBUG
+        XCTAssertEqual(logger.logLevel, .debug)
+        #endif
+        logger.debug("ApplicationTests complete")
+    }
+}

--- a/Tests/ApodiniTests/Helper/Blob+Equatable.swift
+++ b/Tests/ApodiniTests/Helper/Blob+Equatable.swift
@@ -1,0 +1,15 @@
+//
+//  Blob+Equatable.swift
+//  
+//
+//  Created by Paul Schmiedmayer on 6/16/21.
+//
+
+import Apodini
+
+
+extension Blob: Equatable {
+    public static func == (lhs: Blob, rhs: Blob) -> Bool {
+        lhs.byteBuffer == rhs.byteBuffer && lhs.type == rhs.type
+    }
+}

--- a/Tests/ApodiniTests/ResponseTests/BlobTests.swift
+++ b/Tests/ApodiniTests/ResponseTests/BlobTests.swift
@@ -1,0 +1,102 @@
+//
+//  File.swift
+//  
+//
+//  Created by Paul Schmiedmayer on 6/16/21.
+//
+
+import XCTApodini
+import ApodiniREST
+@testable import Apodini
+@testable import ApodiniOpenAPI
+import Vapor
+
+
+final class BlobTests: ApodiniTests {
+    func testBlobResponseHandler() throws {
+        struct BlobResponseHandler: Handler {
+            @Parameter var mimeType: MimeType
+            
+            func handle() -> Blob {
+                Blob(Data(), type: mimeType)
+            }
+        }
+        
+        let handler = BlobResponseHandler().inject(app: app)
+        let endpoint = handler.mockEndpoint()
+
+        let mimeTypes = [
+            MimeType.text(.html, parameters: ["Test": "Test"]),
+            MimeType.application(.json),
+            MimeType.image(.gif)
+        ]
+        
+        let exporter = MockExporter<String>(queued: mimeTypes[0], mimeTypes[1], mimeTypes[2])
+        let context = endpoint.createConnectionContext(for: exporter)
+
+        try XCTCheckResponse(
+            context.handle(request: "", eventLoop: app.eventLoopGroup.next()),
+            content: Blob(Data(), type: mimeTypes[0]),
+            connectionEffect: .close
+        )
+        
+        try XCTCheckResponse(
+            context.handle(request: "", eventLoop: app.eventLoopGroup.next()),
+            content: Blob(Data(), type: mimeTypes[1]),
+            connectionEffect: .close
+        )
+        
+        try XCTCheckResponse(
+            context.handle(request: "", eventLoop: app.eventLoopGroup.next()),
+            content: Blob(Data(), type: mimeTypes[2]),
+            connectionEffect: .close
+        )
+    }
+    
+    func testBlobResponseHandlerWithRESTExporter() throws {
+        struct BlobResponseHandler: Handler {
+            @Parameter var name: String
+            @Parameter var mimeType: MimeType
+            
+            func handle() -> Blob {
+                Blob(Data(name.utf8), type: mimeType)
+            }
+        }
+        
+        let handler = BlobResponseHandler()
+        let endpoint = handler.mockEndpoint(app: app)
+        
+        let exporter = RESTInterfaceExporter(app)
+        let context = endpoint.createConnectionContext(for: exporter)
+        
+        
+        func makeRequest(blobContent: String, mimeType: MimeType) throws {
+            let firstRequest = Vapor.Request(
+                application: app.vapor.app,
+                method: .GET,
+                url: URI("https://ase.in.tum.de/schmiedmayer?name=\(blobContent)"),
+                collectedBody: ByteBuffer(data: try JSONEncoder().encode(mimeType)),
+                on: app.eventLoopGroup.next()
+            )
+            
+            let blob = try XCTUnwrap(
+                try context.handle(request: firstRequest)
+                    .wait()
+                    .typed(Blob.self)?
+                    .content
+            )
+                
+            XCTAssertEqual(blob.byteBuffer.getString(at: blob.byteBuffer.readerIndex, length: blob.byteBuffer.readableBytes), blobContent)
+            XCTAssertEqual(blob.type, mimeType)
+        }
+
+        try makeRequest(blobContent: "Nadine", mimeType: .application(.json))
+        try makeRequest(blobContent: "Paul", mimeType: .text(.plain, parameters: ["User": "Paul"]))
+        try makeRequest(blobContent: "Bernd", mimeType: .image(.gif))
+    }
+    
+    func testBlobResponseHandlerWithOpenAPIExporter() throws {
+        let blobSchema = try OpenAPIComponentsObjectBuilder().buildResponse(for: Blob.self)
+        XCTAssertEqual(.string(format: .binary, required: true), blobSchema)
+    }
+}

--- a/Tests/ApodiniTests/ResponseTests/BlobTests.swift
+++ b/Tests/ApodiniTests/ResponseTests/BlobTests.swift
@@ -58,8 +58,8 @@ final class BlobTests: ApodiniTests {
             @Parameter var name: String
             @Parameter var mimeType: MimeType
             
-            func handle() -> Blob {
-                Blob(Data(name.utf8), type: mimeType)
+            func handle() -> Apodini.Response<Blob> {
+                .send(Blob(Data(name.utf8), type: mimeType), status: .ok)
             }
         }
         
@@ -117,5 +117,39 @@ final class BlobTests: ApodiniTests {
             }
             """
         )
+    }
+    
+    func testMIMEDecoding() throws {
+        let validMIMEJSON =
+            """
+            {
+              "type" : "text",
+              "subtype" : "plain",
+              "parameters" : {
+            
+              }
+            }
+            """
+        
+        let decoder = JSONDecoder()
+        let mimeType = try XCTUnwrap(decoder.decode(MimeType.self, from: Data(validMIMEJSON.utf8)))
+        
+        XCTAssertEqual(mimeType.type, "text")
+        XCTAssertEqual(mimeType.subtype, "plain")
+        XCTAssertTrue(mimeType.parameters.isEmpty)
+        
+        
+        let inValidMIMEJSON =
+            """
+            {
+              "type" : "myFancyType",
+              "subtype" : "plain",
+              "parameters" : {
+            
+              }
+            }
+            """
+        
+        try XCTAssertThrowsError(decoder.decode(MimeType.self, from: Data(inValidMIMEJSON.utf8)))
     }
 }

--- a/Tests/ApodiniTests/ResponseTests/BlobTests.swift
+++ b/Tests/ApodiniTests/ResponseTests/BlobTests.swift
@@ -102,21 +102,9 @@ final class BlobTests: ApodiniTests {
         encoder.outputFormatting = .prettyPrinted
         let encodedBlob = try XCTUnwrap(String(data: try encoder.encode(blob), encoding: .utf8))
         
-        XCTAssertEqual(
-            encodedBlob,
-            """
-            {
-              "type" : {
-                "type" : "text",
-                "subtype" : "plain",
-                "parameters" : {
-            
-                }
-              },
-              "byteBuffer" : "UGF1bA=="
-            }
-            """
-        )
+        XCTAssert(encodedBlob.contains(#""byteBuffer" : "UGF1bA==""#))
+        XCTAssert(encodedBlob.contains(#""type" : "text""#))
+        XCTAssert(encodedBlob.contains(#""subtype" : "plain""#))
     }
     
     func testMIMEDecoding() throws {


### PR DESCRIPTION
# Binary Large Objects

## :recycle: Current situation

An Apodini web service can currently not return a **b**inary **l**arge **ob**ject (**blob**) directly. Use cases for this would be to return an HTML page that is displayed in a browser, offer `Handler`s that return files or return images from a `Handler`.
Apodini needs a convenient way to return these blobs from a `Handler` and attach e.g. a MIME type to the blob so it can be correctly interpreted by a client.

## :bulb: Proposed solution

This pull request introduces a `Blob` type that allows a developer to return a `blob` including a MIME type.
The PR includes a common set of MIME types as listed on https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types .

### Implications

The `Blob` is an additive change. It has implications on the existing and future exporters. In addition to handling the special `Empty` type exporters should now also consider handling the `Blob` type. The `Blob` type includes a default `Encodable` implementation that enables Exporters that don't include code to specially handle the `Blob` type to continue working.

## :heavy_plus_sign: Additional Information

### Related Packages
Can be used by the new [ApodiniLeaf](https://github.com/Apodini/ApodiniLeaf) package. 

### Testing
Includes test to cover responses including a `Blob` and testing the RESTExporter as well as the OpenAPI Exporter

## 🛠 Migration Guide

Binary Large Objects (`Blob`) allow you to return binary files from a `Handler` that are not encoded by exporters. This can be used to return files or return already encoded files or binary data such as HTML pages or any other content that should be displayed by a browser. A `Blob` can be initialized using a `Data` or `ByteBuffer` instance as well as a `MimeType` that indicates the file type expressed with the `Blob`.

The following example shows a `Handler` that returns a `Blob`:
```swift
struct BlobResponseHandler: Handler {
    func handle() -> Blob {
        let data: Data = // ...
        let mimeType: MimeType = .image(.gif)
        return Blob(data, type: mimeType)
    }
}
```
You can get an overview of all `MimeTypes` that are implemented in Apodini in [MimeType.swift](https://github.com/Apodini/Apodini/blob/develop/Sources/Apodini/Response/MimeType.swift)