### PR TITLE
Use the ApodiniBot to perform the Swift Package Update

### DIFF
--- a/.github/workflows/spm-update.yml
+++ b/.github/workflows/spm-update.yml
@@ -27,6 +27,7 @@ jobs:
         delete-branch: true
         base: develop
         branch: bots/update-dependencies
-        assignees: PSchmiedmayer
-        committer: PSchmiedmayer <PSchmiedmayer@users.noreply.github.com>
-        author: PSchmiedmayer <PSchmiedmayer@users.noreply.github.com>
+        assignees: ApodiniBot
+        committer: ApodiniBot <ApodiniBot@users.noreply.github.com>
+        author: ApodiniBot <ApodiniBot@users.noreply.github.com>
+        reviewers: PSchmiedmayer


### PR DESCRIPTION
# Use the ApodiniBot to perform the Swift Package Update

## :recycle: Current situation
Currently an access token by @PSchmiedmayer powers the Swift Package Update workflow.

## :bulb: Proposed solution & Implications
This has been changed to the @ApodiniBot user. No implications for the main project.