### PR TITLE
Update fluent version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.45.0"),
-        .package(url: "https://github.com/vapor/fluent.git", from: "4.3.0"),
+        .package(url: "https://github.com/vapor/fluent.git", from: "4.3.1"),
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.13.0"),
         .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.1.0"),
         // Used by the `NotificationCenter` to send push notifications to `APNS`.


### PR DESCRIPTION
# Update fluent version

## :recycle: Current situation & Problem
With fluent 4.3.0 I get the error "'Content' requires that 'T' conform to 'Encodable'" in fluent > Sources > Fluent > Fluent+Paginate.swift:16 when trying to build my Apodini project. With fluent version 4.3.1, it works just fine. It seems to be an error within fluent.

## :bulb: Proposed solution
Update the required fluent version to 4.3.1

### Reviewer Nudging
Package.swift
