### PR TITLE
Codable Based Traversal

### DIFF
--- a/Sources/Apodini/Components/Component/AnyComponent.swift
+++ b/Sources/Apodini/Components/Component/AnyComponent.swift
@@ -21,7 +21,7 @@ public struct AnyComponent: Component, SyntaxTreeVisitable {
 }
 
 
-public struct AnyHandler: Handler, SyntaxTreeVisitable, VisitableHandler {
+public struct AnyHandler: _Handler, SyntaxTreeVisitable, VisitableHandler {
     public typealias Response = Never
     
     private let _accept: (SyntaxTreeVisitor) -> Void

--- a/Sources/Apodini/Components/Component/AnyComponent.swift
+++ b/Sources/Apodini/Components/Component/AnyComponent.swift
@@ -21,7 +21,7 @@ public struct AnyComponent: Component, SyntaxTreeVisitable {
 }
 
 
-public struct AnyHandler: _Handler, SyntaxTreeVisitable, VisitableHandler {
+public struct AnyHandler: HandlerDefiningComponent, SyntaxTreeVisitable, VisitableHandler {
     public typealias Response = Never
     
     private let _accept: (SyntaxTreeVisitor) -> Void

--- a/Sources/Apodini/Components/Handler/BaseHandler/Text.swift
+++ b/Sources/Apodini/Components/Handler/BaseHandler/Text.swift
@@ -6,10 +6,10 @@
 //
 
 public struct Text: Handler {
-    private let text: String
+    @Binding private var text: String
     
     public init(_ text: String) {
-        self.text = text
+        self._text = .constant(text)
     }
     
     public func handle() -> String {

--- a/Sources/Apodini/Components/Handler/Handler.swift
+++ b/Sources/Apodini/Components/Handler/Handler.swift
@@ -7,10 +7,10 @@
 
 import NIO
 
-public protocol Handler: PropertyIterable, _Handler { }
+public protocol Handler: PropertyIterable, HandlerDefiningComponent { }
 
-/// A `Handler` is a `Component` which defines an endpoint and can handle requests.
-public protocol _Handler: HandlerMetadataNamespace, Component {
+/// A `HandlerDefiningComponent` is a `Component` which defines an endpoint and knows a `Handler` that can handle requests.
+public protocol HandlerDefiningComponent: HandlerMetadataNamespace, Component {
     /// The type that is returned from the `handle()` method when the component handles a request. The return type of the `handle` method is encoded into the response send out to the client.
     associatedtype Response: ResponseTransformable
 
@@ -21,14 +21,14 @@ public protocol _Handler: HandlerMetadataNamespace, Component {
 }
 
 // MARK: Metadata DSL
-public extension _Handler {
+public extension HandlerDefiningComponent {
     /// Handlers have an empty `AnyHandlerMetadata` by default.
     var metadata: AnyHandlerMetadata {
         Empty()
     }
 }
 
-extension _Handler {
+extension HandlerDefiningComponent {
     /// By default, `Handler`s don't provide any further content
     public var content: some Component {
         EmptyComponent()

--- a/Sources/Apodini/Components/Handler/Handler.swift
+++ b/Sources/Apodini/Components/Handler/Handler.swift
@@ -7,8 +7,10 @@
 
 import NIO
 
+public protocol Handler: PropertyIterable, _Handler { }
+
 /// A `Handler` is a `Component` which defines an endpoint and can handle requests.
-public protocol Handler: HandlerMetadataNamespace, Component {
+public protocol _Handler: HandlerMetadataNamespace, Component {
     /// The type that is returned from the `handle()` method when the component handles a request. The return type of the `handle` method is encoded into the response send out to the client.
     associatedtype Response: ResponseTransformable
 
@@ -19,14 +21,14 @@ public protocol Handler: HandlerMetadataNamespace, Component {
 }
 
 // MARK: Metadata DSL
-public extension Handler {
+public extension _Handler {
     /// Handlers have an empty `AnyHandlerMetadata` by default.
     var metadata: AnyHandlerMetadata {
         Empty()
     }
 }
 
-extension Handler {
+extension _Handler {
     /// By default, `Handler`s don't provide any further content
     public var content: some Component {
         EmptyComponent()

--- a/Sources/Apodini/Components/Handler/IdentifiableHandler.swift
+++ b/Sources/Apodini/Components/Handler/IdentifiableHandler.swift
@@ -22,7 +22,7 @@ struct ExplicitHandlerIdentifierContextKey: Apodini.OptionalContextKey {
 }
 
 
-public struct ExplicitlyIdentifiedHandlerModifier<Content: _Handler>: HandlerModifier {
+public struct ExplicitlyIdentifiedHandlerModifier<Content: HandlerDefiningComponent>: HandlerModifier {
     public let component: Content
     let identifier: AnyHandlerIdentifier
 
@@ -32,7 +32,7 @@ public struct ExplicitlyIdentifiedHandlerModifier<Content: _Handler>: HandlerMod
 }
 
 
-extension _Handler {
+extension HandlerDefiningComponent {
     /// Attach an identifier to this handler
     public func identified(by identifier: String) -> ExplicitlyIdentifiedHandlerModifier<Self> {
         ExplicitlyIdentifiedHandlerModifier(component: self, identifier: AnyHandlerIdentifier(identifier))

--- a/Sources/Apodini/Components/Handler/IdentifiableHandler.swift
+++ b/Sources/Apodini/Components/Handler/IdentifiableHandler.swift
@@ -22,7 +22,7 @@ struct ExplicitHandlerIdentifierContextKey: Apodini.OptionalContextKey {
 }
 
 
-public struct ExplicitlyIdentifiedHandlerModifier<Content: Handler>: HandlerModifier {
+public struct ExplicitlyIdentifiedHandlerModifier<Content: _Handler>: HandlerModifier {
     public let component: Content
     let identifier: AnyHandlerIdentifier
 
@@ -32,7 +32,7 @@ public struct ExplicitlyIdentifiedHandlerModifier<Content: Handler>: HandlerModi
 }
 
 
-extension Handler {
+extension _Handler {
     /// Attach an identifier to this handler
     public func identified(by identifier: String) -> ExplicitlyIdentifiedHandlerModifier<Self> {
         ExplicitlyIdentifiedHandlerModifier(component: self, identifier: AnyHandlerIdentifier(identifier))

--- a/Sources/Apodini/Components/Handler/PropertyIterable.swift
+++ b/Sources/Apodini/Components/Handler/PropertyIterable.swift
@@ -1,0 +1,19 @@
+//
+//  PropertyIterable.swift
+//  
+//
+//  Created by Max Obermeier on 09.07.21.
+//
+
+import Foundation
+
+/// The children and recursive children of an `PropertyIterable` element can be
+/// accessed by Apodini in a performant manner without usage of runtime reflection.
+///
+/// A `PropertyIterable` object may only have Apodini-defined `Property`s,
+/// `DynamicProperty`s or `Properties` as its children. The same restriction applies
+/// to its recursive children nested inside `DynamicProperty`s or `Properties`.
+public protocol PropertyIterable: Codable { }
+
+
+public protocol PIHandler: Handler, PropertyIterable { }

--- a/Sources/Apodini/Components/Handler/PropertyIterable.swift
+++ b/Sources/Apodini/Components/Handler/PropertyIterable.swift
@@ -11,9 +11,6 @@ import Foundation
 /// accessed by Apodini in a performant manner without usage of runtime reflection.
 ///
 /// A `PropertyIterable` object may only have Apodini-defined `Property`s,
-/// `DynamicProperty`s or `Properties` as its children. The same restriction applies
-/// to its recursive children nested inside `DynamicProperty`s or `Properties`.
+/// as its children. The same restriction applies to any recursive children nested inside
+/// a `DynamicProperty` or `Properties` element.
 public protocol PropertyIterable: Codable { }
-
-
-public protocol PIHandler: Handler, PropertyIterable { }

--- a/Sources/Apodini/Components/Handler/PropertyIterable.swift
+++ b/Sources/Apodini/Components/Handler/PropertyIterable.swift
@@ -13,4 +13,6 @@ import Foundation
 /// A `PropertyIterable` object may only have Apodini-defined `Property`s,
 /// as its children. The same restriction applies to any recursive children nested inside
 /// a `DynamicProperty` or `Properties` element.
+///
+/// - Warning: Only `struct`s can be `PropertyIterable`!
 public protocol PropertyIterable: Codable { }

--- a/Sources/Apodini/Components/Handler/PropertyIterable.swift
+++ b/Sources/Apodini/Components/Handler/PropertyIterable.swift
@@ -11,8 +11,8 @@ import Foundation
 /// accessed by Apodini in a performant manner without usage of runtime reflection.
 ///
 /// A `PropertyIterable` object may only have Apodini-defined `Property`s,
-/// as its children. The same restriction applies to any recursive children nested inside
-/// a `DynamicProperty` or `Properties` element.
+/// or `Delegate` as its children. The same restriction applies to any recursive children
+/// nested inside a `DynamicProperty` or `Properties` element.
 ///
 /// - Warning: Only `struct`s can be `PropertyIterable`!
 public protocol PropertyIterable: Codable { }

--- a/Sources/Apodini/Components/NeverExtensions/Handler+Never.swift
+++ b/Sources/Apodini/Components/NeverExtensions/Handler+Never.swift
@@ -22,7 +22,7 @@ extension Never: ResponseTransformable {
     }
 }
 
-extension Handler where Response == Never {
+extension _Handler where Response == Never {
     /// Default implementation which will simply crash
     public func handle() -> Self.Response {
         fatalError("'\(Self.self).\(#function)' is not implemented because 'Self.Response' is set to '\(Self.Response.self)'")
@@ -36,7 +36,7 @@ extension _EmptyComponentCustomNeverImpl: ResponseTransformable {
     }
 }
 
-extension Handler where Response == _EmptyComponentCustomNeverImpl {
+extension _Handler where Response == _EmptyComponentCustomNeverImpl {
     /// Default implementation which will simply crash
     public func handle() -> Self.Response {
         fatalError("'\(Self.self).\(#function)' is not implemented because 'Self.Response' is set to '\(Self.Response.self)'")

--- a/Sources/Apodini/Components/NeverExtensions/Handler+Never.swift
+++ b/Sources/Apodini/Components/NeverExtensions/Handler+Never.swift
@@ -22,7 +22,7 @@ extension Never: ResponseTransformable {
     }
 }
 
-extension _Handler where Response == Never {
+extension HandlerDefiningComponent where Response == Never {
     /// Default implementation which will simply crash
     public func handle() -> Self.Response {
         fatalError("'\(Self.self).\(#function)' is not implemented because 'Self.Response' is set to '\(Self.Response.self)'")
@@ -36,7 +36,7 @@ extension _EmptyComponentCustomNeverImpl: ResponseTransformable {
     }
 }
 
-extension _Handler where Response == _EmptyComponentCustomNeverImpl {
+extension HandlerDefiningComponent where Response == _EmptyComponentCustomNeverImpl {
     /// Default implementation which will simply crash
     public func handle() -> Self.Response {
         fatalError("'\(Self.self).\(#function)' is not implemented because 'Self.Response' is set to '\(Self.Response.self)'")

--- a/Sources/Apodini/Metadata/BuiltinMetadata/CommunicationalPatternMetadata.swift
+++ b/Sources/Apodini/Metadata/BuiltinMetadata/CommunicationalPatternMetadata.swift
@@ -64,7 +64,7 @@ public struct CommunicationalPatternMetadata: HandlerMetadataDefinition {
     }
 }
 
-extension Handler {
+extension HandlerDefiningComponent {
     /// A `pattern` Modifier can be used to specify the ``CommunicationalPatternMetadata`` via a ``HandlerModifier``.
     /// - Parameter value: The communicational pattern of the associated ``Handler``.
     /// - Returns: The modified `Handler` with the `CommunicationalPatternMetadata` added.

--- a/Sources/Apodini/Metadata/BuiltinMetadata/DescriptionMetadata.swift
+++ b/Sources/Apodini/Metadata/BuiltinMetadata/DescriptionMetadata.swift
@@ -74,7 +74,7 @@ extension Component {
     }
 }
 
-extension Handler {
+extension HandlerDefiningComponent {
     /// A `description` Modifier can be used to specify the `DescriptionMetadata` via a `HandlerModifier`.
     /// - Parameter description: The `description` that is used to for the `Handler`.
     /// - Returns: The modified `Handler` with the `DescriptionMetadata` added.

--- a/Sources/Apodini/Metadata/BuiltinMetadata/OperationMetadata.swift
+++ b/Sources/Apodini/Metadata/BuiltinMetadata/OperationMetadata.swift
@@ -53,7 +53,7 @@ public struct OperationHandlerMetadata: HandlerMetadataDefinition {
     }
 }
 
-extension _Handler {
+extension HandlerDefiningComponent {
     /// A `Handler.operation(...)` modifier can be used to explicitly specify the `Operation` Metadata for the given `Handler`
     /// - Parameter operation: The `Operation` that is used to for the handler
     /// - Returns: The modified `Handler` with a specified `Operation`

--- a/Sources/Apodini/Metadata/BuiltinMetadata/OperationMetadata.swift
+++ b/Sources/Apodini/Metadata/BuiltinMetadata/OperationMetadata.swift
@@ -53,7 +53,7 @@ public struct OperationHandlerMetadata: HandlerMetadataDefinition {
     }
 }
 
-extension Handler {
+extension _Handler {
     /// A `Handler.operation(...)` modifier can be used to explicitly specify the `Operation` Metadata for the given `Handler`
     /// - Parameter operation: The `Operation` that is used to for the handler
     /// - Returns: The modified `Handler` with a specified `Operation`

--- a/Sources/Apodini/Metadata/BuiltinMetadata/ServiceTypeMetadata.swift
+++ b/Sources/Apodini/Metadata/BuiltinMetadata/ServiceTypeMetadata.swift
@@ -52,7 +52,7 @@ public struct ServiceTypeHandlerMetadata: HandlerMetadataDefinition {
     }
 }
 
-extension Handler {
+extension HandlerDefiningComponent {
     /// A `Handler.serviceType(...)` modifier can be used to explicitly specify the `ServiceType` Metadata for the given `Handler`,
     /// setting the name of the gRPC service exposed.
     /// - Parameter serviceType: The `ServiceType` that is applied to the Handler

--- a/Sources/Apodini/Metadata/Modifier/HandlerMetadataModifier.swift
+++ b/Sources/Apodini/Metadata/Modifier/HandlerMetadataModifier.swift
@@ -3,16 +3,16 @@
 //
 
 /// The `HandlerMetadataModifier` can be used to easily add `HandlerMetadataDefinition`
-/// to a `Handler` via a `HandlerModifier`.
+/// to a `HandlerDefiningComponent` via a `HandlerModifier`.
 /// Apodini provides `Handler.metadata(content:)` and `Handler.metadata(...)` as general purpose
 /// Modifiers to add arbitrary Metadata to a `Handler`.
 ///
 /// Furthermore `HandlerMetadataModifier` serves as a build block to easily create a custom
 /// `HandlerModifier` for your `HandlerMetadataDefinition` without much overhead.
-/// In order to create a Modifier declare a `Handler` extension as usual, returning a
+/// In order to create a Modifier declare a `HandlerDefiningComponent` extension as usual, returning a
 /// `HandlerMetadataModifier` instantiated via `HandlerMetadataModifier.init(modifies:with:)`:
 /// ```swift
-/// extension Handler {
+/// extension HandlerDefiningComponent {
 ///     public func myModifier(_ value: ExampleValue) -> HandlerMetadataModifier<Self> {
 ///         HandlerMetadataModifier(modifies: self, with: ExampleHandlerMetadata(value))
 ///     }

--- a/Sources/Apodini/Metadata/Modifier/HandlerMetadataModifier.swift
+++ b/Sources/Apodini/Metadata/Modifier/HandlerMetadataModifier.swift
@@ -18,7 +18,7 @@
 ///     }
 /// }
 /// ```
-public struct HandlerMetadataModifier<H: Handler>: HandlerModifier {
+public struct HandlerMetadataModifier<H: _Handler>: HandlerModifier {
     public let component: H
     // property is not called `metadata` as it would conflict with the Metadata Declaration block
     let handlerMetadata: AnyHandlerMetadata
@@ -38,7 +38,7 @@ public struct HandlerMetadataModifier<H: Handler>: HandlerModifier {
     }
 }
 
-extension Handler {
+extension _Handler {
     /// The `Handler.metadata(content:)` Modifier can be used to apply a Handler Metadata Declaration Block
     /// to the given `Handler`.
     /// - Parameter content: The closure containing the Metadata to be built.

--- a/Sources/Apodini/Metadata/Modifier/HandlerMetadataModifier.swift
+++ b/Sources/Apodini/Metadata/Modifier/HandlerMetadataModifier.swift
@@ -18,7 +18,7 @@
 ///     }
 /// }
 /// ```
-public struct HandlerMetadataModifier<H: _Handler>: HandlerModifier {
+public struct HandlerMetadataModifier<H: HandlerDefiningComponent>: HandlerModifier {
     public let component: H
     // property is not called `metadata` as it would conflict with the Metadata Declaration block
     let handlerMetadata: AnyHandlerMetadata
@@ -38,7 +38,7 @@ public struct HandlerMetadataModifier<H: _Handler>: HandlerModifier {
     }
 }
 
-extension _Handler {
+extension HandlerDefiningComponent {
     /// The `Handler.metadata(content:)` Modifier can be used to apply a Handler Metadata Declaration Block
     /// to the given `Handler`.
     /// - Parameter content: The closure containing the Metadata to be built.

--- a/Sources/Apodini/Modifier/DelegationModifier.swift
+++ b/Sources/Apodini/Modifier/DelegationModifier.swift
@@ -40,7 +40,7 @@ public struct DelegationModifier<C: Component, I: DelegatingHandlerInitializer>:
     }
 }
 
-extension DelegationModifier: HandlerModifier where Self.ModifiedComponent: _Handler {
+extension DelegationModifier: HandlerModifier where Self.ModifiedComponent: HandlerDefiningComponent {
     public typealias Response = I.Response
 }
 

--- a/Sources/Apodini/Modifier/DelegationModifier.swift
+++ b/Sources/Apodini/Modifier/DelegationModifier.swift
@@ -40,7 +40,7 @@ public struct DelegationModifier<C: Component, I: DelegatingHandlerInitializer>:
     }
 }
 
-extension DelegationModifier: HandlerModifier where Self.ModifiedComponent: Handler {
+extension DelegationModifier: HandlerModifier where Self.ModifiedComponent: _Handler {
     public typealias Response = I.Response
 }
 

--- a/Sources/Apodini/Modifier/Guard.swift
+++ b/Sources/Apodini/Modifier/Guard.swift
@@ -43,7 +43,7 @@ extension Component {
     }
 }
 
-extension Handler {
+extension HandlerDefiningComponent {
     /// Use an asynchronous `Guard` to guard a `Handler` by inspecting incoming requests
     /// - Parameter guard: The `Guard` used to inspecting incoming requests
     /// - Returns: Returns a modified `Component` protected by the asynchronous `Guard`

--- a/Sources/Apodini/Modifier/Guard.swift
+++ b/Sources/Apodini/Modifier/Guard.swift
@@ -10,14 +10,14 @@ import NIO
 
 /// A `SyncGuard` can be used to inspect request and guard `Component`s using the check method.
 /// SyncGuard`s can  be used with different request-response property wrappers to inject values from incoming requests.
-public protocol SyncGuard {
+public protocol SyncGuard: PropertyIterable {
     /// The `check` method can be used to inspect incoming requests
     func check() throws
 }
 
 
 /// A `Guard` can be used to inspect request and guard `Component`s using the check method
-public protocol Guard {
+public protocol Guard: PropertyIterable {
     /// The `check` method can be used to inspect incoming requests
     func check() throws -> EventLoopFuture<Void>
 }

--- a/Sources/Apodini/Modifier/Guard.swift
+++ b/Sources/Apodini/Modifier/Guard.swift
@@ -64,8 +64,8 @@ internal struct GuardingHandler<D, G>: Handler where D: Handler, G: Guard {
     let `guard`: Delegate<G>
     
     func handle() throws -> EventLoopFuture<D.Response> {
-        try `guard`().check().flatMapThrowing { _ in
-            try guarded().handle()
+        try `guard`.instance().check().flatMapThrowing { _ in
+            try guarded.instance().handle()
         }
     }
 }
@@ -87,8 +87,8 @@ struct SyncGuardingHandler<D, G>: Handler where D: Handler, G: SyncGuard {
     let `guard`: Delegate<G>
     
     func handle() throws -> D.Response {
-        try `guard`().check()
-        return try guarded().handle()
+        try `guard`.instance().check()
+        return try guarded.instance().handle()
     }
 }
 

--- a/Sources/Apodini/Modifier/Modifier.swift
+++ b/Sources/Apodini/Modifier/Modifier.swift
@@ -22,10 +22,10 @@ public protocol Modifier: Component, SyntaxTreeVisitable {
 
 // Workaround for the "swift conditional conformance does not imply conformance to inherited protocol" compiler error
 /// A modifier which can be invoked on a `Handler` or a `Component`
-public typealias HandlerModifier = HandlerModifierProto & Handler & HandlerMetadataNamespace
+public typealias HandlerModifier = HandlerModifierProto & _Handler & HandlerMetadataNamespace
 
 /// A modifier which can be invoked on a `Handler` or a `Component`
-public protocol HandlerModifierProto: Modifier, Handler where ModifiedComponent: Handler {
+public protocol HandlerModifierProto: Modifier, _Handler where ModifiedComponent: _Handler {
     associatedtype Response = ModifiedComponent.Response
     var component: ModifiedComponent { get }
 }

--- a/Sources/Apodini/Modifier/Modifier.swift
+++ b/Sources/Apodini/Modifier/Modifier.swift
@@ -22,10 +22,10 @@ public protocol Modifier: Component, SyntaxTreeVisitable {
 
 // Workaround for the "swift conditional conformance does not imply conformance to inherited protocol" compiler error
 /// A modifier which can be invoked on a `Handler` or a `Component`
-public typealias HandlerModifier = HandlerModifierProto & _Handler & HandlerMetadataNamespace
+public typealias HandlerModifier = HandlerModifierProto & HandlerDefiningComponent & HandlerMetadataNamespace
 
 /// A modifier which can be invoked on a `Handler` or a `Component`
-public protocol HandlerModifierProto: Modifier, _Handler where ModifiedComponent: _Handler {
+public protocol HandlerModifierProto: Modifier, HandlerDefiningComponent where ModifiedComponent: HandlerDefiningComponent {
     associatedtype Response = ModifiedComponent.Response
     var component: ModifiedComponent { get }
 }

--- a/Sources/Apodini/Modifier/ResponseTransformer.swift
+++ b/Sources/Apodini/Modifier/ResponseTransformer.swift
@@ -27,7 +27,7 @@ public protocol ResponseTransformer {
     func transform(content: Self.InputContent) -> Self.Content
 }
 
-internal struct ResponseTransformingHandler<D, T>: Handler where D: Handler, T: ResponseTransformer, D.Response.Content == T.InputContent {
+internal struct ResponseTransformingHandler<D, T>: Handler where D: Handler, T: ResponseTransformer, D.Response.BodyContent == T.InputContent {
     let transformed: Delegate<D>
     let transformer: Delegate<T>
     
@@ -64,7 +64,7 @@ private struct TransformerCandidate<Transformer: ResponseTransformer, Delegate: 
     let delegate: Delegate
 }
 
-extension TransformerCandidate: Transformable where Transformer.InputContent == Delegate.Response.Content {
+extension TransformerCandidate: Transformable where Transformer.InputContent == Delegate.Response.BodyContent {
     func callAsFunction() -> Any {
         SomeHandler<Response<Transformer.Content>>(ResponseTransformingHandler<Delegate, Transformer>(
                                                     transformed: Apodini.Delegate(delegate),
@@ -82,7 +82,7 @@ extension Handler {
     /// - Returns: The modified `Handler` with a new `ResponseTransformable` type
     public func response<T: ResponseTransformer>(
         _ responseTransformer: T
-    ) -> DelegationModifier<Self, ResponseTransformingHandlerInitializer<T>> where Self.Response.Content == T.InputContent {
+    ) -> DelegationModifier<Self, ResponseTransformingHandlerInitializer<T>> where Self.Response.BodyContent == T.InputContent {
         self.delegated(by: ResponseTransformingHandlerInitializer(transformer: responseTransformer))
     }
 }

--- a/Sources/Apodini/Modifier/ResponseTransformer.swift
+++ b/Sources/Apodini/Modifier/ResponseTransformer.swift
@@ -34,9 +34,9 @@ internal struct ResponseTransformingHandler<D, T>: Handler where D: Handler, T: 
     @Environment(\.connection) var connection
     
     func handle() throws -> EventLoopFuture<Response<T.Content>> {
-        try transformed().handle().transformToResponse(on: connection.eventLoop).flatMapThrowing { responseToTransform in
+        try transformed.instance().handle().transformToResponse(on: connection.eventLoop).flatMapThrowing { responseToTransform in
             try responseToTransform.map { content in
-                try transformer().transform(content: content)
+                try transformer.instance().transform(content: content)
             }
         }
     }

--- a/Sources/Apodini/Modifier/ResponseTransformer.swift
+++ b/Sources/Apodini/Modifier/ResponseTransformer.swift
@@ -14,7 +14,7 @@ import ApodiniUtils
 /// It only maps in the `.send`,  `.finish` and `.automatic` cases.
 /// If the previous Handler or ResponseTransformer returned an `Response.end` or `Response.nothing` it is not called and will not map anything.
 /// Both types (`InputContent` and `Content`) have to conform to `Encodable`
-public protocol ResponseTransformer { // TODO: make PropertyIterable (also for Guard) and make PropertyIterable requirement for usage of Delegate
+public protocol ResponseTransformer: PropertyIterable {
     /// The type that should be transformed
     associatedtype InputContent: Encodable
     /// The type the `ResponseTransformable`  should be transformed to
@@ -76,7 +76,7 @@ private protocol Transformable {
     func callAsFunction() -> Any
 }
 
-extension _Handler {
+extension HandlerDefiningComponent {
     /// A `response` modifier can be used to transform the output of a `Handler`'s response to a different type using a `ResponseTransformer`
     /// - Parameter responseTransformer: The `ResponseTransformer` used to transform the response of a `Handler`
     /// - Returns: The modified `Handler` with a new `ResponseTransformable` type

--- a/Sources/Apodini/Modifier/ResponseTransformer.swift
+++ b/Sources/Apodini/Modifier/ResponseTransformer.swift
@@ -14,7 +14,7 @@ import ApodiniUtils
 /// It only maps in the `.send`,  `.finish` and `.automatic` cases.
 /// If the previous Handler or ResponseTransformer returned an `Response.end` or `Response.nothing` it is not called and will not map anything.
 /// Both types (`InputContent` and `Content`) have to conform to `Encodable`
-public protocol ResponseTransformer {
+public protocol ResponseTransformer { // TODO: make PropertyIterable (also for Guard) and make PropertyIterable requirement for usage of Delegate
     /// The type that should be transformed
     associatedtype InputContent: Encodable
     /// The type the `ResponseTransformable`  should be transformed to
@@ -76,7 +76,7 @@ private protocol Transformable {
     func callAsFunction() -> Any
 }
 
-extension Handler {
+extension _Handler {
     /// A `response` modifier can be used to transform the output of a `Handler`'s response to a different type using a `ResponseTransformer`
     /// - Parameter responseTransformer: The `ResponseTransformer` used to transform the response of a `Handler`
     /// - Returns: The modified `Handler` with a new `ResponseTransformable` type

--- a/Sources/Apodini/Properties/Binding.swift
+++ b/Sources/Apodini/Properties/Binding.swift
@@ -79,6 +79,7 @@ extension Binding.Configuration: Activatable {
 }
 
 extension Binding {
+    /// Persistently override the actual value of this ``Binding`` with the given  `value`.
     func override(with value: Value) {
         guard let box = config.override else {
             fatalError("Binding was overridden before it was activated.")
@@ -106,14 +107,17 @@ extension Binding: PathComponent & _PathComponent where Value: Codable {
 extension Binding {
     private init(constant: Value) {
         store = Properties()
-            .with(Configuration(retriever: { _ in constant}, parameterId: nil), named: "config")
+            .with(Configuration(retriever: { _ in constant }, parameterId: nil), named: "config")
     }
     
-    /// Create a `Binding` that always returns the given `value`.
+    /// Create a `Binding` that always returns the given `value`  (unless a different value is set
+    /// using ``Delegate/set(_:to:)``).
     public static func constant(_ value: Value) -> Binding<Value> {
         Binding(constant: value)
     }
     
+    /// Create a ``Binding`` that always returns the given `value` (unless a different value is set
+    /// using ``Delegate/set(_:to:)``).
     public init(wrappedValue value: Value) {
         self.init(constant: value)
     }

--- a/Sources/Apodini/Properties/Binding.swift
+++ b/Sources/Apodini/Properties/Binding.swift
@@ -32,7 +32,7 @@ private enum Retrieval<Value> {
 /// or an `@Environment`. The latter `Binding`s for the latter two are contained in their
 /// `projectedValue`s.
 @propertyWrapper
-public struct Binding<Value>: DynamicProperty, PotentiallyParameterIdentifyingBinding {
+public struct Binding<Value>: InstanceCodable, DynamicProperty, PotentiallyParameterIdentifyingBinding {
     private let store: Properties
     private let retrieval: Retrieval<Value>
     let parameterId: UUID?

--- a/Sources/Apodini/Properties/Binding.swift
+++ b/Sources/Apodini/Properties/Binding.swift
@@ -91,7 +91,7 @@ extension Binding {
 
 extension Binding {
     private init<K: EnvironmentAccessible>(environment: Environment<K, Value>) {
-        store = Properties(wrappedValue: ["environment": environment])
+        store = Properties().with(environment, named: "environment")
         retrieval = .storage { store in
             guard let parameter = store.wrappedValue["environment"] as? Environment<K, Value> else {
                 fatalError("Could not find Environment in store. The internal logic of Binding is broken!")
@@ -110,7 +110,7 @@ extension Binding {
 
 extension Binding {
     private init(environmentobject: EnvironmentObject<Value>) {
-        store = Properties(wrappedValue: ["environmentobject": environmentobject])
+        store = Properties().with(environmentobject, named: "environmentobject")
         retrieval = .storage { store in
             guard let parameter = store.wrappedValue["environmentobject"] as? EnvironmentObject<Value> else {
                 fatalError("Could not find EnvironmentObject in store. The internal logic of Binding is broken!")
@@ -130,9 +130,9 @@ extension Binding {
 
 extension Binding where Value: Codable {
     private init(parameter: Parameter<Value>) {
-        store = Properties(wrappedValue: ["parameter": parameter], namingStrategy: { names in
+        store = Properties(namingStrategy: { names in
             names[names.count - 3]
-        })
+        }).with(parameter, named: "parameter")
         retrieval = .storage { store in
             guard let parameter = store.wrappedValue["parameter"] as? Parameter<Value> else {
                 fatalError("Could not find Parameter object in store. The internal logic of Binding is broken!")

--- a/Sources/Apodini/Properties/Binding.swift
+++ b/Sources/Apodini/Properties/Binding.swift
@@ -65,7 +65,7 @@ public struct Binding<Value>: DynamicProperty, PotentiallyParameterIdentifyingBi
 // MARK: Override
 
 extension Binding {
-    fileprivate struct Configuration: Property, InstanceCodable {
+    fileprivate struct Configuration: Property, _InstanceCodable {
         var override: Box<Value?>?
         let retriever: (Properties) -> Value
         let parameterId: UUID?

--- a/Sources/Apodini/Properties/Delegate.swift
+++ b/Sources/Apodini/Properties/Delegate.swift
@@ -14,7 +14,7 @@ import Foundation
 /// of `@Parameter`s to the point where you call `Delegate` as a function. This enables you to decode
 /// input lazily and to do manual error handling in case decoding fails.
 /// - Warning: `D` must be a `struct`
-public struct Delegate<D>: InstanceCodable {
+public struct Delegate<D>: _InstanceCodable {
     struct Storage {
         var connection: Connection?
         // swiftlint:disable:next weak_delegate

--- a/Sources/Apodini/Properties/Delegate.swift
+++ b/Sources/Apodini/Properties/Delegate.swift
@@ -52,7 +52,9 @@ public struct Delegate<D>: InstanceCodable {
         if let codableDelegate = delegate as? PropertyIterable {
             let encoder = FlatInstanceEncoder()
             try! codableDelegate.encode(to: encoder)
-            self.delegateModel = .codable(encoder.freezed)
+            let decoder = encoder.freezed
+            print(decoder.store)
+            self.delegateModel = .codable(decoder)
         } else {
             self.delegateModel = .legacy(delegate)
         }

--- a/Sources/Apodini/Properties/Delegate.swift
+++ b/Sources/Apodini/Properties/Delegate.swift
@@ -13,7 +13,6 @@ import Foundation
 /// instance of `D` discoverable to the Apodini runtime framework. Moreover, it delays initialization and verification
 /// of `@Parameter`s to the point where you call `Delegate` as a function. This enables you to decode
 /// input lazily and to do manual error handling in case decoding fails.
-/// - Warning: `D` must be a `struct`
 public struct Delegate<D: PropertyIterable>: _InstanceCodable {
     struct Storage {
         var connection: Connection?
@@ -53,7 +52,7 @@ public struct Delegate<D: PropertyIterable>: _InstanceCodable {
     }
     
     /// Prepare the wrapped delegate `D` for usage.
-    public func callAsFunction() throws -> D {
+    public func instance() throws -> D {
         guard let store = storage else {
             fatalError("'Delegate' was called before activation.")
         }
@@ -319,6 +318,6 @@ public extension _Internal {
         } catch {
             throw ApodiniError(type: .serverError, reason: "Internal Framework Error", description: "Could not inject Request into 'Delegate'")
         }
-        return try delegate().handle()
+        return try delegate.instance().handle()
     }
 }

--- a/Sources/Apodini/Properties/Delegate.swift
+++ b/Sources/Apodini/Properties/Delegate.swift
@@ -49,7 +49,7 @@ public struct Delegate<D>: InstanceCodable {
     /// - Parameter `delegate`: the wrapped instance
     /// - Parameter `optionality`: the `Optionality` for all `@Parameter`s of the `delegate`
     public init(_ delegate: D, _ optionality: Optionality = .optional) {
-        if let codableDelegate = delegate as? Codable {
+        if let codableDelegate = delegate as? PropertyIterable {
             let encoder = FlatInstanceEncoder()
             try! codableDelegate.encode(to: encoder)
             self.delegateModel = .codable(encoder.freezed)

--- a/Sources/Apodini/Properties/Delegate.swift
+++ b/Sources/Apodini/Properties/Delegate.swift
@@ -14,7 +14,7 @@ import Foundation
 /// of `@Parameter`s to the point where you call `Delegate` as a function. This enables you to decode
 /// input lazily and to do manual error handling in case decoding fails.
 /// - Warning: `D` must be a `struct`
-public struct Delegate<D> {
+public struct Delegate<D>: InstanceCodable {
     struct Storage {
         var connection: Connection?
         var didActivate = false

--- a/Sources/Apodini/Properties/Environment.swift
+++ b/Sources/Apodini/Properties/Environment.swift
@@ -6,7 +6,7 @@ import ApodiniUtils
 /// `ObservableObject`, `Environment` observes its value just as `ObservedObject`.
 /// Use `Delegate.environment(_:, _:)` to inject a value locally, or define a global default
 /// using `EnvironmentValue`.
-public struct Environment<Key: EnvironmentAccessible, Value>: Property {
+public struct Environment<Key: EnvironmentAccessible, Value>: InstanceCodable, Property {
     private struct Storage {
         var changed: Bool
         weak var ownObservation: Observation?

--- a/Sources/Apodini/Properties/Environment.swift
+++ b/Sources/Apodini/Properties/Environment.swift
@@ -6,7 +6,7 @@ import ApodiniUtils
 /// `ObservableObject`, `Environment` observes its value just as `ObservedObject`.
 /// Use `Delegate.environment(_:, _:)` to inject a value locally, or define a global default
 /// using `EnvironmentValue`.
-public struct Environment<Key: EnvironmentAccessible, Value>: InstanceCodable, Property {
+public struct Environment<Key: EnvironmentAccessible, Value>: _InstanceCodable, Property {
     private struct Storage {
         var changed: Bool
         weak var ownObservation: Observation?

--- a/Sources/Apodini/Properties/EnvironmentObject.swift
+++ b/Sources/Apodini/Properties/EnvironmentObject.swift
@@ -12,7 +12,7 @@ import ApodiniUtils
 /// A property wrapper to inject pre-defined values  to a `Component`.  If `Value` is an
 /// `ObservableObject`, `Environment` observes its value just as `ObservedObject`.
 /// Use `Delegate.environmentObject(_:)` to inject a value.
-public struct EnvironmentObject<Value>: InstanceCodable, DynamicProperty {
+public struct EnvironmentObject<Value>: _InstanceCodable, DynamicProperty {
     private struct Storage {
         var changed: Bool
         weak var ownObservation: Observation?

--- a/Sources/Apodini/Properties/EnvironmentObject.swift
+++ b/Sources/Apodini/Properties/EnvironmentObject.swift
@@ -12,7 +12,7 @@ import ApodiniUtils
 /// A property wrapper to inject pre-defined values  to a `Component`.  If `Value` is an
 /// `ObservableObject`, `Environment` observes its value just as `ObservedObject`.
 /// Use `Delegate.environmentObject(_:)` to inject a value.
-public struct EnvironmentObject<Value>: DynamicProperty {
+public struct EnvironmentObject<Value>: InstanceCodable, DynamicProperty {
     private struct Storage {
         var changed: Bool
         weak var ownObservation: Observation?

--- a/Sources/Apodini/Properties/InstanceCodable.swift
+++ b/Sources/Apodini/Properties/InstanceCodable.swift
@@ -1,0 +1,434 @@
+//
+//  InstanceCodable.swift
+//  
+//
+//  Created by Max Obermeier on 06.07.21.
+//
+
+import Foundation
+
+protocol InstanceCoder: Encoder, Decoder {
+    func singleInstanceContainer() throws -> SingleValueInstanceContainer
+}
+
+protocol SingleValueInstanceContainer: SingleValueDecodingContainer, SingleValueEncodingContainer {
+    func decode<T>(_ type: T.Type) throws -> T
+    func encode<T>(_ value: T) throws
+}
+
+public protocol InstanceCodable: Codable { }
+
+enum InstanceCodingError: Error {
+    case instantializedUsingNonInstanceCoder
+    case encodedUsingNonInstanceCoder
+    case notImplemented
+    case badType
+}
+
+//@propertyWrapper
+//struct Parameter<T>:  ContentInjectable, InstanceCodable {
+//    var _value: T?
+//
+//    var wrappedValue: T {
+//        get {
+//            guard let value = _value else {
+//                fatalError()
+//            }
+//            return value
+//        }
+//        set {
+//            _value = newValue
+//        }
+//    }
+//
+//    init() { }
+//
+//    mutating func inject(_ value: Content) {
+//        switch T.self {
+//        case is Int.Type:
+//            self._value = (value.int as! T)
+//        case is String.Type:
+//            self._value = (value.string as! T)
+//        case is Int?.Type:
+//            self._value = (value.optional as! T)
+//        case is SomeClass.Type:
+//            self._value = (value.reference as! T)
+//        default:
+//            fatalError()
+//        }
+//    }
+//
+//    init(from decoder: Decoder) throws {
+//        guard let ic = decoder as? InstanceCoder else {
+//            throw InstanceCodingError.instantializedUsingNonInstanceCoder
+//        }
+//
+//        let container = try ic.singleInstanceContainer()
+//        let injectedValue = try container.decode(Parameter<T>.self)
+//
+//        self = injectedValue
+//    }
+//
+//    func encode(to encoder: Encoder) throws {
+//        guard let ic = encoder as? InstanceCoder else {
+//            throw InstanceCodingError.encodedUsingNonInstanceCoder
+//        }
+//
+//        let container = try ic.singleInstanceContainer()
+//        try container.encode(self)
+//    }
+//}
+
+extension Property {
+    public init(from decoder: Decoder) throws {
+        guard let ic = decoder as? InstanceCoder else {
+            throw InstanceCodingError.instantializedUsingNonInstanceCoder
+        }
+
+        let container = try ic.singleInstanceContainer()
+        self = try container.decode(Self.self)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        guard let ic = encoder as? InstanceCoder else {
+            throw InstanceCodingError.encodedUsingNonInstanceCoder
+        }
+
+        let container = try ic.singleInstanceContainer()
+        try container.encode(self)
+    }
+}
+
+typealias Activator = Mutator<Activatable>
+
+extension Activator {
+    convenience init() {
+        self.init { activatable in
+            activatable.activate()
+        }
+    }
+}
+
+// MARK: Mutator
+
+class Mutator<Target>: InstanceCoder {
+    var codingPath: [CodingKey] = []
+    
+    var userInfo: [CodingUserInfoKey : Any] = [:]
+    
+    internal fileprivate(set) var store: [InstanceCodable] = []
+    
+    fileprivate var count: Int = 0
+    
+    fileprivate var mutation: (inout Target) throws -> Void
+    
+    init(_ mutation: @escaping (inout Target) throws -> Void) {
+        self.mutation = mutation
+    }
+    
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+        KeyedEncodingContainer(KeyedInstanceContainer(injector: self))
+    }
+    
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        UnkeyedInstanceEncodingContainer(injector: self)
+    }
+    
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        InstanceContainer(injector: self)
+    }
+    
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
+        KeyedDecodingContainer(KeyedInstanceContainer(injector: self))
+    }
+    
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        UnkeyedInstanceDecodingContainer(injector: self)
+    }
+    
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        InstanceContainer(injector: self)
+    }
+    
+    func singleInstanceContainer() throws -> SingleValueInstanceContainer {
+        InstanceContainer(injector: self)
+    }
+    
+    func mutate(_ element: inout Target) throws {
+        try mutation(&element)
+    }
+    
+    func reset() {
+        self.count = 0
+    }
+}
+
+// MARK: UnkeyedInstanceDecodingContainer
+
+struct UnkeyedInstanceDecodingContainer<Target>: UnkeyedDecodingContainer {
+    let injector: Mutator<Target>
+    
+    var codingPath: [CodingKey] {
+        get {
+            injector.codingPath
+        }
+        set {
+            injector.codingPath = newValue
+        }
+    }
+    
+    var count: Int? = nil
+    
+    var isAtEnd: Bool = false
+    
+    var currentIndex: Int = 0
+    
+    mutating func decodeNil() throws -> Bool {
+        false
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+        try injector.container(keyedBy: type)
+    }
+    
+    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        try injector.unkeyedContainer()
+    }
+    
+    mutating func superDecoder() throws -> Decoder {
+        injector
+    }
+    
+    mutating func decode<T>(_ type: T.Type) throws -> T {
+//        print("UnkeyedInstanceDecodingContainer.decode \(type)")
+//        print(injector.store)
+        guard T.self is InstanceCodable.Type else {
+            throw InstanceCodingError.notImplemented
+        }
+        
+        let next = injector.store[injector.count]
+        injector.count += 1
+        
+        guard let typed = next as? T else {
+            throw InstanceCodingError.badType
+        }
+        
+        if var element = typed as? Target {
+            try injector.mutate(&element)
+            return element as! T
+        } else {
+            return typed
+        }
+    }
+}
+
+// MARK: UnkeyedInstanceEncodingContainer
+
+struct UnkeyedInstanceEncodingContainer<Target>: UnkeyedEncodingContainer {
+    let injector: Mutator<Target>
+    
+    var codingPath: [CodingKey] {
+        get {
+            injector.codingPath
+        }
+        set {
+            injector.codingPath = newValue
+        }
+    }
+    
+    var count: Int = 0
+    
+    mutating func encodeNil() throws {
+        throw InstanceCodingError.notImplemented
+    }
+    
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        injector.container(keyedBy: keyType)
+    }
+    
+    mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        injector.unkeyedContainer()
+    }
+    
+    mutating func superEncoder() -> Encoder {
+        injector
+    }
+    
+    mutating func encode<T>(_ value: T) throws {
+//        print("UnkeyedInstanceEncodingContainer.encode \(value)")
+        guard let typed = value as? InstanceCodable else {
+            throw InstanceCodingError.notImplemented
+        }
+        
+        injector.store.append(typed)
+    }
+}
+
+// MARK: KeyedInstanceContainer
+
+struct KeyedInstanceContainer<K: CodingKey, Target>: KeyedEncodingContainerProtocol, KeyedDecodingContainerProtocol {
+    mutating func encodeNil(forKey key: K) throws {
+        throw InstanceCodingError.notImplemented
+    }
+    
+    mutating func encode<T>(_ value: T, forKey key: K) throws {
+//        print("KeyedInstanceContainer.encode \(value) forkey \(key)")
+        guard let typed = value as? InstanceCodable else {
+            throw InstanceCodingError.notImplemented
+        }
+        
+        injector.store.append(typed)
+    }
+    
+    var allKeys: [K] {
+//        print("allKeys")
+        return []
+    }
+    
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: K) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        injector.container(keyedBy: keyType)
+    }
+    
+    mutating func nestedUnkeyedContainer(forKey key: K) -> UnkeyedEncodingContainer {
+        injector.unkeyedContainer()
+    }
+    
+    mutating func superEncoder() -> Encoder {
+        injector
+    }
+    
+    mutating func superEncoder(forKey key: K) -> Encoder {
+        injector
+    }
+    
+    func contains(_ key: K) -> Bool {
+//        print("contains \(key)")
+        return false
+    }
+    
+    func decodeNil(forKey key: K) throws -> Bool {
+        false
+    }
+    
+    func decode<T>(_ type: T.Type, forKey key: K) throws -> T {
+//        print("KeyedInstanceContainer.decode \(type)")
+//        print(injector.store)
+        guard T.self is InstanceCodable.Type else {
+            throw InstanceCodingError.notImplemented
+        }
+        
+        let next = injector.store[injector.count]
+        injector.count += 1
+        
+        guard let typed = next as? T else {
+            throw InstanceCodingError.badType
+        }
+        
+        if var element = typed as? Target {
+            try injector.mutate(&element)
+            return element as! T
+        } else {
+            return typed
+        }
+    }
+    
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+        try injector.container(keyedBy: type)
+    }
+    
+    func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
+        try injector.unkeyedContainer()
+    }
+    
+    func superDecoder() throws -> Decoder {
+        injector
+    }
+    
+    func superDecoder(forKey key: K) throws -> Decoder {
+        injector
+    }
+    
+    typealias Key = K
+    
+    let injector: Mutator<Target>
+    
+    var codingPath: [CodingKey] {
+        get {
+            injector.codingPath
+        }
+        set {
+            injector.codingPath = newValue
+        }
+    }
+}
+
+// MARK: InstanceContainer
+
+struct InstanceContainer<Target>: SingleValueInstanceContainer {
+    let injector: Mutator<Target>
+    
+    var codingPath: [CodingKey] {
+        get {
+            injector.codingPath
+        }
+        set {
+            injector.codingPath = newValue
+        }
+    }
+    
+    func decode<T>(_ type: T.Type) throws -> T {
+//        print("InstanceContainer.decode \(type)")
+//        print(injector.store)
+        guard T.self is InstanceCodable.Type else {
+            throw InstanceCodingError.notImplemented
+        }
+        
+        let next = injector.store[injector.count]
+        injector.count += 1
+        
+        guard let typed = next as? T else {
+            throw InstanceCodingError.badType
+        }
+        
+        if var element = typed as? Target {
+            try injector.mutate(&element)
+            return element as! T
+        } else {
+            return typed
+        }
+    }
+    
+    func encode<T>(_ value: T) throws {
+//        print("InstanceContainer.encode \(value)")
+//        print(injector.store)
+        guard let typed = value as? InstanceCodable else {
+            throw InstanceCodingError.notImplemented
+        }
+        
+        injector.store.append(typed)
+    }
+    
+    func decodeNil() -> Bool {
+        false
+    }
+    
+    mutating func encodeNil() throws {
+        throw InstanceCodingError.notImplemented
+    }
+}
+
+//extension InstanceCodableBasedHandler: ContentInjectable {
+//    mutating func inject(_ content: Content) throws {
+//        var injector: Injector
+//        if let i = Self.injector {
+//            injector = i
+//        } else {
+//            injector = Injector(valueToInject: Content(string: "x", int: -1, optional: -1, reference: SomeClass(string: "x")))
+//            try self.encode(to: injector)
+//            Self.injector = injector
+//        }
+//        injector.valueToInject = content
+//        self = try InstanceCodableBasedHandler(from: injector)
+//        injector.reset()
+//    }
+//}

--- a/Sources/Apodini/Properties/InstanceCodable.swift
+++ b/Sources/Apodini/Properties/InstanceCodable.swift
@@ -368,7 +368,7 @@ extension Properties: Codable {
         
         for (key, (type, _)) in info.codingInfo {
             let decoder = try instanceContainer.decode(DecoderExtractor.self, forKey: key).decoder
-            elements[key] = try (type.init(from: decoder) as! Property)
+            elements[key] = try type.init(from: decoder) as! Property
         }
         
         self.codingInfo = info.codingInfo

--- a/Sources/Apodini/Properties/InstanceCodable.swift
+++ b/Sources/Apodini/Properties/InstanceCodable.swift
@@ -60,408 +60,75 @@ enum InstanceCodingError: Error {
     case badType
 }
 
-// MARK: Stores
+protocol Counter {
+    func next() -> Int
+}
 
-enum Element: CustomDebugStringConvertible {
-    case store(ContainerStore)
-    case value(Any)
+struct ThreadSpecificCounter: Counter {
+    let counter: ThreadSpecificVariable<Box<Int>> = ThreadSpecificVariable()
     
-    var debugDescription: String {
-        switch self {
-        case let .store(store):
-            return "Element.store(\(store))"
-        case let .value(value):
-            return "Element.value(\(value))"
+    let count: Int
+    
+    func next() -> Int {
+        if let current = counter.currentValue {
+            current.value += 1
+            if current.value >= count {
+                current.value = 0
+            }
+            return current.value
+        } else {
+            counter.currentValue = Box(0)
+            return 0
         }
     }
 }
-
-protocol ContainerStore: CustomDebugStringConvertible {
-    // encoding only
-    var keyed: KeyedElementStore? { get nonmutating set }
-    var single: SingleElementStore? { get nonmutating set }
-    
-    // decoding only
-    func next() -> Any
-}
-
-protocol KeyedElementStore: CustomDebugStringConvertible {
-    // encoding only
-    var current: Element? { get nonmutating set }
-    func add<K: CodingKey>(_ key: K)
-    
-    // decoding only
-    /// Loops through all stored `Element`s indefinitely
-    func next() -> Element
-}
-
-protocol SingleElementStore: CustomDebugStringConvertible {
-    // encoding only
-    var element: Element? { get nonmutating set }
-    
-    // decoding only
-    /// Loops through all stored `Element`s indefinitely
-    func next() -> Element
-}
-
-
-
-class BaseContainerStore: ContainerStore {
-    private var _container: Any? = nil
-    
-    init() { }
-    
-    // encoding
-    
-    var keyed: KeyedElementStore? {
-        get {
-            guard _container != nil else {
-                return nil
-            }
-            
-            return _container as! KeyedElementStore
-        }
-        set {
-            _container = newValue
-        }
-    }
-    
-    var single: SingleElementStore? {
-        get {
-            guard _container != nil else {
-                return nil
-            }
-            
-            return _container as! SingleElementStore
-        }
-        set {
-            _container = newValue
-        }
-    }
-    
-    // decoding
-    
-    func next() -> Any {
-        _container!
-    }
-    
-    // misc
-    
-    var debugDescription: String {
-        guard let container = _container else {
-            return "BaseContainerStore(nil)"
-        }
-        
-        guard let describable = container as? CustomDebugStringConvertible else {
-            return "BaseContainerStore(fatal)"
-        }
-        
-        return "BaseContainerStore(\(describable.debugDescription))"
-    }
-}
-
-
-struct RecursiveContainerStore: ContainerStore {
-    var _container: Any?
-    
-    let store: SingleElementStore
-    
-    private var selfCopy: Self {
-        get {
-            guard let element = store.element else {
-                store.element = .store(self)
-                return self
-            }
-            
-            guard case let .store(container) = element else {
-                fatalError()
-            }
-            return container as! Self
-        }
-        nonmutating set {
-            store.element = .store(newValue)
-        }
-    }
-    
-    // encoding
-    
-    var keyed: KeyedElementStore? {
-        get {
-            selfCopy._container as? KeyedElementStore
-        }
-        nonmutating set {
-            var copy = self
-            copy._container = newValue
-            selfCopy = copy
-        }
-    }
-    
-    var single: SingleElementStore? {
-        get {
-            selfCopy._container as? SingleElementStore
-        }
-        nonmutating set {
-            var copy = self
-            copy._container = newValue
-            selfCopy = copy
-        }
-    }
-    
-    // decoding
-    
-    func next() -> Any {
-        _container!
-    }
-    
-    // misc
-    
-    var debugDescription: String {
-        guard let container = _container else {
-            return "RecursiveContainerStore(nil)"
-        }
-        
-        guard let describable = container as? CustomDebugStringConvertible else {
-            return "RecursiveContainerStore(fatal)"
-        }
-        
-        return "RecursiveContainerStore(\(describable.debugDescription))"
-    }
-}
-
-struct PrekeyedSingleElementStore<Key: CodingKey>: SingleElementStore {
-    let store: KeyedElementStore
-    
-    let key: Key
-    
-    init(store: KeyedElementStore, key: Key) {
-        store.add(key)
-        self.store = store
-        self.key = key
-    }
-    
-    // encoding
-    
-    var element: Element? {
-        get {
-            store.current
-        }
-        nonmutating set {
-            store.current = newValue
-        }
-    }
-    
-    // decoding
-    
-    func next() -> Element {
-        store.next()
-    }
-    
-    // misc
-    
-    var debugDescription: String {
-        return "PrekeyedSingleElementStore(key: \(key), store:\(store.debugDescription))"
-    }
-}
-
-struct RecursiveSingleElementStore: SingleElementStore {
-    var _element: Element?
-    
-    let store: ContainerStore
-    
-    private var selfCopy: Self {
-        get {
-            guard let single = store.single else {
-                store.single = self
-                return self
-            }
-            
-            return single as! Self
-        }
-        nonmutating set {
-            store.single = newValue
-        }
-    }
-    
-    // encoding
-    
-    var element: Element? {
-        get {
-            selfCopy._element
-        }
-        nonmutating set {
-            var copy = selfCopy
-            copy._element = newValue
-            selfCopy = copy
-        }
-    }
-    
-    // decoding
-    
-    func next() -> Element {
-        _element!
-    }
-    
-    // misc
-    
-    var debugDescription: String {
-        guard let element = _element else {
-            return "RecursiveSingleElementStore(nil)"
-        }
-
-        return "RecursiveSingleElementStore(\(element.debugDescription))"
-    }
-}
-
-
-
-struct RecursiveKeyedElementStore<Key: CodingKey>: KeyedElementStore {
-    var _elements: [(Key, Element?)]
-    var _next: ThreadSpecificVariable<Box<Int>> = ThreadSpecificVariable()
-    
-    var thisNext: Int {
-        get {
-            if let next = _next.currentValue {
-                return next.value
-            } else {
-                _next.currentValue = Box(0)
-                return 0
-            }
-        }
-        nonmutating set {
-            if let next = _next.currentValue {
-                next.value = newValue
-            } else {
-                _next.currentValue = Box(newValue)
-            }
-        }
-    }
-    
-    let store: ContainerStore
-    
-    private var selfCopy: Self {
-        get {
-            guard let keyed = store.keyed else {
-                store.keyed = self
-                return self
-            }
-            
-            return keyed as! Self
-        }
-        nonmutating set {
-            store.keyed = newValue
-        }
-    }
-    
-    // encoding
-    
-    func add<K>(_ key: K) where K : CodingKey {
-        guard let typedKey = key as? Key else {
-            fatalError()
-        }
-        
-        var copy = selfCopy
-        copy._elements.append((typedKey, nil))
-        selfCopy = copy
-    }
-    
-    var current: Element? {
-        get {
-            let selfCopy = selfCopy
-            
-            guard selfCopy._elements.count > 0 else {
-                return nil
-            }
-            
-            return selfCopy._elements[selfCopy._elements.count - 1].1
-        }
-        nonmutating set {
-            var copy = selfCopy
-            
-            guard copy._elements.count > 0 else {
-                fatalError()
-            }
-            
-            copy._elements[copy._elements.count - 1].1 = newValue
-            selfCopy = copy
-        }
-    }
-    
-    // decoding
-    
-    func next() -> Element {
-        let element = _elements[thisNext]
-        
-        thisNext = (thisNext + 1) % _elements.count
-        
-        return element.1!
-    }
-    
-    
-    // misc
-    
-    var debugDescription: String {
-        return """
-            RecursiveKeyedElementStore(
-                \(_elements)
-            )
-        """
-    }
-}
-
 
 // MARK: Coder
 
 
-struct Coder: InstanceCoder {
-    var codingPath: [CodingKey]
+class Coder: InstanceCoder {
+    var codingPath: [CodingKey] = []
     
-    var userInfo: [CodingUserInfoKey : Any]
+    var userInfo: [CodingUserInfoKey : Any] = [:]
     
-    var store: ContainerStore
+    var store: [(String, Any)] = []
     
-    let baseStore: BaseContainerStore
+    fileprivate var namingStrategy: ([String]) -> String? = Properties.defaultNamingStrategy
     
-    init() {
-        let store = BaseContainerStore()
-        self.baseStore = store
-        self.store = store
-        self.codingPath = []
-        self.userInfo = [:]
+    fileprivate lazy var counter = ThreadSpecificCounter(count: store.count)
+    
+    init() {}
+    
+    fileprivate func add(_ value: Any) {
+        store.append((namingStrategy(codingPath.map{ $0.stringValue })!, value))
     }
+    
+    fileprivate func next() -> Any {
+        store[counter.next()].1
+    }
+    
     
     // encoding
     
     func singleInstanceEncodingContainer() throws -> SingleValueInstanceEncodingContainer {
-        let nestedStore = RecursiveSingleElementStore(_element: nil, store: store)
-        store.single = nestedStore
-        return InstanceContainer(codingPath: self.codingPath, store: nestedStore)
+        InstanceContainer(codingPath: self.codingPath, coder: self)
     }
     
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        let nestedStore = RecursiveKeyedElementStore<Key>(_elements: [], store: store)
-        store.keyed = nestedStore
-        return KeyedEncodingContainer(KeyedInstanceEncodingContainer(codingPath: self.codingPath,
-                                                                     encoder: self,
-                                                                     store: nestedStore))
+        KeyedEncodingContainer(KeyedInstanceEncodingContainer(codingPath: self.codingPath,
+                                                              coder: self))
     }
     
     
     // decoding
     
     func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer {
-        guard let nestedStore = store.next() as? SingleElementStore else {
-            fatalError()
-        }
-        return InstanceContainer(codingPath: self.codingPath, store: nestedStore)
+        InstanceContainer(codingPath: self.codingPath, coder: self)
     }
     
     func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
-        guard let nestedStore = store.next() as? KeyedElementStore else {
-            fatalError()
-        }
-        return KeyedDecodingContainer(KeyedInstanceDecodingContainer(codingPath: self.codingPath,
-                                                                     decoder: self,
-                                                                     store: nestedStore))
+        KeyedDecodingContainer(KeyedInstanceDecodingContainer(codingPath: self.codingPath,
+                                                              coder: self))
     }
     
     
@@ -490,37 +157,37 @@ struct KeyedInstanceEncodingContainer<K: CodingKey>: KeyedEncodingContainerProto
     
     var codingPath: [CodingKey]
     
-    let encoder: Coder
-    
-    let store: KeyedElementStore
+    let coder: Coder
     
     mutating func encode<T>(_ value: T, forKey key: K) throws where T : Encodable {
         if T.self is InstanceCodable.Type {
-            store.add(key)
-            store.current = .value(value)
+            coder.codingPath += [key]
+            defer { coder.codingPath.removeLast() }
+            coder.add(value)
             return
         }
         
-        assert(value is DynamicProperty || value is Properties || value is Properties.EncodingWrapper,
+        precondition(value is DynamicProperty || value is Properties || value is Properties.EncodingWrapper,
                "You can only use 'Property's or 'DynamicProperty's on 'Handler's or values you pass into a 'Delegate'!")
         
-        var encoder = encoder
-        encoder.store = RecursiveContainerStore(_container: nil,
-                                                store: PrekeyedSingleElementStore(store: self.store, key: key))
-        encoder.codingPath += [key]
+        let previousNamingStrategy = coder.namingStrategy
+        if let dynamicProperty = value as? DynamicProperty {
+            coder.namingStrategy = dynamicProperty.namingStrategy(_:)
+        }
+        if let properties = value as? Properties {
+            coder.namingStrategy = properties.namingStrategy
+        }
+        defer { coder.namingStrategy = previousNamingStrategy }
         
-        try value.encode(to: encoder)
+        coder.codingPath += [key]
+        defer { coder.codingPath.removeLast() }
+        
+        try value.encode(to: coder)
     }
     
     mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: K) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        let nestedStore = RecursiveKeyedElementStore<NestedKey>(
-            _elements: [],
-            store: RecursiveContainerStore(_container: nil,
-                                           store: PrekeyedSingleElementStore(store: self.store, key: key)))
-        
         return KeyedEncodingContainer(KeyedInstanceEncodingContainer<NestedKey>(codingPath: self.codingPath + [key],
-                                                                                encoder: self.encoder,
-                                                                                store: nestedStore))
+                                                                                coder: self.coder))
     }
     
     // fatals
@@ -553,42 +220,24 @@ struct KeyedInstanceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProto
     
     var codingPath: [CodingKey]
     
-    let decoder: Coder
-    
-    let store: KeyedElementStore
+    let coder: Coder
     
     // decoding
     
     func decode<T>(_ type: T.Type, forKey key: K) throws -> T where T: Decodable {
         if T.self is InstanceCodable.Type {
-            guard case let .value(value) = store.next() else {
-                fatalError()
-            }
-            return value as! T
+            return coder.next() as! T
         }
         
-        var decoder = decoder
-        guard case let .store(store) = store.next() else {
-            fatalError()
-        }
-        decoder.store = store
-        decoder.codingPath += [key]
+        coder.codingPath += [key]
+        defer { coder.codingPath.removeLast() }
         
-        return try type.init(from: decoder)
+        return try type.init(from: coder)
     }
     
     func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
-        guard case let .store(containerStore) = store.next() else {
-            fatalError()
-        }
-        
-        guard let nestedStore = (containerStore as! RecursiveContainerStore).next() as? KeyedElementStore else {
-            fatalError()
-        }
-        
         return KeyedDecodingContainer(KeyedInstanceDecodingContainer<NestedKey>(codingPath: self.codingPath + [key],
-                                                                                decoder: self.decoder,
-                                                                                store: nestedStore))
+                                                                                coder: self.coder))
     }
     
     
@@ -622,19 +271,7 @@ struct KeyedInstanceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProto
 struct InstanceContainer: SingleValueInstanceEncodingContainer, SingleValueInstanceDecodingContainer {
     var codingPath: [CodingKey]
     
-    let store: SingleElementStore
-    
-    var instance: Any {
-        get {
-            guard case let .value(instance) = store.element else {
-                fatalError()
-            }
-            return instance
-        }
-        nonmutating set {
-            store.element = .value(newValue)
-        }
-    }
+    let coder: Coder
     
     // encoding
     
@@ -643,17 +280,13 @@ struct InstanceContainer: SingleValueInstanceEncodingContainer, SingleValueInsta
             fatalError()
         }
         
-        instance = value
+        coder.add(value)
     }
     
     // decoding
     
     func decode<T>(_ type: T.Type) throws -> T {
-        guard case let .value(value) = store.next() else {
-            fatalError()
-        }
-        
-        return value as! T
+        return coder.next() as! T
     }
     
     // fatals
@@ -755,410 +388,3 @@ extension Properties: Codable {
         case codingInfo
     }
 }
-
-
-
-// MARK: Mutator
-
-//private protocol InstanceCoderStorage {
-//    var single: InstanceContainer.Value { get nonmutating set }
-//
-//    func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value)
-//
-//    func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value
-//
-//    var count: Int { get nonmutating set }
-//
-//    func append(_ value: Any)
-//}
-//
-//private class BaseStorage: InstanceCoderStorage {
-//    private var store: [Any] = []
-//
-//    var count: Int = -1
-//
-//    fileprivate var single: InstanceContainer.Value {
-//        get {
-//            store[count == -1 ? store.count - 1 : count] as! InstanceContainer.Value
-//        }
-//        set {
-//            store[store.count - 1] = newValue as Any
-//        }
-//    }
-//
-//    fileprivate func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value {
-//        store[count == -1 ? store.count - 1 : count] as! KeyedInstanceContainer<K>.Value
-//    }
-//
-//    fileprivate func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value) {
-//        store[store.count - 1] = value
-//    }
-//
-//    func append(_ value: Any) {
-//        store.append(value)
-//    }
-//}
-//
-//struct Mutator: InstanceCoder {
-//    var codingPath: [CodingKey] = [] // implementing that could become the real struggle
-//
-//    var userInfo: [CodingUserInfoKey : Any] = [:]
-//
-//    private let baseStorage: BaseStorage
-//
-//    fileprivate var store: InstanceCoderStorage
-//
-//    init() {
-//        let storage = BaseStorage()
-//        self.baseStorage = storage
-//        self.store = storage
-//    }
-//
-//    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-//        store.append(KeyedInstanceContainer<Key>.Value(count: -1, array: []))
-//        return KeyedEncodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self.store, coder: self))
-//    }
-//
-//    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
-//        store.count += 1
-//        return KeyedDecodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self.store, coder: self))
-//    }
-//
-//    func singleInstanceEncodingContainer() throws -> SingleValueInstanceEncodingContainer {
-//        store.append(InstanceContainer.Value.none as Any)
-//        return InstanceContainer(store: self.store, codingPath: self.codingPath)
-//    }
-//
-//    func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer {
-//        store.count += 1
-//        return InstanceContainer(store: self.store, codingPath: self.codingPath)
-//    }
-//
-//    func unkeyedContainer() -> UnkeyedEncodingContainer {
-//        fatalError() // UnkeyedInstanceEncodingContainer(injector: self)
-//    }
-//
-//    func singleValueContainer() -> SingleValueEncodingContainer {
-//        fatalError() // think that won't be needed InstanceContainer(injector: self)
-//    }
-//
-//    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-//        fatalError() // UnkeyedInstanceDecodingContainer(injector: self)
-//    }
-//
-//    func singleValueContainer() throws -> SingleValueDecodingContainer {
-//        fatalError() // think that won't be needed InstanceContainer(injector: self)
-//    }
-//
-//    mutating func reset() {
-//        store = baseStorage
-//        store.count = 0
-//    }
-//}
-//
-//// MARK: KeyedInstanceContainer
-//
-//private struct KeyedInstanceContainer<K: CodingKey>: KeyedEncodingContainerProtocol, KeyedDecodingContainerProtocol, InstanceCoderStorage {
-//    enum Element {
-//        case value(InstanceCodable?)
-//        case container(Any)
-//    }
-//
-//    typealias Key = K
-//
-//    typealias Value = (count: Int, array: [(key: K, value: Element)])
-//
-//    var codingPath: [CodingKey]
-//
-//    let store: InstanceCoderStorage
-//
-//    let coder: Mutator
-//
-//    var instances: [(key: K, value: Element)] {
-//        get {
-//            store.getKeyed(K.self).array
-//        }
-//        nonmutating set {
-//            store.setKeyed((store.getKeyed(K.self).count, newValue))
-//        }
-//    }
-//
-//
-//    var count: Int {
-//        get {
-//            store.getKeyed(K.self).count
-//        }
-//        nonmutating set {
-//            store.setKeyed((newValue, store.getKeyed(K.self).array))
-//        }
-//    }
-//
-//    var single: InstanceContainer.Value {
-//        get {
-//            guard case let .container(container) = instances[count == -1 ? instances.count - 1 : count].value else {
-//                fatalError()
-//            }
-//            return container as! InstanceContainer.Value
-//        }
-//        nonmutating set {
-//            instances[instances.count - 1] = (instances[instances.count - 1].key, .container(newValue as Any))
-//        }
-//    }
-//
-//    func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value {
-//        guard case let .container(container) = instances[count == -1 ? instances.count - 1 : count].value else {
-//            fatalError()
-//        }
-//        return container as! KeyedInstanceContainer<K>.Value
-//    }
-//
-//    func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value) {
-//        instances[instances.count - 1] = (instances[instances.count - 1].key, .container(value as Any))
-//    }
-//
-//    func append(_ value: Any) {
-//        instances.append(value as! (K, KeyedInstanceContainer<K>.Element))
-//    }
-//
-//
-//    var allKeys: [K] {
-//        instances.map(\.key)
-//    }
-//
-//    func contains(_ key: K) -> Bool {
-//        instances.contains(where: { (instanceKey, _) in
-//            key.stringValue == instanceKey.stringValue
-//        })
-//    }
-//
-//    mutating func encodeNil(forKey key: K) throws {
-//        instances.append((key, .value(nil)))
-//    }
-//
-//    func decodeNil(forKey key: K) throws -> Bool {
-//        count += 1
-//        guard case let (foundKey, .value(value)) = instances[count], key.stringValue == foundKey.stringValue else {
-//            fatalError()
-//        }
-//        return value == nil
-//    }
-//
-//    mutating func encode<T>(_ value: T, forKey key: K) throws {
-//        if let dynamicProperty = value as? DynamicProperty {
-//            var encoder = coder
-//            encoder.store = self
-//            try dynamicProperty.encode(to: encoder)
-//        }
-//
-//        instances.append((key, .value((value as! InstanceCodable))))
-//    }
-//
-//    func decode<T>(_ type: T.Type, forKey key: K) throws -> T {
-//        count += 1
-//
-//        if let dynamicPropertyType = T.self as? DynamicProperty.Type {
-//            var decoder = coder
-//            decoder.store = self
-//            return try dynamicPropertyType.init(from: decoder) as! T
-//        }
-//
-//        guard case let (foundKey, .value(.some(value))) = instances[count], key.stringValue == foundKey.stringValue else {
-//            fatalError()
-//        }
-//        return value as! T
-//    }
-//
-//    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: K) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-//        instances.append((key, .container(KeyedInstanceContainer<NestedKey>.Value(count: -1, array: []))))
-//        return KeyedEncodingContainer(KeyedInstanceContainer<NestedKey>(codingPath: self.codingPath + [key], store: self, coder: self.coder))
-//    }
-//
-//    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
-//        count += 1
-//        return KeyedDecodingContainer(KeyedInstanceContainer<NestedKey>(codingPath: self.codingPath + [key], store: self, coder: self.coder))
-//    }
-//
-//    mutating func superEncoder() -> Encoder {
-//        fatalError()
-//    }
-//
-//    mutating func superEncoder(forKey key: K) -> Encoder {
-//        fatalError()
-//    }
-//
-//    mutating func nestedUnkeyedContainer(forKey key: K) -> UnkeyedEncodingContainer {
-//        fatalError()
-//    }
-//
-//    func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
-//        fatalError()
-//    }
-//
-//    func superDecoder() throws -> Decoder {
-//        fatalError()
-//    }
-//
-//    func superDecoder(forKey key: K) throws -> Decoder {
-//        fatalError()
-//    }
-//}
-//
-//// MARK: InstanceContainer
-//
-//private struct InstanceContainer: SingleValueInstanceDecodingContainer, SingleValueInstanceEncodingContainer {
-//    typealias Value = InstanceCodable?
-//
-//    let store: InstanceCoderStorage
-//
-//    var instance: Value {
-//        get {
-//            store.single
-//        }
-//        nonmutating set {
-//            store.single = newValue
-//        }
-//    }
-//
-//    var codingPath: [CodingKey]
-//
-//    func decode<T>(_ type: T.Type) throws -> T {
-//        guard let typed = instance as? T else {
-//            throw InstanceCodingError.badType
-//        }
-//
-//        return typed
-//    }
-//
-//    mutating func encode<T>(_ value: T) throws {
-//        guard let typed = value as? InstanceCodable else {
-//            throw InstanceCodingError.notImplemented
-//        }
-//
-//        instance = typed
-//    }
-//
-//    func decodeNil() -> Bool {
-//        instance == nil
-//    }
-//
-//    mutating func encodeNil() throws {
-//        instance = nil
-//    }
-//}
-
-//extension InstanceCodableBasedHandler: ContentInjectable {
-//    mutating func inject(_ content: Content) throws {
-//        var injector: Injector
-//        if let i = Self.injector {
-//            injector = i
-//        } else {
-//            injector = Injector(valueToInject: Content(string: "x", int: -1, optional: -1, reference: SomeClass(string: "x")))
-//            try self.encode(to: injector)
-//            Self.injector = injector
-//        }
-//        injector.valueToInject = content
-//        self = try InstanceCodableBasedHandler(from: injector)
-//        injector.reset()
-//    }
-//}
-//
-//// MARK: UnkeyedInstanceDecodingContainer
-//
-//struct UnkeyedInstanceDecodingContainer<Target>: UnkeyedDecodingContainer {
-//    let injector: Mutator<Target>
-//
-//    var codingPath: [CodingKey] {
-//        get {
-//            injector.codingPath
-//        }
-//        set {
-//            injector.codingPath = newValue
-//        }
-//    }
-//
-//    var count: Int? = nil
-//
-//    var isAtEnd: Bool = false
-//
-//    var currentIndex: Int = 0
-//
-//    mutating func decodeNil() throws -> Bool {
-//        false
-//    }
-//
-//    mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
-//        try injector.container(keyedBy: type)
-//    }
-//
-//    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
-//        try injector.unkeyedContainer()
-//    }
-//
-//    mutating func superDecoder() throws -> Decoder {
-//        injector
-//    }
-//
-//    mutating func decode<T>(_ type: T.Type) throws -> T {
-////        print("UnkeyedInstanceDecodingContainer.decode \(type)")
-////        print(injector.store)
-//        guard T.self is InstanceCodable.Type else {
-//            throw InstanceCodingError.notImplemented
-//        }
-//
-//        let next = injector.store[injector.count]
-//        injector.count += 1
-//
-//        guard let typed = next as? T else {
-//            throw InstanceCodingError.badType
-//        }
-//
-//        if var element = typed as? Target {
-//            try injector.mutate(&element)
-//            return element as! T
-//        } else {
-//            return typed
-//        }
-//    }
-//}
-//
-//// MARK: UnkeyedInstanceEncodingContainer
-//
-//struct UnkeyedInstanceEncodingContainer<Target>: UnkeyedEncodingContainer {
-//    let injector: Mutator<Target>
-//
-//    var codingPath: [CodingKey] {
-//        get {
-//            injector.codingPath
-//        }
-//        set {
-//            injector.codingPath = newValue
-//        }
-//    }
-//
-//    var count: Int = 0
-//
-//    mutating func encodeNil() throws {
-//        throw InstanceCodingError.notImplemented
-//    }
-//
-//    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-//        injector.container(keyedBy: keyType)
-//    }
-//
-//    mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-//        injector.unkeyedContainer()
-//    }
-//
-//    mutating func superEncoder() -> Encoder {
-//        injector
-//    }
-//
-//    mutating func encode<T>(_ value: T) throws {
-////        print("UnkeyedInstanceEncodingContainer.encode \(value)")
-//        guard let typed = value as? InstanceCodable else {
-//            throw InstanceCodingError.notImplemented
-//        }
-//
-//        injector.store.append(typed)
-//    }
-//}

--- a/Sources/Apodini/Properties/InstanceCodable.swift
+++ b/Sources/Apodini/Properties/InstanceCodable.swift
@@ -59,75 +59,75 @@ private protocol InstanceCoderStorage {
     func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value
 }
 
-//class Mutator: InstanceCoder, InstanceCoderStorage {
-//    var codingPath: [CodingKey] = [] // implementing that could become the real struggle
-//
-//    var userInfo: [CodingUserInfoKey : Any] = [:]
-//
-//    private var store: [Any] = []
-//
-//    private var count: Int = -1
-//
-//    init() { }
-//
-//    fileprivate var single: InstanceContainer.Value {
-//        get {
-//            store[count == -1 ? store.count - 1 : count] as! InstanceContainer.Value
-//        }
-//        set {
-//            store[store.count - 1] = newValue as Any
-//        }
-//    }
-//
-//    fileprivate func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value {
-//        store[count == -1 ? store.count - 1 : count] as! KeyedInstanceContainer<K>.Value
-//    }
-//
-//    fileprivate func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value) {
-//        store[store.count - 1] = value
-//    }
-//
-//    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-//        store.append(KeyedInstanceContainer<Key>.Value(count: -1, array: []))
-//        return KeyedEncodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self))
-//    }
-//
-//    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
-//        count += 1
-//        return KeyedDecodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self))
-//    }
-//
-//    func singleInstanceEncodingContainer() throws -> SingleValueInstanceEncodingContainer {
-//        store.append(InstanceContainer.Value.none as Any)
-//        return InstanceContainer(store: self, codingPath: self.codingPath)
-//    }
-//
-//    func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer {
-//        count += 1
-//        return InstanceContainer(store: self, codingPath: self.codingPath)
-//    }
-//
-//    func unkeyedContainer() -> UnkeyedEncodingContainer {
-//        fatalError() // UnkeyedInstanceEncodingContainer(injector: self)
-//    }
-//
-//    func singleValueContainer() -> SingleValueEncodingContainer {
-//        fatalError() // think that won't be needed InstanceContainer(injector: self)
-//    }
-//
-//    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-//        fatalError() // UnkeyedInstanceDecodingContainer(injector: self)
-//    }
-//
-//    func singleValueContainer() throws -> SingleValueDecodingContainer {
-//        fatalError() // think that won't be needed InstanceContainer(injector: self)
-//    }
-//
-//    func reset() {
-//        self.count = 0
-//    }
-//}
-//
+class Mutator: InstanceCoder, InstanceCoderStorage {
+    var codingPath: [CodingKey] = [] // implementing that could become the real struggle
+
+    var userInfo: [CodingUserInfoKey : Any] = [:]
+
+    private var store: [Any] = []
+
+    private var count: Int = -1
+
+    init() { }
+
+    fileprivate var single: InstanceContainer.Value {
+        get {
+            store[count == -1 ? store.count - 1 : count] as! InstanceContainer.Value
+        }
+        set {
+            store[store.count - 1] = newValue as Any
+        }
+    }
+
+    fileprivate func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value {
+        store[count == -1 ? store.count - 1 : count] as! KeyedInstanceContainer<K>.Value
+    }
+
+    fileprivate func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value) {
+        store[store.count - 1] = value
+    }
+
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+        store.append(KeyedInstanceContainer<Key>.Value(count: -1, array: []))
+        return KeyedEncodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self))
+    }
+
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
+        count += 1
+        return KeyedDecodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self))
+    }
+
+    func singleInstanceEncodingContainer() throws -> SingleValueInstanceEncodingContainer {
+        store.append(InstanceContainer.Value.none as Any)
+        return InstanceContainer(store: self, codingPath: self.codingPath)
+    }
+
+    func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer {
+        count += 1
+        return InstanceContainer(store: self, codingPath: self.codingPath)
+    }
+
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        fatalError() // UnkeyedInstanceEncodingContainer(injector: self)
+    }
+
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        fatalError() // think that won't be needed InstanceContainer(injector: self)
+    }
+
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        fatalError() // UnkeyedInstanceDecodingContainer(injector: self)
+    }
+
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        fatalError() // think that won't be needed InstanceContainer(injector: self)
+    }
+
+    func reset() {
+        self.count = 0
+    }
+}
+
 // MARK: KeyedInstanceContainer
 
 private struct KeyedInstanceContainer<K: CodingKey>: KeyedEncodingContainerProtocol, KeyedDecodingContainerProtocol, InstanceCoderStorage {
@@ -166,7 +166,7 @@ private struct KeyedInstanceContainer<K: CodingKey>: KeyedEncodingContainerProto
 
     var single: InstanceContainer.Value {
         get {
-            guard case let .container(container) = instances[count == -1 ? instances.count -1 : count].value else {
+            guard case let .container(container) = instances[count == -1 ? instances.count - 1 : count].value else {
                 fatalError()
             }
             return container as! InstanceContainer.Value
@@ -177,7 +177,7 @@ private struct KeyedInstanceContainer<K: CodingKey>: KeyedEncodingContainerProto
     }
 
     func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value {
-        guard case let .container(container) = instances[count == -1 ? instances.count -1 : count].value else {
+        guard case let .container(container) = instances[count == -1 ? instances.count - 1 : count].value else {
             fatalError()
         }
         return container as! KeyedInstanceContainer<K>.Value

--- a/Sources/Apodini/Properties/InstanceCodable.swift
+++ b/Sources/Apodini/Properties/InstanceCodable.swift
@@ -77,7 +77,7 @@ struct ThreadSpecificCounter: Counter {
 /// The name is calculated from the coding-keys and the `namingStrategy` valid for the current scope.
 /// The `namingStrategy` is ``Properties/defaultNamingStrategy`` by default, but is overridden
 /// when in the context of a ``DynamicProperty`` or ``Properties`` element (which both provide their
-/// own `namingStrategy`.
+/// own `namingStrategy`).
 ///
 /// On this array `[(String, Any)]`, `Traversable` can be implemented in a very performant manner.
 

--- a/Sources/Apodini/Properties/InstanceCodable.swift
+++ b/Sources/Apodini/Properties/InstanceCodable.swift
@@ -6,6 +6,37 @@
 //
 
 import Foundation
+import ApodiniUtils
+import NIO
+
+//struct Verifier {
+//    @Environment(\.someToken) var token
+//
+//    @Environment(\.database) var db
+//
+//    func verify() throws -> AuthenticatedUser {
+//        let userid = try checkToken()
+//
+//        return db.getUserById(userId)
+//    }
+//
+//    private func checkToken() throws -> UUID {
+//        // ...
+//    }
+//}
+//
+//struct VerifyingHandler<H: Handler>: Handler { // created by DelegatingHandlerInitializer
+//    let verifier = Delegate(Verifier(), .required)
+//    let handler: Delegate<H>
+//
+//    func handle() throws -> H.Response {
+//        let user = try verifier().verify()
+//
+//        return try handler.environmentObject(user)().handle()
+//    }
+//}
+//
+
 
 protocol InstanceCoder: Encoder, Decoder {
     func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer
@@ -29,6 +60,616 @@ enum InstanceCodingError: Error {
     case badType
 }
 
+// MARK: Stores
+
+enum Element: CustomDebugStringConvertible {
+    case store(ContainerStore)
+    case value(Any)
+    
+    var debugDescription: String {
+        switch self {
+        case let .store(store):
+            return "Element.store(\(store))"
+        case let .value(value):
+            return "Element.value(\(value))"
+        }
+    }
+}
+
+protocol ContainerStore: CustomDebugStringConvertible {
+    // encoding only
+    var keyed: KeyedElementStore? { get nonmutating set }
+    var single: SingleElementStore? { get nonmutating set }
+    
+    // decoding only
+    func next() -> Any
+}
+
+protocol KeyedElementStore: CustomDebugStringConvertible {
+    // encoding only
+    var current: Element? { get nonmutating set }
+    func add<K: CodingKey>(_ key: K)
+    
+    // decoding only
+    /// Loops through all stored `Element`s indefinitely
+    func next() -> Element
+}
+
+protocol SingleElementStore: CustomDebugStringConvertible {
+    // encoding only
+    var element: Element? { get nonmutating set }
+    
+    // decoding only
+    /// Loops through all stored `Element`s indefinitely
+    func next() -> Element
+}
+
+
+
+class BaseContainerStore: ContainerStore {
+    private var _container: Any? = nil
+    
+    init() { }
+    
+    // encoding
+    
+    var keyed: KeyedElementStore? {
+        get {
+            guard _container != nil else {
+                return nil
+            }
+            
+            return _container as! KeyedElementStore
+        }
+        set {
+            _container = newValue
+        }
+    }
+    
+    var single: SingleElementStore? {
+        get {
+            guard _container != nil else {
+                return nil
+            }
+            
+            return _container as! SingleElementStore
+        }
+        set {
+            _container = newValue
+        }
+    }
+    
+    // decoding
+    
+    func next() -> Any {
+        _container!
+    }
+    
+    // misc
+    
+    var debugDescription: String {
+        guard let container = _container else {
+            return "BaseContainerStore(nil)"
+        }
+        
+        guard let describable = container as? CustomDebugStringConvertible else {
+            return "BaseContainerStore(fatal)"
+        }
+        
+        return "BaseContainerStore(\(describable.debugDescription))"
+    }
+}
+
+
+struct RecursiveContainerStore: ContainerStore {
+    var _container: Any?
+    
+    let store: SingleElementStore
+    
+    private var selfCopy: Self {
+        get {
+            guard let element = store.element else {
+                store.element = .store(self)
+                return self
+            }
+            
+            guard case let .store(container) = element else {
+                fatalError()
+            }
+            return container as! Self
+        }
+        nonmutating set {
+            store.element = .store(newValue)
+        }
+    }
+    
+    // encoding
+    
+    var keyed: KeyedElementStore? {
+        get {
+            selfCopy._container as? KeyedElementStore
+        }
+        nonmutating set {
+            var copy = self
+            copy._container = newValue
+            selfCopy = copy
+        }
+    }
+    
+    var single: SingleElementStore? {
+        get {
+            selfCopy._container as? SingleElementStore
+        }
+        nonmutating set {
+            var copy = self
+            copy._container = newValue
+            selfCopy = copy
+        }
+    }
+    
+    // decoding
+    
+    func next() -> Any {
+        _container!
+    }
+    
+    // misc
+    
+    var debugDescription: String {
+        guard let container = _container else {
+            return "RecursiveContainerStore(nil)"
+        }
+        
+        guard let describable = container as? CustomDebugStringConvertible else {
+            return "RecursiveContainerStore(fatal)"
+        }
+        
+        return "RecursiveContainerStore(\(describable.debugDescription))"
+    }
+}
+
+struct PrekeyedSingleElementStore<Key: CodingKey>: SingleElementStore {
+    let store: KeyedElementStore
+    
+    let key: Key
+    
+    init(store: KeyedElementStore, key: Key) {
+        store.add(key)
+        self.store = store
+        self.key = key
+    }
+    
+    // encoding
+    
+    var element: Element? {
+        get {
+            store.current
+        }
+        nonmutating set {
+            store.current = newValue
+        }
+    }
+    
+    // decoding
+    
+    func next() -> Element {
+        store.next()
+    }
+    
+    // misc
+    
+    var debugDescription: String {
+        return "PrekeyedSingleElementStore(key: \(key), store:\(store.debugDescription))"
+    }
+}
+
+struct RecursiveSingleElementStore: SingleElementStore {
+    var _element: Element?
+    
+    let store: ContainerStore
+    
+    private var selfCopy: Self {
+        get {
+            guard let single = store.single else {
+                store.single = self
+                return self
+            }
+            
+            return single as! Self
+        }
+        nonmutating set {
+            store.single = newValue
+        }
+    }
+    
+    // encoding
+    
+    var element: Element? {
+        get {
+            selfCopy._element
+        }
+        nonmutating set {
+            var copy = selfCopy
+            copy._element = newValue
+            selfCopy = copy
+        }
+    }
+    
+    // decoding
+    
+    func next() -> Element {
+        _element!
+    }
+    
+    // misc
+    
+    var debugDescription: String {
+        guard let element = _element else {
+            return "RecursiveSingleElementStore(nil)"
+        }
+
+        return "RecursiveSingleElementStore(\(element.debugDescription))"
+    }
+}
+
+
+
+struct RecursiveKeyedElementStore<Key: CodingKey>: KeyedElementStore {
+    var _elements: [(Key, Element?)]
+    var _next: ThreadSpecificVariable<Box<Int>> = ThreadSpecificVariable()
+    
+    var thisNext: Int {
+        get {
+            if let next = _next.currentValue {
+                return next.value
+            } else {
+                _next.currentValue = Box(0)
+                return 0
+            }
+        }
+        nonmutating set {
+            if let next = _next.currentValue {
+                next.value = newValue
+            } else {
+                _next.currentValue = Box(newValue)
+            }
+        }
+    }
+    
+    let store: ContainerStore
+    
+    private var selfCopy: Self {
+        get {
+            guard let keyed = store.keyed else {
+                store.keyed = self
+                return self
+            }
+            
+            return keyed as! Self
+        }
+        nonmutating set {
+            store.keyed = newValue
+        }
+    }
+    
+    // encoding
+    
+    func add<K>(_ key: K) where K : CodingKey {
+        guard let typedKey = key as? Key else {
+            fatalError()
+        }
+        
+        var copy = selfCopy
+        copy._elements.append((typedKey, nil))
+        selfCopy = copy
+    }
+    
+    var current: Element? {
+        get {
+            let selfCopy = selfCopy
+            
+            guard selfCopy._elements.count > 0 else {
+                return nil
+            }
+            
+            return selfCopy._elements[selfCopy._elements.count - 1].1
+        }
+        nonmutating set {
+            var copy = selfCopy
+            
+            guard copy._elements.count > 0 else {
+                fatalError()
+            }
+            
+            copy._elements[copy._elements.count - 1].1 = newValue
+            selfCopy = copy
+        }
+    }
+    
+    // decoding
+    
+    func next() -> Element {
+        let element = _elements[thisNext]
+        
+        thisNext = (thisNext + 1) % _elements.count
+        
+        return element.1!
+    }
+    
+    
+    // misc
+    
+    var debugDescription: String {
+        return """
+            RecursiveKeyedElementStore(
+                \(_elements)
+            )
+        """
+    }
+}
+
+
+// MARK: Coder
+
+
+struct Coder: InstanceCoder {
+    var codingPath: [CodingKey]
+    
+    var userInfo: [CodingUserInfoKey : Any]
+    
+    var store: ContainerStore
+    
+    let baseStore: BaseContainerStore
+    
+    init() {
+        let store = BaseContainerStore()
+        self.baseStore = store
+        self.store = store
+        self.codingPath = []
+        self.userInfo = [:]
+    }
+    
+    // encoding
+    
+    func singleInstanceEncodingContainer() throws -> SingleValueInstanceEncodingContainer {
+        let nestedStore = RecursiveSingleElementStore(_element: nil, store: store)
+        store.single = nestedStore
+        return InstanceContainer(codingPath: self.codingPath, store: nestedStore)
+    }
+    
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+        let nestedStore = RecursiveKeyedElementStore<Key>(_elements: [], store: store)
+        store.keyed = nestedStore
+        return KeyedEncodingContainer(KeyedInstanceEncodingContainer(codingPath: self.codingPath,
+                                                                     encoder: self,
+                                                                     store: nestedStore))
+    }
+    
+    
+    // decoding
+    
+    func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer {
+        guard let nestedStore = store.next() as? SingleElementStore else {
+            fatalError()
+        }
+        return InstanceContainer(codingPath: self.codingPath, store: nestedStore)
+    }
+    
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
+        guard let nestedStore = store.next() as? KeyedElementStore else {
+            fatalError()
+        }
+        return KeyedDecodingContainer(KeyedInstanceDecodingContainer(codingPath: self.codingPath,
+                                                                     decoder: self,
+                                                                     store: nestedStore))
+    }
+    
+    
+    // fatals
+    
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        fatalError()
+    }
+    
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        fatalError()
+    }
+    
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        fatalError()
+    }
+    
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        fatalError()
+    }
+}
+
+
+struct KeyedInstanceEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
+    typealias Key = K
+    
+    var codingPath: [CodingKey]
+    
+    let encoder: Coder
+    
+    let store: KeyedElementStore
+    
+    mutating func encode<T>(_ value: T, forKey key: K) throws where T : Encodable {
+        if T.self is InstanceCodable.Type {
+            store.add(key)
+            store.current = .value(value)
+            return
+        }
+        
+        assert(value is DynamicProperty || value is Properties || value is Properties.EncodingWrapper,
+               "You can only use 'Property's or 'DynamicProperty's on 'Handler's or values you pass into a 'Delegate'!")
+        
+        var encoder = encoder
+        encoder.store = RecursiveContainerStore(_container: nil,
+                                                store: PrekeyedSingleElementStore(store: self.store, key: key))
+        encoder.codingPath += [key]
+        
+        try value.encode(to: encoder)
+    }
+    
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: K) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        let nestedStore = RecursiveKeyedElementStore<NestedKey>(
+            _elements: [],
+            store: RecursiveContainerStore(_container: nil,
+                                           store: PrekeyedSingleElementStore(store: self.store, key: key)))
+        
+        return KeyedEncodingContainer(KeyedInstanceEncodingContainer<NestedKey>(codingPath: self.codingPath + [key],
+                                                                                encoder: self.encoder,
+                                                                                store: nestedStore))
+    }
+    
+    // fatals
+    
+    mutating func encodeNil(forKey key: K) throws {
+        fatalError()
+    }
+    
+    mutating func encode<T>(_ value: T, forKey key: K) throws {
+        // this should only be called for all the base-types, so never as we always end up with an
+        // `InstanceCodable` object
+        fatalError()
+    }
+    
+    mutating func nestedUnkeyedContainer(forKey key: K) -> UnkeyedEncodingContainer {
+        fatalError()
+    }
+    
+    mutating func superEncoder() -> Encoder {
+        fatalError()
+    }
+    
+    mutating func superEncoder(forKey key: K) -> Encoder {
+        fatalError()
+    }
+}
+
+struct KeyedInstanceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
+    typealias Key = K
+    
+    var codingPath: [CodingKey]
+    
+    let decoder: Coder
+    
+    let store: KeyedElementStore
+    
+    // decoding
+    
+    func decode<T>(_ type: T.Type, forKey key: K) throws -> T where T: Decodable {
+        if T.self is InstanceCodable.Type {
+            guard case let .value(value) = store.next() else {
+                fatalError()
+            }
+            return value as! T
+        }
+        
+        var decoder = decoder
+        guard case let .store(store) = store.next() else {
+            fatalError()
+        }
+        decoder.store = store
+        decoder.codingPath += [key]
+        
+        return try type.init(from: decoder)
+    }
+    
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+        guard case let .store(containerStore) = store.next() else {
+            fatalError()
+        }
+        
+        guard let nestedStore = (containerStore as! RecursiveContainerStore).next() as? KeyedElementStore else {
+            fatalError()
+        }
+        
+        return KeyedDecodingContainer(KeyedInstanceDecodingContainer<NestedKey>(codingPath: self.codingPath + [key],
+                                                                                decoder: self.decoder,
+                                                                                store: nestedStore))
+    }
+    
+    
+    // fatals
+    
+    var allKeys: [K] {
+        fatalError()
+    }
+    
+    func contains(_ key: K) -> Bool {
+        fatalError()
+    }
+    
+    func decodeNil(forKey key: K) throws -> Bool {
+        fatalError()
+    }
+    
+    func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
+        fatalError()
+    }
+    
+    func superDecoder() throws -> Decoder {
+        fatalError()
+    }
+    
+    func superDecoder(forKey key: K) throws -> Decoder {
+        fatalError()
+    }
+}
+
+struct InstanceContainer: SingleValueInstanceEncodingContainer, SingleValueInstanceDecodingContainer {
+    var codingPath: [CodingKey]
+    
+    let store: SingleElementStore
+    
+    var instance: Any {
+        get {
+            guard case let .value(instance) = store.element else {
+                fatalError()
+            }
+            return instance
+        }
+        nonmutating set {
+            store.element = .value(newValue)
+        }
+    }
+    
+    // encoding
+    
+    mutating func encode<T>(_ value: T) throws {
+        guard T.self is InstanceCodable.Type else {
+            fatalError()
+        }
+        
+        instance = value
+    }
+    
+    // decoding
+    
+    func decode<T>(_ type: T.Type) throws -> T {
+        guard case let .value(value) = store.next() else {
+            fatalError()
+        }
+        
+        return value as! T
+    }
+    
+    // fatals
+    
+    mutating func encodeNil() throws {
+        fatalError()
+    }
+    
+    func decodeNil() -> Bool {
+        fatalError()
+    }
+}
+
+
+// MARK: Default Conformance
+
 extension InstanceCodable {
     public init(from decoder: Decoder) throws {
         guard let ic = decoder as? InstanceCoder else {
@@ -49,257 +690,361 @@ extension InstanceCodable {
     }
 }
 
+
+// MARK: Properties Conformance
+
+extension Properties: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: PropertiesElements.self)
+        
+        let info = try container.decode(PropertiesCodableInformation.self, forKey: .codingInfo)
+        
+        let instanceContainer = try container.nestedContainer(keyedBy: String.self, forKey: .instances)
+        
+        var elements = [String: Property]()
+        
+        for (key, (type, _)) in info.codingInfo {
+            let decoder = try instanceContainer.decode(DecoderExtractor.self, forKey: key).decoder
+            elements[key] = try type.init(from: decoder) as! Property
+        }
+        
+        self.codingInfo = info.codingInfo
+        self.namingStrategy = info.namingStrategy
+        self.elements = elements
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: PropertiesElements.self)
+        
+        let info = PropertiesCodableInformation(codingInfo: self.codingInfo, namingStrategy: self.namingStrategy)
+        
+        try container.encode(info, forKey: .codingInfo)
+        
+        var instanceContainer = container.nestedContainer(keyedBy: String.self, forKey: .instances)
+        
+        for (key, (_, closure)) in self.codingInfo { // we always use codingInfo for iteration as its order is fixed!
+            try instanceContainer.encode(EncodingWrapper(closure: closure, value: elements[key]!),
+                                         forKey: key)
+        }
+    }
+    
+    struct DecoderExtractor: Decodable {
+        let decoder: Decoder
+        
+        init(from decoder: Decoder) throws {
+            self.decoder = decoder
+        }
+    }
+    
+    struct EncodingWrapper: Encodable {
+        let closure: (Encoder, Property) throws -> Void
+        let value: Property
+        
+        func encode(to encoder: Encoder) throws {
+            try closure(encoder, value)
+        }
+    }
+    
+    private struct PropertiesCodableInformation: InstanceCodable {
+        let codingInfo: [String: (Decodable.Type, (Encoder, Property) throws -> Void)]
+        let namingStrategy: ([String]) -> String?
+    }
+    
+    private enum PropertiesElements: CodingKey {
+        case instances
+        case codingInfo
+    }
+}
+
+
+
 // MARK: Mutator
 
-private protocol InstanceCoderStorage {
-    var single: InstanceContainer.Value { get nonmutating set }
-
-    func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value)
-
-    func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value
-}
-
-class Mutator: InstanceCoder, InstanceCoderStorage {
-    var codingPath: [CodingKey] = [] // implementing that could become the real struggle
-
-    var userInfo: [CodingUserInfoKey : Any] = [:]
-
-    private var store: [Any] = []
-
-    private var count: Int = -1
-
-    init() { }
-
-    fileprivate var single: InstanceContainer.Value {
-        get {
-            store[count == -1 ? store.count - 1 : count] as! InstanceContainer.Value
-        }
-        set {
-            store[store.count - 1] = newValue as Any
-        }
-    }
-
-    fileprivate func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value {
-        store[count == -1 ? store.count - 1 : count] as! KeyedInstanceContainer<K>.Value
-    }
-
-    fileprivate func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value) {
-        store[store.count - 1] = value
-    }
-
-    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        store.append(KeyedInstanceContainer<Key>.Value(count: -1, array: []))
-        return KeyedEncodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self))
-    }
-
-    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
-        count += 1
-        return KeyedDecodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self))
-    }
-
-    func singleInstanceEncodingContainer() throws -> SingleValueInstanceEncodingContainer {
-        store.append(InstanceContainer.Value.none as Any)
-        return InstanceContainer(store: self, codingPath: self.codingPath)
-    }
-
-    func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer {
-        count += 1
-        return InstanceContainer(store: self, codingPath: self.codingPath)
-    }
-
-    func unkeyedContainer() -> UnkeyedEncodingContainer {
-        fatalError() // UnkeyedInstanceEncodingContainer(injector: self)
-    }
-
-    func singleValueContainer() -> SingleValueEncodingContainer {
-        fatalError() // think that won't be needed InstanceContainer(injector: self)
-    }
-
-    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-        fatalError() // UnkeyedInstanceDecodingContainer(injector: self)
-    }
-
-    func singleValueContainer() throws -> SingleValueDecodingContainer {
-        fatalError() // think that won't be needed InstanceContainer(injector: self)
-    }
-
-    func reset() {
-        self.count = 0
-    }
-}
-
-// MARK: KeyedInstanceContainer
-
-private struct KeyedInstanceContainer<K: CodingKey>: KeyedEncodingContainerProtocol, KeyedDecodingContainerProtocol, InstanceCoderStorage {
-    enum Element {
-        case value(InstanceCodable?)
-        case container(Any)
-    }
-
-    typealias Key = K
-
-    typealias Value = (count: Int, array: [(key: K, value: Element)])
-
-    var codingPath: [CodingKey]
-
-    let store: InstanceCoderStorage
-
-    var count: Int {
-        get {
-            store.getKeyed(K.self).count
-        }
-        nonmutating set {
-            store.setKeyed((newValue, store.getKeyed(K.self).array))
-        }
-    }
-
-    var instances: [(key: K, value: Element)] {
-        get {
-            store.getKeyed(K.self).array
-        }
-        nonmutating set {
-            store.setKeyed((store.getKeyed(K.self).count, newValue))
-        }
-    }
-
-
-
-    var single: InstanceContainer.Value {
-        get {
-            guard case let .container(container) = instances[count == -1 ? instances.count - 1 : count].value else {
-                fatalError()
-            }
-            return container as! InstanceContainer.Value
-        }
-        nonmutating set {
-            instances[instances.count - 1] = (instances[instances.count - 1].key, .container(newValue as Any))
-        }
-    }
-
-    func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value {
-        guard case let .container(container) = instances[count == -1 ? instances.count - 1 : count].value else {
-            fatalError()
-        }
-        return container as! KeyedInstanceContainer<K>.Value
-    }
-
-    func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value) {
-        instances[instances.count - 1] = (instances[instances.count - 1].key, .container(value as Any))
-    }
-
-
-
-    var allKeys: [K] {
-        instances.map(\.key)
-    }
-
-    func contains(_ key: K) -> Bool {
-        instances.contains(where: { (instanceKey, _) in
-            key.stringValue == instanceKey.stringValue
-        })
-    }
-
-    mutating func encodeNil(forKey key: K) throws {
-        instances.append((key, .value(nil)))
-    }
-
-    func decodeNil(forKey key: K) throws -> Bool {
-        count += 1
-        guard case let (foundKey, .value(value)) = instances[count], key.stringValue == foundKey.stringValue else {
-            fatalError()
-        }
-        return value == nil
-    }
-
-    mutating func encode<T>(_ value: T, forKey key: K) throws {
-        instances.append((key, .value((value as! InstanceCodable))))
-    }
-
-    func decode<T>(_ type: T.Type, forKey key: K) throws -> T {
-        count += 1
-        guard case let (foundKey, .value(.some(value))) = instances[count], key.stringValue == foundKey.stringValue else {
-            fatalError()
-        }
-        return value as! T
-    }
-
-    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: K) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        instances.append((key, .container(KeyedInstanceContainer<NestedKey>.Value(count: -1, array: []))))
-        return KeyedEncodingContainer(KeyedInstanceContainer<NestedKey>(codingPath: self.codingPath + [key], store: self))
-    }
-
-    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
-        count += 1
-        return KeyedDecodingContainer(KeyedInstanceContainer<NestedKey>(codingPath: self.codingPath + [key], store: self))
-    }
-
-    mutating func superEncoder() -> Encoder {
-        fatalError()
-    }
-
-    mutating func superEncoder(forKey key: K) -> Encoder {
-        fatalError()
-    }
-
-    mutating func nestedUnkeyedContainer(forKey key: K) -> UnkeyedEncodingContainer {
-        fatalError()
-    }
-
-    func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
-        fatalError()
-    }
-
-    func superDecoder() throws -> Decoder {
-        fatalError()
-    }
-
-    func superDecoder(forKey key: K) throws -> Decoder {
-        fatalError()
-    }
-}
-
-// MARK: InstanceContainer
-
-private struct InstanceContainer: SingleValueInstanceDecodingContainer, SingleValueInstanceEncodingContainer {
-    typealias Value = InstanceCodable?
-
-    let store: InstanceCoderStorage
-
-    var instance: Value {
-        get {
-            store.single
-        }
-        nonmutating set {
-            store.single = newValue
-        }
-    }
-
-    var codingPath: [CodingKey]
-
-    func decode<T>(_ type: T.Type) throws -> T {
-        guard let typed = instance as? T else {
-            throw InstanceCodingError.badType
-        }
-
-        return typed
-    }
-
-    mutating func encode<T>(_ value: T) throws {
-        guard let typed = value as? InstanceCodable else {
-            throw InstanceCodingError.notImplemented
-        }
-
-        instance = typed
-    }
-
-    func decodeNil() -> Bool {
-        instance == nil
-    }
-
-    mutating func encodeNil() throws {
-        instance = nil
-    }
-}
+//private protocol InstanceCoderStorage {
+//    var single: InstanceContainer.Value { get nonmutating set }
+//
+//    func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value)
+//
+//    func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value
+//
+//    var count: Int { get nonmutating set }
+//
+//    func append(_ value: Any)
+//}
+//
+//private class BaseStorage: InstanceCoderStorage {
+//    private var store: [Any] = []
+//
+//    var count: Int = -1
+//
+//    fileprivate var single: InstanceContainer.Value {
+//        get {
+//            store[count == -1 ? store.count - 1 : count] as! InstanceContainer.Value
+//        }
+//        set {
+//            store[store.count - 1] = newValue as Any
+//        }
+//    }
+//
+//    fileprivate func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value {
+//        store[count == -1 ? store.count - 1 : count] as! KeyedInstanceContainer<K>.Value
+//    }
+//
+//    fileprivate func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value) {
+//        store[store.count - 1] = value
+//    }
+//
+//    func append(_ value: Any) {
+//        store.append(value)
+//    }
+//}
+//
+//struct Mutator: InstanceCoder {
+//    var codingPath: [CodingKey] = [] // implementing that could become the real struggle
+//
+//    var userInfo: [CodingUserInfoKey : Any] = [:]
+//
+//    private let baseStorage: BaseStorage
+//
+//    fileprivate var store: InstanceCoderStorage
+//
+//    init() {
+//        let storage = BaseStorage()
+//        self.baseStorage = storage
+//        self.store = storage
+//    }
+//
+//    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+//        store.append(KeyedInstanceContainer<Key>.Value(count: -1, array: []))
+//        return KeyedEncodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self.store, coder: self))
+//    }
+//
+//    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
+//        store.count += 1
+//        return KeyedDecodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self.store, coder: self))
+//    }
+//
+//    func singleInstanceEncodingContainer() throws -> SingleValueInstanceEncodingContainer {
+//        store.append(InstanceContainer.Value.none as Any)
+//        return InstanceContainer(store: self.store, codingPath: self.codingPath)
+//    }
+//
+//    func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer {
+//        store.count += 1
+//        return InstanceContainer(store: self.store, codingPath: self.codingPath)
+//    }
+//
+//    func unkeyedContainer() -> UnkeyedEncodingContainer {
+//        fatalError() // UnkeyedInstanceEncodingContainer(injector: self)
+//    }
+//
+//    func singleValueContainer() -> SingleValueEncodingContainer {
+//        fatalError() // think that won't be needed InstanceContainer(injector: self)
+//    }
+//
+//    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+//        fatalError() // UnkeyedInstanceDecodingContainer(injector: self)
+//    }
+//
+//    func singleValueContainer() throws -> SingleValueDecodingContainer {
+//        fatalError() // think that won't be needed InstanceContainer(injector: self)
+//    }
+//
+//    mutating func reset() {
+//        store = baseStorage
+//        store.count = 0
+//    }
+//}
+//
+//// MARK: KeyedInstanceContainer
+//
+//private struct KeyedInstanceContainer<K: CodingKey>: KeyedEncodingContainerProtocol, KeyedDecodingContainerProtocol, InstanceCoderStorage {
+//    enum Element {
+//        case value(InstanceCodable?)
+//        case container(Any)
+//    }
+//
+//    typealias Key = K
+//
+//    typealias Value = (count: Int, array: [(key: K, value: Element)])
+//
+//    var codingPath: [CodingKey]
+//
+//    let store: InstanceCoderStorage
+//
+//    let coder: Mutator
+//
+//    var instances: [(key: K, value: Element)] {
+//        get {
+//            store.getKeyed(K.self).array
+//        }
+//        nonmutating set {
+//            store.setKeyed((store.getKeyed(K.self).count, newValue))
+//        }
+//    }
+//
+//
+//    var count: Int {
+//        get {
+//            store.getKeyed(K.self).count
+//        }
+//        nonmutating set {
+//            store.setKeyed((newValue, store.getKeyed(K.self).array))
+//        }
+//    }
+//
+//    var single: InstanceContainer.Value {
+//        get {
+//            guard case let .container(container) = instances[count == -1 ? instances.count - 1 : count].value else {
+//                fatalError()
+//            }
+//            return container as! InstanceContainer.Value
+//        }
+//        nonmutating set {
+//            instances[instances.count - 1] = (instances[instances.count - 1].key, .container(newValue as Any))
+//        }
+//    }
+//
+//    func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value {
+//        guard case let .container(container) = instances[count == -1 ? instances.count - 1 : count].value else {
+//            fatalError()
+//        }
+//        return container as! KeyedInstanceContainer<K>.Value
+//    }
+//
+//    func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value) {
+//        instances[instances.count - 1] = (instances[instances.count - 1].key, .container(value as Any))
+//    }
+//
+//    func append(_ value: Any) {
+//        instances.append(value as! (K, KeyedInstanceContainer<K>.Element))
+//    }
+//
+//
+//    var allKeys: [K] {
+//        instances.map(\.key)
+//    }
+//
+//    func contains(_ key: K) -> Bool {
+//        instances.contains(where: { (instanceKey, _) in
+//            key.stringValue == instanceKey.stringValue
+//        })
+//    }
+//
+//    mutating func encodeNil(forKey key: K) throws {
+//        instances.append((key, .value(nil)))
+//    }
+//
+//    func decodeNil(forKey key: K) throws -> Bool {
+//        count += 1
+//        guard case let (foundKey, .value(value)) = instances[count], key.stringValue == foundKey.stringValue else {
+//            fatalError()
+//        }
+//        return value == nil
+//    }
+//
+//    mutating func encode<T>(_ value: T, forKey key: K) throws {
+//        if let dynamicProperty = value as? DynamicProperty {
+//            var encoder = coder
+//            encoder.store = self
+//            try dynamicProperty.encode(to: encoder)
+//        }
+//
+//        instances.append((key, .value((value as! InstanceCodable))))
+//    }
+//
+//    func decode<T>(_ type: T.Type, forKey key: K) throws -> T {
+//        count += 1
+//
+//        if let dynamicPropertyType = T.self as? DynamicProperty.Type {
+//            var decoder = coder
+//            decoder.store = self
+//            return try dynamicPropertyType.init(from: decoder) as! T
+//        }
+//
+//        guard case let (foundKey, .value(.some(value))) = instances[count], key.stringValue == foundKey.stringValue else {
+//            fatalError()
+//        }
+//        return value as! T
+//    }
+//
+//    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: K) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+//        instances.append((key, .container(KeyedInstanceContainer<NestedKey>.Value(count: -1, array: []))))
+//        return KeyedEncodingContainer(KeyedInstanceContainer<NestedKey>(codingPath: self.codingPath + [key], store: self, coder: self.coder))
+//    }
+//
+//    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+//        count += 1
+//        return KeyedDecodingContainer(KeyedInstanceContainer<NestedKey>(codingPath: self.codingPath + [key], store: self, coder: self.coder))
+//    }
+//
+//    mutating func superEncoder() -> Encoder {
+//        fatalError()
+//    }
+//
+//    mutating func superEncoder(forKey key: K) -> Encoder {
+//        fatalError()
+//    }
+//
+//    mutating func nestedUnkeyedContainer(forKey key: K) -> UnkeyedEncodingContainer {
+//        fatalError()
+//    }
+//
+//    func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
+//        fatalError()
+//    }
+//
+//    func superDecoder() throws -> Decoder {
+//        fatalError()
+//    }
+//
+//    func superDecoder(forKey key: K) throws -> Decoder {
+//        fatalError()
+//    }
+//}
+//
+//// MARK: InstanceContainer
+//
+//private struct InstanceContainer: SingleValueInstanceDecodingContainer, SingleValueInstanceEncodingContainer {
+//    typealias Value = InstanceCodable?
+//
+//    let store: InstanceCoderStorage
+//
+//    var instance: Value {
+//        get {
+//            store.single
+//        }
+//        nonmutating set {
+//            store.single = newValue
+//        }
+//    }
+//
+//    var codingPath: [CodingKey]
+//
+//    func decode<T>(_ type: T.Type) throws -> T {
+//        guard let typed = instance as? T else {
+//            throw InstanceCodingError.badType
+//        }
+//
+//        return typed
+//    }
+//
+//    mutating func encode<T>(_ value: T) throws {
+//        guard let typed = value as? InstanceCodable else {
+//            throw InstanceCodingError.notImplemented
+//        }
+//
+//        instance = typed
+//    }
+//
+//    func decodeNil() -> Bool {
+//        instance == nil
+//    }
+//
+//    mutating func encodeNil() throws {
+//        instance = nil
+//    }
+//}
 
 //extension InstanceCodableBasedHandler: ContentInjectable {
 //    mutating func inject(_ content: Content) throws {

--- a/Sources/Apodini/Properties/InstanceCodable.swift
+++ b/Sources/Apodini/Properties/InstanceCodable.swift
@@ -1,6 +1,6 @@
 //
 //  InstanceCodable.swift
-//  
+//
 //
 //  Created by Max Obermeier on 06.07.21.
 //
@@ -8,12 +8,16 @@
 import Foundation
 
 protocol InstanceCoder: Encoder, Decoder {
-    func singleInstanceContainer() throws -> SingleValueInstanceContainer
+    func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer
+    func singleInstanceEncodingContainer() throws -> SingleValueInstanceEncodingContainer
 }
 
-protocol SingleValueInstanceContainer: SingleValueDecodingContainer, SingleValueEncodingContainer {
+protocol SingleValueInstanceDecodingContainer: SingleValueDecodingContainer {
     func decode<T>(_ type: T.Type) throws -> T
-    func encode<T>(_ value: T) throws
+}
+
+protocol SingleValueInstanceEncodingContainer: SingleValueEncodingContainer {
+    mutating func encode<T>(_ value: T) throws
 }
 
 public protocol InstanceCodable: Codable { }
@@ -25,395 +29,275 @@ enum InstanceCodingError: Error {
     case badType
 }
 
-//@propertyWrapper
-//struct Parameter<T>:  ContentInjectable, InstanceCodable {
-//    var _value: T?
-//
-//    var wrappedValue: T {
-//        get {
-//            guard let value = _value else {
-//                fatalError()
-//            }
-//            return value
-//        }
-//        set {
-//            _value = newValue
-//        }
-//    }
-//
-//    init() { }
-//
-//    mutating func inject(_ value: Content) {
-//        switch T.self {
-//        case is Int.Type:
-//            self._value = (value.int as! T)
-//        case is String.Type:
-//            self._value = (value.string as! T)
-//        case is Int?.Type:
-//            self._value = (value.optional as! T)
-//        case is SomeClass.Type:
-//            self._value = (value.reference as! T)
-//        default:
-//            fatalError()
-//        }
-//    }
-//
-//    init(from decoder: Decoder) throws {
-//        guard let ic = decoder as? InstanceCoder else {
-//            throw InstanceCodingError.instantializedUsingNonInstanceCoder
-//        }
-//
-//        let container = try ic.singleInstanceContainer()
-//        let injectedValue = try container.decode(Parameter<T>.self)
-//
-//        self = injectedValue
-//    }
-//
-//    func encode(to encoder: Encoder) throws {
-//        guard let ic = encoder as? InstanceCoder else {
-//            throw InstanceCodingError.encodedUsingNonInstanceCoder
-//        }
-//
-//        let container = try ic.singleInstanceContainer()
-//        try container.encode(self)
-//    }
-//}
-
-extension Property {
+extension InstanceCodable {
     public init(from decoder: Decoder) throws {
         guard let ic = decoder as? InstanceCoder else {
             throw InstanceCodingError.instantializedUsingNonInstanceCoder
         }
 
-        let container = try ic.singleInstanceContainer()
+        let container = try ic.singleInstanceDecodingContainer()
         self = try container.decode(Self.self)
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         guard let ic = encoder as? InstanceCoder else {
             throw InstanceCodingError.encodedUsingNonInstanceCoder
         }
 
-        let container = try ic.singleInstanceContainer()
+        var container = try ic.singleInstanceEncodingContainer()
         try container.encode(self)
-    }
-}
-
-typealias Activator = Mutator<Activatable>
-
-extension Activator {
-    convenience init() {
-        self.init { activatable in
-            activatable.activate()
-        }
     }
 }
 
 // MARK: Mutator
 
-class Mutator<Target>: InstanceCoder {
-    var codingPath: [CodingKey] = []
-    
-    var userInfo: [CodingUserInfoKey : Any] = [:]
-    
-    internal fileprivate(set) var store: [InstanceCodable] = []
-    
-    fileprivate var count: Int = 0
-    
-    fileprivate var mutation: (inout Target) throws -> Void
-    
-    init(_ mutation: @escaping (inout Target) throws -> Void) {
-        self.mutation = mutation
-    }
-    
-    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        KeyedEncodingContainer(KeyedInstanceContainer(injector: self))
-    }
-    
-    func unkeyedContainer() -> UnkeyedEncodingContainer {
-        UnkeyedInstanceEncodingContainer(injector: self)
-    }
-    
-    func singleValueContainer() -> SingleValueEncodingContainer {
-        InstanceContainer(injector: self)
-    }
-    
-    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
-        KeyedDecodingContainer(KeyedInstanceContainer(injector: self))
-    }
-    
-    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-        UnkeyedInstanceDecodingContainer(injector: self)
-    }
-    
-    func singleValueContainer() throws -> SingleValueDecodingContainer {
-        InstanceContainer(injector: self)
-    }
-    
-    func singleInstanceContainer() throws -> SingleValueInstanceContainer {
-        InstanceContainer(injector: self)
-    }
-    
-    func mutate(_ element: inout Target) throws {
-        try mutation(&element)
-    }
-    
-    func reset() {
-        self.count = 0
-    }
+private protocol InstanceCoderStorage {
+    var single: InstanceContainer.Value { get nonmutating set }
+
+    func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value)
+
+    func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value
 }
 
-// MARK: UnkeyedInstanceDecodingContainer
-
-struct UnkeyedInstanceDecodingContainer<Target>: UnkeyedDecodingContainer {
-    let injector: Mutator<Target>
-    
-    var codingPath: [CodingKey] {
-        get {
-            injector.codingPath
-        }
-        set {
-            injector.codingPath = newValue
-        }
-    }
-    
-    var count: Int? = nil
-    
-    var isAtEnd: Bool = false
-    
-    var currentIndex: Int = 0
-    
-    mutating func decodeNil() throws -> Bool {
-        false
-    }
-
-    mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
-        try injector.container(keyedBy: type)
-    }
-    
-    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
-        try injector.unkeyedContainer()
-    }
-    
-    mutating func superDecoder() throws -> Decoder {
-        injector
-    }
-    
-    mutating func decode<T>(_ type: T.Type) throws -> T {
-//        print("UnkeyedInstanceDecodingContainer.decode \(type)")
-//        print(injector.store)
-        guard T.self is InstanceCodable.Type else {
-            throw InstanceCodingError.notImplemented
-        }
-        
-        let next = injector.store[injector.count]
-        injector.count += 1
-        
-        guard let typed = next as? T else {
-            throw InstanceCodingError.badType
-        }
-        
-        if var element = typed as? Target {
-            try injector.mutate(&element)
-            return element as! T
-        } else {
-            return typed
-        }
-    }
-}
-
-// MARK: UnkeyedInstanceEncodingContainer
-
-struct UnkeyedInstanceEncodingContainer<Target>: UnkeyedEncodingContainer {
-    let injector: Mutator<Target>
-    
-    var codingPath: [CodingKey] {
-        get {
-            injector.codingPath
-        }
-        set {
-            injector.codingPath = newValue
-        }
-    }
-    
-    var count: Int = 0
-    
-    mutating func encodeNil() throws {
-        throw InstanceCodingError.notImplemented
-    }
-    
-    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        injector.container(keyedBy: keyType)
-    }
-    
-    mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-        injector.unkeyedContainer()
-    }
-    
-    mutating func superEncoder() -> Encoder {
-        injector
-    }
-    
-    mutating func encode<T>(_ value: T) throws {
-//        print("UnkeyedInstanceEncodingContainer.encode \(value)")
-        guard let typed = value as? InstanceCodable else {
-            throw InstanceCodingError.notImplemented
-        }
-        
-        injector.store.append(typed)
-    }
-}
-
+//class Mutator: InstanceCoder, InstanceCoderStorage {
+//    var codingPath: [CodingKey] = [] // implementing that could become the real struggle
+//
+//    var userInfo: [CodingUserInfoKey : Any] = [:]
+//
+//    private var store: [Any] = []
+//
+//    private var count: Int = -1
+//
+//    init() { }
+//
+//    fileprivate var single: InstanceContainer.Value {
+//        get {
+//            store[count == -1 ? store.count - 1 : count] as! InstanceContainer.Value
+//        }
+//        set {
+//            store[store.count - 1] = newValue as Any
+//        }
+//    }
+//
+//    fileprivate func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value {
+//        store[count == -1 ? store.count - 1 : count] as! KeyedInstanceContainer<K>.Value
+//    }
+//
+//    fileprivate func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value) {
+//        store[store.count - 1] = value
+//    }
+//
+//    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+//        store.append(KeyedInstanceContainer<Key>.Value(count: -1, array: []))
+//        return KeyedEncodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self))
+//    }
+//
+//    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
+//        count += 1
+//        return KeyedDecodingContainer(KeyedInstanceContainer(codingPath: self.codingPath, store: self))
+//    }
+//
+//    func singleInstanceEncodingContainer() throws -> SingleValueInstanceEncodingContainer {
+//        store.append(InstanceContainer.Value.none as Any)
+//        return InstanceContainer(store: self, codingPath: self.codingPath)
+//    }
+//
+//    func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer {
+//        count += 1
+//        return InstanceContainer(store: self, codingPath: self.codingPath)
+//    }
+//
+//    func unkeyedContainer() -> UnkeyedEncodingContainer {
+//        fatalError() // UnkeyedInstanceEncodingContainer(injector: self)
+//    }
+//
+//    func singleValueContainer() -> SingleValueEncodingContainer {
+//        fatalError() // think that won't be needed InstanceContainer(injector: self)
+//    }
+//
+//    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+//        fatalError() // UnkeyedInstanceDecodingContainer(injector: self)
+//    }
+//
+//    func singleValueContainer() throws -> SingleValueDecodingContainer {
+//        fatalError() // think that won't be needed InstanceContainer(injector: self)
+//    }
+//
+//    func reset() {
+//        self.count = 0
+//    }
+//}
+//
 // MARK: KeyedInstanceContainer
 
-struct KeyedInstanceContainer<K: CodingKey, Target>: KeyedEncodingContainerProtocol, KeyedDecodingContainerProtocol {
-    mutating func encodeNil(forKey key: K) throws {
-        throw InstanceCodingError.notImplemented
+private struct KeyedInstanceContainer<K: CodingKey>: KeyedEncodingContainerProtocol, KeyedDecodingContainerProtocol, InstanceCoderStorage {
+    enum Element {
+        case value(InstanceCodable?)
+        case container(Any)
     }
-    
-    mutating func encode<T>(_ value: T, forKey key: K) throws {
-//        print("KeyedInstanceContainer.encode \(value) forkey \(key)")
-        guard let typed = value as? InstanceCodable else {
-            throw InstanceCodingError.notImplemented
-        }
-        
-        injector.store.append(typed)
-    }
-    
-    var allKeys: [K] {
-//        print("allKeys")
-        return []
-    }
-    
-    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: K) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        injector.container(keyedBy: keyType)
-    }
-    
-    mutating func nestedUnkeyedContainer(forKey key: K) -> UnkeyedEncodingContainer {
-        injector.unkeyedContainer()
-    }
-    
-    mutating func superEncoder() -> Encoder {
-        injector
-    }
-    
-    mutating func superEncoder(forKey key: K) -> Encoder {
-        injector
-    }
-    
-    func contains(_ key: K) -> Bool {
-//        print("contains \(key)")
-        return false
-    }
-    
-    func decodeNil(forKey key: K) throws -> Bool {
-        false
-    }
-    
-    func decode<T>(_ type: T.Type, forKey key: K) throws -> T {
-//        print("KeyedInstanceContainer.decode \(type)")
-//        print(injector.store)
-        guard T.self is InstanceCodable.Type else {
-            throw InstanceCodingError.notImplemented
-        }
-        
-        let next = injector.store[injector.count]
-        injector.count += 1
-        
-        guard let typed = next as? T else {
-            throw InstanceCodingError.badType
-        }
-        
-        if var element = typed as? Target {
-            try injector.mutate(&element)
-            return element as! T
-        } else {
-            return typed
-        }
-    }
-    
-    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
-        try injector.container(keyedBy: type)
-    }
-    
-    func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
-        try injector.unkeyedContainer()
-    }
-    
-    func superDecoder() throws -> Decoder {
-        injector
-    }
-    
-    func superDecoder(forKey key: K) throws -> Decoder {
-        injector
-    }
-    
+
     typealias Key = K
-    
-    let injector: Mutator<Target>
-    
-    var codingPath: [CodingKey] {
+
+    typealias Value = (count: Int, array: [(key: K, value: Element)])
+
+    var codingPath: [CodingKey]
+
+    let store: InstanceCoderStorage
+
+    var count: Int {
         get {
-            injector.codingPath
+            store.getKeyed(K.self).count
         }
-        set {
-            injector.codingPath = newValue
+        nonmutating set {
+            store.setKeyed((newValue, store.getKeyed(K.self).array))
         }
+    }
+
+    var instances: [(key: K, value: Element)] {
+        get {
+            store.getKeyed(K.self).array
+        }
+        nonmutating set {
+            store.setKeyed((store.getKeyed(K.self).count, newValue))
+        }
+    }
+
+
+
+    var single: InstanceContainer.Value {
+        get {
+            guard case let .container(container) = instances[count == -1 ? instances.count -1 : count].value else {
+                fatalError()
+            }
+            return container as! InstanceContainer.Value
+        }
+        nonmutating set {
+            instances[instances.count - 1] = (instances[instances.count - 1].key, .container(newValue as Any))
+        }
+    }
+
+    func getKeyed<K: CodingKey>(_ type: K.Type) -> KeyedInstanceContainer<K>.Value {
+        guard case let .container(container) = instances[count == -1 ? instances.count -1 : count].value else {
+            fatalError()
+        }
+        return container as! KeyedInstanceContainer<K>.Value
+    }
+
+    func setKeyed<K: CodingKey>(_ value: KeyedInstanceContainer<K>.Value) {
+        instances[instances.count - 1] = (instances[instances.count - 1].key, .container(value as Any))
+    }
+
+
+
+    var allKeys: [K] {
+        instances.map(\.key)
+    }
+
+    func contains(_ key: K) -> Bool {
+        instances.contains(where: { (instanceKey, _) in
+            key.stringValue == instanceKey.stringValue
+        })
+    }
+
+    mutating func encodeNil(forKey key: K) throws {
+        instances.append((key, .value(nil)))
+    }
+
+    func decodeNil(forKey key: K) throws -> Bool {
+        count += 1
+        guard case let (foundKey, .value(value)) = instances[count], key.stringValue == foundKey.stringValue else {
+            fatalError()
+        }
+        return value == nil
+    }
+
+    mutating func encode<T>(_ value: T, forKey key: K) throws {
+        instances.append((key, .value((value as! InstanceCodable))))
+    }
+
+    func decode<T>(_ type: T.Type, forKey key: K) throws -> T {
+        count += 1
+        guard case let (foundKey, .value(.some(value))) = instances[count], key.stringValue == foundKey.stringValue else {
+            fatalError()
+        }
+        return value as! T
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: K) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        instances.append((key, .container(KeyedInstanceContainer<NestedKey>.Value(count: -1, array: []))))
+        return KeyedEncodingContainer(KeyedInstanceContainer<NestedKey>(codingPath: self.codingPath + [key], store: self))
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+        count += 1
+        return KeyedDecodingContainer(KeyedInstanceContainer<NestedKey>(codingPath: self.codingPath + [key], store: self))
+    }
+
+    mutating func superEncoder() -> Encoder {
+        fatalError()
+    }
+
+    mutating func superEncoder(forKey key: K) -> Encoder {
+        fatalError()
+    }
+
+    mutating func nestedUnkeyedContainer(forKey key: K) -> UnkeyedEncodingContainer {
+        fatalError()
+    }
+
+    func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
+        fatalError()
+    }
+
+    func superDecoder() throws -> Decoder {
+        fatalError()
+    }
+
+    func superDecoder(forKey key: K) throws -> Decoder {
+        fatalError()
     }
 }
 
 // MARK: InstanceContainer
 
-struct InstanceContainer<Target>: SingleValueInstanceContainer {
-    let injector: Mutator<Target>
-    
-    var codingPath: [CodingKey] {
+private struct InstanceContainer: SingleValueInstanceDecodingContainer, SingleValueInstanceEncodingContainer {
+    typealias Value = InstanceCodable?
+
+    let store: InstanceCoderStorage
+
+    var instance: Value {
         get {
-            injector.codingPath
+            store.single
         }
-        set {
-            injector.codingPath = newValue
+        nonmutating set {
+            store.single = newValue
         }
     }
-    
+
+    var codingPath: [CodingKey]
+
     func decode<T>(_ type: T.Type) throws -> T {
-//        print("InstanceContainer.decode \(type)")
-//        print(injector.store)
-        guard T.self is InstanceCodable.Type else {
-            throw InstanceCodingError.notImplemented
-        }
-        
-        let next = injector.store[injector.count]
-        injector.count += 1
-        
-        guard let typed = next as? T else {
+        guard let typed = instance as? T else {
             throw InstanceCodingError.badType
         }
-        
-        if var element = typed as? Target {
-            try injector.mutate(&element)
-            return element as! T
-        } else {
-            return typed
-        }
+
+        return typed
     }
-    
-    func encode<T>(_ value: T) throws {
-//        print("InstanceContainer.encode \(value)")
-//        print(injector.store)
+
+    mutating func encode<T>(_ value: T) throws {
         guard let typed = value as? InstanceCodable else {
             throw InstanceCodingError.notImplemented
         }
-        
-        injector.store.append(typed)
+
+        instance = typed
     }
-    
+
     func decodeNil() -> Bool {
-        false
+        instance == nil
     }
-    
+
     mutating func encodeNil() throws {
-        throw InstanceCodingError.notImplemented
+        instance = nil
     }
 }
 
@@ -430,5 +314,106 @@ struct InstanceContainer<Target>: SingleValueInstanceContainer {
 //        injector.valueToInject = content
 //        self = try InstanceCodableBasedHandler(from: injector)
 //        injector.reset()
+//    }
+//}
+//
+//// MARK: UnkeyedInstanceDecodingContainer
+//
+//struct UnkeyedInstanceDecodingContainer<Target>: UnkeyedDecodingContainer {
+//    let injector: Mutator<Target>
+//
+//    var codingPath: [CodingKey] {
+//        get {
+//            injector.codingPath
+//        }
+//        set {
+//            injector.codingPath = newValue
+//        }
+//    }
+//
+//    var count: Int? = nil
+//
+//    var isAtEnd: Bool = false
+//
+//    var currentIndex: Int = 0
+//
+//    mutating func decodeNil() throws -> Bool {
+//        false
+//    }
+//
+//    mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+//        try injector.container(keyedBy: type)
+//    }
+//
+//    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+//        try injector.unkeyedContainer()
+//    }
+//
+//    mutating func superDecoder() throws -> Decoder {
+//        injector
+//    }
+//
+//    mutating func decode<T>(_ type: T.Type) throws -> T {
+////        print("UnkeyedInstanceDecodingContainer.decode \(type)")
+////        print(injector.store)
+//        guard T.self is InstanceCodable.Type else {
+//            throw InstanceCodingError.notImplemented
+//        }
+//
+//        let next = injector.store[injector.count]
+//        injector.count += 1
+//
+//        guard let typed = next as? T else {
+//            throw InstanceCodingError.badType
+//        }
+//
+//        if var element = typed as? Target {
+//            try injector.mutate(&element)
+//            return element as! T
+//        } else {
+//            return typed
+//        }
+//    }
+//}
+//
+//// MARK: UnkeyedInstanceEncodingContainer
+//
+//struct UnkeyedInstanceEncodingContainer<Target>: UnkeyedEncodingContainer {
+//    let injector: Mutator<Target>
+//
+//    var codingPath: [CodingKey] {
+//        get {
+//            injector.codingPath
+//        }
+//        set {
+//            injector.codingPath = newValue
+//        }
+//    }
+//
+//    var count: Int = 0
+//
+//    mutating func encodeNil() throws {
+//        throw InstanceCodingError.notImplemented
+//    }
+//
+//    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+//        injector.container(keyedBy: keyType)
+//    }
+//
+//    mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+//        injector.unkeyedContainer()
+//    }
+//
+//    mutating func superEncoder() -> Encoder {
+//        injector
+//    }
+//
+//    mutating func encode<T>(_ value: T) throws {
+////        print("UnkeyedInstanceEncodingContainer.encode \(value)")
+//        guard let typed = value as? InstanceCodable else {
+//            throw InstanceCodingError.notImplemented
+//        }
+//
+//        injector.store.append(typed)
 //    }
 //}

--- a/Sources/Apodini/Properties/InstanceCodable.swift
+++ b/Sources/Apodini/Properties/InstanceCodable.swift
@@ -126,50 +126,6 @@ class FlatInstanceEncoder: InstanceEncoder {
     }
 }
 
-// MARK: FlatInstanceDecoder
-
-struct FlatInstanceDecoder: InstanceDecoder {
-    var codingPath: [CodingKey] = []
-    
-    var userInfo: [CodingUserInfoKey: Any] = [:]
-    
-    var store: [(String, Any)]
-    
-    private let counter: Counter
-    
-    init(_ store: [(String, Any)]) {
-        self.store = store
-        self.counter = ThreadSpecificCounter(count: store.count)
-    }
-    
-    fileprivate func next() -> Any {
-        store[counter.next()].1
-    }
-    
-    
-    // decoding
-    
-    func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer {
-        InstanceDecodingContainer(codingPath: self.codingPath, coder: self)
-    }
-    
-    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey {
-        KeyedDecodingContainer(KeyedInstanceDecodingContainer(codingPath: self.codingPath,
-                                                              coder: self))
-    }
-    
-    
-    // fatals
-    
-    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-        fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
-    }
-    
-    func singleValueContainer() throws -> SingleValueDecodingContainer {
-        fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
-    }
-}
-
 struct KeyedInstanceEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
     typealias Key = K
     
@@ -214,12 +170,6 @@ struct KeyedInstanceEncodingContainer<K: CodingKey>: KeyedEncodingContainerProto
         fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
     }
     
-    mutating func encode<T>(_ value: T, forKey key: K) throws {
-        // this should only be called for all the base-types, so never as we always end up with an
-        // `InstanceCodable` object
-        fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
-    }
-    
     mutating func nestedUnkeyedContainer(forKey key: K) -> UnkeyedEncodingContainer {
         fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
     }
@@ -229,6 +179,73 @@ struct KeyedInstanceEncodingContainer<K: CodingKey>: KeyedEncodingContainerProto
     }
     
     mutating func superEncoder(forKey key: K) -> Encoder {
+        fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
+    }
+}
+
+struct InstanceEncodingContainer: SingleValueInstanceEncodingContainer {
+    var codingPath: [CodingKey]
+    
+    let coder: FlatInstanceEncoder
+    
+    // encoding
+    
+    func encode<T>(_ value: T) throws {
+        guard T.self is _InstanceCodable.Type else {
+            fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
+        }
+        
+        coder.add(value)
+    }
+    
+    // fatals
+    
+    mutating func encodeNil() throws {
+        fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
+    }
+}
+
+
+// MARK: FlatInstanceDecoder
+
+struct FlatInstanceDecoder: InstanceDecoder {
+    var codingPath: [CodingKey] = []
+    
+    var userInfo: [CodingUserInfoKey: Any] = [:]
+    
+    var store: [(String, Any)]
+    
+    private let counter: Counter
+    
+    init(_ store: [(String, Any)]) {
+        self.store = store
+        self.counter = ThreadSpecificCounter(count: store.count)
+    }
+    
+    fileprivate func next() -> Any {
+        store[counter.next()].1
+    }
+    
+    
+    // decoding
+    
+    func singleInstanceDecodingContainer() throws -> SingleValueInstanceDecodingContainer {
+        InstanceDecodingContainer(codingPath: self.codingPath, coder: self)
+    }
+    
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey {
+        KeyedDecodingContainer(KeyedInstanceDecodingContainer(codingPath: self.codingPath,
+                                                              coder: self))
+    }
+    
+    
+    // fatals
+    
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
+    }
+    
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
         fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
     }
 }
@@ -284,28 +301,6 @@ struct KeyedInstanceDecodingContainer<K: CodingKey>: KeyedDecodingContainerProto
     }
     
     func superDecoder(forKey key: K) throws -> Decoder {
-        fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
-    }
-}
-
-struct InstanceEncodingContainer: SingleValueInstanceEncodingContainer {
-    var codingPath: [CodingKey]
-    
-    let coder: FlatInstanceEncoder
-    
-    // encoding
-    
-    func encode<T>(_ value: T) throws {
-        guard T.self is _InstanceCodable.Type else {
-            fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
-        }
-        
-        coder.add(value)
-    }
-    
-    // fatals
-    
-    mutating func encodeNil() throws {
         fatalError("FlatInstanceEncoder/FlatInstanceDecoder was used for encoding/decoding an object that is no valid 'PropertyIterable'.")
     }
 }

--- a/Sources/Apodini/Properties/ObservedObject.swift
+++ b/Sources/Apodini/Properties/ObservedObject.swift
@@ -6,7 +6,7 @@ import ApodiniUtils
 ///
 /// This is helpful for service-side streams or bidirectional communication.
 @propertyWrapper
-public struct ObservedObject<Element: ObservableObject>: Property {
+public struct ObservedObject<Element: ObservableObject>: InstanceCodable, Property {
     private struct Storage {
         var changed: Bool
         var element: Element

--- a/Sources/Apodini/Properties/ObservedObject.swift
+++ b/Sources/Apodini/Properties/ObservedObject.swift
@@ -6,7 +6,7 @@ import ApodiniUtils
 ///
 /// This is helpful for service-side streams or bidirectional communication.
 @propertyWrapper
-public struct ObservedObject<Element: ObservableObject>: InstanceCodable, Property {
+public struct ObservedObject<Element: ObservableObject>: _InstanceCodable, Property {
     private struct Storage {
         var changed: Bool
         var element: Element

--- a/Sources/Apodini/Properties/Parameter.swift
+++ b/Sources/Apodini/Properties/Parameter.swift
@@ -15,7 +15,7 @@ public enum ParameterOptionNameSpace { }
 
 /// The `@Parameter` property wrapper can be used to express input in `Components`
 @propertyWrapper
-public struct Parameter<Element: Codable>: Property, Identifiable, InstanceCodable {
+public struct Parameter<Element: Codable>: Property, Identifiable, _InstanceCodable {
     /// Keys for options that can be passed to an `@Parameter` property wrapper
     public typealias OptionKey<T: PropertyOption> = PropertyOptionKey<ParameterOptionNameSpace, T>
     /// Type erased options that can be passed to an `@Parameter` property wrapper

--- a/Sources/Apodini/Properties/Parameter.swift
+++ b/Sources/Apodini/Properties/Parameter.swift
@@ -15,7 +15,7 @@ public enum ParameterOptionNameSpace { }
 
 /// The `@Parameter` property wrapper can be used to express input in `Components`
 @propertyWrapper
-public struct Parameter<Element: Codable>: Property, Identifiable {
+public struct Parameter<Element: Codable>: Property, Identifiable, InstanceCodable {
     /// Keys for options that can be passed to an `@Parameter` property wrapper
     public typealias OptionKey<T: PropertyOption> = PropertyOptionKey<ParameterOptionNameSpace, T>
     /// Type erased options that can be passed to an `@Parameter` property wrapper

--- a/Sources/Apodini/Properties/Properties.swift
+++ b/Sources/Apodini/Properties/Properties.swift
@@ -13,7 +13,7 @@ import Foundation
 /// `Properties` can be used to e.g. delay the decision, which `Parameter`s are exported to startup-time.
 @dynamicMemberLookup
 @propertyWrapper
-public struct Properties: Property {
+public struct Properties: Property, InstanceCodable {
     internal var elements: [String: Property]
     
     internal var namingStrategy: ([String]) -> String? = Self.defaultNamingStrategy

--- a/Sources/Apodini/Properties/Property.swift
+++ b/Sources/Apodini/Properties/Property.swift
@@ -10,13 +10,13 @@ import Foundation
 
 /// This protocol is implemented by all of Apodini's property wrappers that are used access functionality or information on a handling `Component`.
 /// - Warning: Only structs can be a `Property`
-public protocol Property { }
+public protocol Property: Codable { }
 
 /// `DynamicProperty` allows for wrapping `Property`s while maintaining their functionality. By conforming a `struct` to `DynamicProperty`
 /// you make this `struct`'s properties discoverable to the Apodini runtime framework. This can be used to e.g. combine
 /// two property wrappers provided by the Apodini framework into one that merges their functionality
 /// - Warning: Only structs can be a `DynamicProperty`
-public protocol DynamicProperty: Property, Codable {
+public protocol DynamicProperty: Property {
     /// The `namingStrategy` is called when the framework decides to interact with one of
     /// the `DynamicProperty`'s properties. By default it assumes the label of this property to be the
     /// desired name of the property.

--- a/Sources/Apodini/Properties/Property.swift
+++ b/Sources/Apodini/Properties/Property.swift
@@ -10,13 +10,13 @@ import Foundation
 
 /// This protocol is implemented by all of Apodini's property wrappers that are used access functionality or information on a handling `Component`.
 /// - Warning: Only structs can be a `Property`
-public protocol Property: InstanceCodable { }
+public protocol Property { }
 
 /// `DynamicProperty` allows for wrapping `Property`s while maintaining their functionality. By conforming a `struct` to `DynamicProperty`
 /// you make this `struct`'s properties discoverable to the Apodini runtime framework. This can be used to e.g. combine
 /// two property wrappers provided by the Apodini framework into one that merges their functionality
 /// - Warning: Only structs can be a `DynamicProperty`
-public protocol DynamicProperty: Property {
+public protocol DynamicProperty: Property, Codable {
     /// The `namingStrategy` is called when the framework decides to interact with one of
     /// the `DynamicProperty`'s properties. By default it assumes the label of this property to be the
     /// desired name of the property.

--- a/Sources/Apodini/Properties/Property.swift
+++ b/Sources/Apodini/Properties/Property.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// This protocol is implemented by all of Apodini's property wrappers that are used access functionality or information on a handling `Component`.
 /// - Warning: Only structs can be a `Property`
-public protocol Property { }
+public protocol Property: InstanceCodable { }
 
 /// `DynamicProperty` allows for wrapping `Property`s while maintaining their functionality. By conforming a `struct` to `DynamicProperty`
 /// you make this `struct`'s properties discoverable to the Apodini runtime framework. This can be used to e.g. combine

--- a/Sources/Apodini/Properties/State.swift
+++ b/Sources/Apodini/Properties/State.swift
@@ -12,7 +12,7 @@ import ApodiniUtils
 /// `Response.final(_)`.
 /// - Note `State` has the same scope as the `Connection` available via `@Environment(\.connection)`
 @propertyWrapper
-public struct State<Element>: Property {
+public struct State<Element>: InstanceCodable, Property {
     internal var initializer: () -> Element
     
     private var storage: Box<Element>?

--- a/Sources/Apodini/Properties/State.swift
+++ b/Sources/Apodini/Properties/State.swift
@@ -12,7 +12,7 @@ import ApodiniUtils
 /// `Response.final(_)`.
 /// - Note `State` has the same scope as the `Connection` available via `@Environment(\.connection)`
 @propertyWrapper
-public struct State<Element>: InstanceCodable, Property {
+public struct State<Element>: _InstanceCodable, Property {
     internal var initializer: () -> Element
     
     private var storage: Box<Element>?

--- a/Sources/Apodini/Properties/Throws.swift
+++ b/Sources/Apodini/Properties/Throws.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// A property wrapper that can be used on `Handler`s to obtain `ApodiniError`s.
 @propertyWrapper
-public struct Throws: Property, InstanceCodable {
+public struct Throws: Property, _InstanceCodable {
     private let options: PropertyOptionSet<ErrorOptionNameSpace>
     
     private let `type`: ErrorType

--- a/Sources/Apodini/Properties/Throws.swift
+++ b/Sources/Apodini/Properties/Throws.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// A property wrapper that can be used on `Handler`s to obtain `ApodiniError`s.
 @propertyWrapper
-public struct Throws {
+public struct Throws: Property, InstanceCodable {
     private let options: PropertyOptionSet<ErrorOptionNameSpace>
     
     private let `type`: ErrorType

--- a/Sources/Apodini/Relationships/Modifier/DefaultRelationshipModifier.swift
+++ b/Sources/Apodini/Relationships/Modifier/DefaultRelationshipModifier.swift
@@ -8,7 +8,7 @@ struct DefaultRelationshipContextKey: OptionalContextKey {
     typealias Value = Void
 }
 
-public struct DefaultRelationshipModifier<H: Handler>: HandlerModifier {
+public struct DefaultRelationshipModifier<H: HandlerDefiningComponent>: HandlerModifier {
     public let component: H
 
     init(_ component: H) {
@@ -20,11 +20,11 @@ public struct DefaultRelationshipModifier<H: Handler>: HandlerModifier {
     }
 }
 
-extension Handler {
+extension HandlerDefiningComponent {
     /// A `defaultRelationship` modifier can be used to mark the return type - the `Content` type -
     /// as "default" for Relationships inferred from type information.
     ///
-    /// - Returns: The modified `Handler` with the `Content` being marked as default.
+    /// - Returns: The modified `HandlerDefiningComponent` with the `Content` being marked as default.
     public func defaultRelationship() -> DefaultRelationshipModifier<Self> {
         DefaultRelationshipModifier(self)
     }

--- a/Sources/Apodini/Relationships/Modifier/RelationshipDestinationModifier.swift
+++ b/Sources/Apodini/Relationships/Modifier/RelationshipDestinationModifier.swift
@@ -7,7 +7,7 @@ public struct RelationshipDestinationContextKey: ContextKey {
     public static var defaultValue: [Relationship] = []
 }
 
-public struct RelationshipDestinationModifier<H: _Handler>: HandlerModifier {
+public struct RelationshipDestinationModifier<H: HandlerDefiningComponent>: HandlerModifier {
     public let component: H
     let relationship: Relationship
 
@@ -21,7 +21,7 @@ public struct RelationshipDestinationModifier<H: _Handler>: HandlerModifier {
     }
 }
 
-extension _Handler {
+extension HandlerDefiningComponent {
     /// A `destination(of:)` modifier can be used to mark this `Handler`
     /// as the destination for the given `Relationship` instance.
     ///

--- a/Sources/Apodini/Relationships/Modifier/RelationshipDestinationModifier.swift
+++ b/Sources/Apodini/Relationships/Modifier/RelationshipDestinationModifier.swift
@@ -7,7 +7,7 @@ public struct RelationshipDestinationContextKey: ContextKey {
     public static var defaultValue: [Relationship] = []
 }
 
-public struct RelationshipDestinationModifier<H: Handler>: HandlerModifier {
+public struct RelationshipDestinationModifier<H: _Handler>: HandlerModifier {
     public let component: H
     let relationship: Relationship
 
@@ -21,7 +21,7 @@ public struct RelationshipDestinationModifier<H: Handler>: HandlerModifier {
     }
 }
 
-extension Handler {
+extension _Handler {
     /// A `destination(of:)` modifier can be used to mark this `Handler`
     /// as the destination for the given `Relationship` instance.
     ///

--- a/Sources/Apodini/Relationships/Modifier/RelationshipSourceModifier.swift
+++ b/Sources/Apodini/Relationships/Modifier/RelationshipSourceModifier.swift
@@ -7,7 +7,7 @@ public struct RelationshipSourceContextKey: ContextKey {
     public static var defaultValue: [Relationship] = []
 }
 
-public struct RelationshipSourceModifier<H: Handler>: HandlerModifier {
+public struct RelationshipSourceModifier<H: HandlerDefiningComponent>: HandlerModifier {
     public let component: H
     let relationship: Relationship
 
@@ -21,7 +21,7 @@ public struct RelationshipSourceModifier<H: Handler>: HandlerModifier {
     }
 }
 
-extension Handler {
+extension HandlerDefiningComponent {
     /// A `relationship(to:)` modifier can be used to mark this `Handler`
     /// as the source for the given `Relationship` instance.
     ///

--- a/Sources/Apodini/Relationships/Modifier/TypedRelationshipDestinationModifier.swift
+++ b/Sources/Apodini/Relationships/Modifier/TypedRelationshipDestinationModifier.swift
@@ -22,7 +22,7 @@ public struct TypedRelationshipDestinationModifier<H: Handler, To>: HandlerModif
     }
 }
 
-extension Handler {
+extension HandlerDefiningComponent {
     /// A `relationship(name:of:)` modifier can be used to indicate that this `Handler`
     /// has a relationship with the specified name to a `Handler` which returns the specified type.
     ///

--- a/Sources/Apodini/Relationships/Relationship.swift
+++ b/Sources/Apodini/Relationships/Relationship.swift
@@ -12,7 +12,7 @@ import Foundation
 /// Use the `Handler.destination(of:)` modifier to specify the destination for the Relationship.
 /// You can only define multiple destinations if the `Handler`s are located under the same path.
 public struct Relationship: Decodable {
-    internal let id = UUID()
+    internal let id: UUID
     internal let name: String
 
     /// Initializes a new `Relationship` instance with a given name.
@@ -22,5 +22,6 @@ public struct Relationship: Decodable {
     public init(name: String) {
         precondition(name != "self", "The relationship name 'self' is reserved.")
         self.name = name
+        self.id = UUID()
     }
 }

--- a/Sources/Apodini/Response/Response.swift
+++ b/Sources/Apodini/Response/Response.swift
@@ -59,7 +59,7 @@ extension Response {
     /// Maps an `Self.Content` to an `Response` with an other `Self.Content`
     /// - Parameter transform: The closure to transform the `Self.Content`
     /// - Returns: The transformed `Response`
-    public func map<T: Encodable>(_ transform: (Self.Content) throws -> (T)) rethrows -> Response<T> {
+    public func map<T: Encodable>(_ transform: (Self.BodyContent) throws -> (T)) rethrows -> Response<T> {
         Response<T>(status: status, content: try content.map(transform), information: information, connectionEffect: connectionEffect)
     }
 }

--- a/Sources/Apodini/Response/ResponseTransformable.swift
+++ b/Sources/Apodini/Response/ResponseTransformable.swift
@@ -14,13 +14,12 @@ import NIO
 public protocol ResponseTransformable {
     /// The `Encodable` type that is returned from a `handle()` method in a `Handler`.
     /// The type can be wrapped by an `EventLoopFuture` or an `Response`.
-    associatedtype Content: Encodable
+    associatedtype BodyContent: Encodable
     
     /// Transforms an `ResponseTransformable` into an `Response` to be processed by the Apodini
     /// - Parameter eventLoop: The `EventLoop` that should be used to transform the `ResponseTransformable` to an `Response` if needed
-    func transformToResponse(on eventLoop: EventLoop) -> EventLoopFuture<Response<Content>>
+    func transformToResponse(on eventLoop: EventLoop) -> EventLoopFuture<Response<BodyContent>>
 }
-
 
 // MARK: ResponseTransformable for Generic Encodable Types
 extension Encodable {
@@ -28,7 +27,7 @@ extension Encodable {
     /// 
     /// The `Encodable` type that is returned from a `handle()` method in a `Handler`.
     /// The type can be wrapped by an `EventLoopFuture` or an `Response`.
-    public typealias Content = Self
+    public typealias BodyContent = Self
     
     /// Default Implementation for types conforming to `ResponseTransformable`
     ///
@@ -42,9 +41,9 @@ extension Encodable {
 
 // MARK: EventLoopFuture + ResponseTransformable
 extension EventLoopFuture: ResponseTransformable where Value: ResponseTransformable {
-    public typealias Content = Value.Content
+    public typealias BodyContent = Value.BodyContent
     
-    public func transformToResponse(on eventLoop: EventLoop) -> EventLoopFuture<Response<Content>> {
+    public func transformToResponse(on eventLoop: EventLoop) -> EventLoopFuture<Response<BodyContent>> {
         self.hop(to: eventLoop)
             .flatMap { value in
                 value.transformToResponse(on: eventLoop)
@@ -57,7 +56,7 @@ extension EventLoopFuture where Value == Void {
     ///
     /// If you want to return a more elaborate message to the client you should `map` the `EventLoopFuture` to a custom type conforming to `Encodable`.
     /// - Parameter status: The status that should be passed to the client
-    /// - Returns: Returns an `EventLoopFuture` containing an Apodini `Response` type. The `Content`type is `Empty` and the response does not contain any instance that will be encoded in the response to the client.
+    /// - Returns: Returns an `EventLoopFuture` containing an Apodini `Response` type. The `BodyContent`type is `Empty` and the response does not contain any instance that will be encoded in the response to the client.
     public func transform(to status: Status = .noContent) -> EventLoopFuture<Status> {
         map { _ in
             status
@@ -82,7 +81,7 @@ extension Double: ResponseTransformable {}
 extension Float: ResponseTransformable {}
 extension Bool: ResponseTransformable {}
 extension UUID: ResponseTransformable {}
-extension Optional: ResponseTransformable where Wrapped: Encodable {}
+extension Optional: ResponseTransformable where Wrapped: Encodable { }
 extension Array: ResponseTransformable where Element: Encodable {}
 extension Set: ResponseTransformable where Element: Encodable {}
 extension Dictionary: ResponseTransformable where Key: Encodable, Value: Encodable {}

--- a/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
+++ b/Sources/Apodini/Semantic Model Builder/InterfaceExporter/InterfaceExporter.swift
@@ -29,7 +29,7 @@ public protocol InterfaceExporter {
     ///
     /// - Parameter endpoint: The `Endpoint` which is to be exported.
     /// - Returns: `EndpointExportOutput` which is defined by the `InterfaceExporter`.
-    func export<H: Handler>(blob endpoint: Endpoint<H>) -> EndpointExportOutput where H.Response.Content == Blob
+    func export<H: Handler>(blob endpoint: Endpoint<H>) -> EndpointExportOutput where H.Response.BodyContent == Blob
 
     /// This optional method can be defined to export a `EndpointParameter`.
     /// It is called for every `EndpointParameter` on an `Endpoint` when calling `Endpoint.exportParameters(...)`.

--- a/Sources/Apodini/Semantic Model Builder/KnowledgeSources/HandlerKnowledge.swift
+++ b/Sources/Apodini/Semantic Model Builder/KnowledgeSources/HandlerKnowledge.swift
@@ -20,7 +20,7 @@ public struct HandleReturnType: HandlerKnowledgeSource {
     public let type: Encodable.Type
     
     public init<H, B>(from handler: H, _ blackboard: B) throws where H: Handler, B: Blackboard {
-        self.type = H.Response.Content.self
+        self.type = H.Response.BodyContent.self
     }
 }
 

--- a/Sources/Apodini/Semantic Model Builder/Model/Endpoint.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/Endpoint.swift
@@ -97,7 +97,7 @@ private protocol BlobEndpoint {
     func exportBlobEndpoint<I: InterfaceExporter>(on exporter: I) -> I.EndpointExportOutput
 }
 
-extension Endpoint: BlobEndpoint where H.Response.Content == Blob {
+extension Endpoint: BlobEndpoint where H.Response.BodyContent == Blob {
     func exportBlobEndpoint<I: InterfaceExporter>(on exporter: I) -> I.EndpointExportOutput {
         exporter.export(blob: self)
     }

--- a/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
+++ b/Sources/Apodini/Semantic Model Builder/SemanticModelBuilder.swift
@@ -75,7 +75,7 @@ private protocol IdentifiableHandlerATRVisitorHelper: AssociatedTypeRequirements
 
 private struct TestHandlerType: IdentifiableHandler {
     typealias Response = Never
-    let handlerId = ScopedHandlerIdentifier<Self>("main")
+    @Binding var handlerId = ScopedHandlerIdentifier<Self>("main")
 }
 
 extension IdentifiableHandlerATRVisitorHelper {

--- a/Sources/Apodini/Semantic Model Builder/Traversable.swift
+++ b/Sources/Apodini/Semantic Model Builder/Traversable.swift
@@ -411,28 +411,6 @@ extension Delegate: Traversable {
     }
 }
 
-extension Delegate.DelegateModel: Traversable {
-    func execute<Target>(_ operation: (Target, String) throws -> Void, using names: [String]) rethrows {
-        switch self {
-        case let .codable(decoder):
-            try decoder.execute(operation, using: names)
-        case let .legacy(delegate):
-            try Apodini.execute(operation, on: delegate, using: names)
-        }
-    }
-    
-    mutating func apply<Target>(_ mutation: (inout Target, String) throws -> Void, using names: [String]) rethrows {
-        switch self {
-        case var .codable(decoder):
-            try decoder.apply(mutation, using: names)
-            self = .codable(decoder)
-        case var .legacy(delegate):
-            try Apodini.apply(mutation, to: &delegate, using: names)
-            self = .legacy(delegate)
-        }
-    }
-}
-
 // MARK: Helpers
 
 private extension Runtime.PropertyInfo {

--- a/Sources/Apodini/Semantic Model Builder/Traversable.swift
+++ b/Sources/Apodini/Semantic Model Builder/Traversable.swift
@@ -411,6 +411,28 @@ extension Delegate: Traversable {
     }
 }
 
+extension Delegate.DelegateModel: Traversable {
+    func execute<Target>(_ operation: (Target, String) throws -> Void, using names: [String]) rethrows {
+        switch self {
+        case let .codable(decoder):
+            try decoder.execute(operation, using: names)
+        case let .legacy(delegate):
+            try Apodini.execute(operation, on: delegate, using: names)
+        }
+    }
+    
+    mutating func apply<Target>(_ mutation: (inout Target, String) throws -> Void, using names: [String]) rethrows {
+        switch self {
+        case var .codable(decoder):
+            try decoder.apply(mutation, using: names)
+            self = .codable(decoder)
+        case var .legacy(delegate):
+            try Apodini.apply(mutation, to: &delegate, using: names)
+            self = .legacy(delegate)
+        }
+    }
+}
+
 // MARK: Helpers
 
 private extension Runtime.PropertyInfo {

--- a/Sources/Apodini/Semantic Model Builder/Traversable.swift
+++ b/Sources/Apodini/Semantic Model Builder/Traversable.swift
@@ -180,8 +180,6 @@ private func execute<Element, Target>(
 
         switch child {
         case let target as Target:
-            assert(((try? typeInfo(of: property.type).kind) ?? .none) != .class, "\(Target.self) \(property.name) on element \(info.name) must not be a class")
-            
             try operation(target, (element as? DynamicProperty)?.namingStrategy(names + [property.name]) ?? property.name)
         case let dynamicProperty as DynamicProperty:
             assert(((try? typeInfo(of: property.type).kind) ?? .none) != .class, "DynamicProperty \(property.name) on element \(info.name) must not be a class")
@@ -228,8 +226,6 @@ private func apply<Element, Target>(
 
         switch child {
         case var target as Target:
-            assert(((try? typeInfo(of: property.type).kind) ?? .none) != .class, "\(Target.self) \(property.name) on element \(info.name) must not be a class")
-            
             try mutation(&target, (element as? DynamicProperty)?.namingStrategy(names + [property.name]) ?? property.name)
             let elem = element
             property.unsafeSet(
@@ -289,15 +285,13 @@ extension Properties: Traversable {
         for (name, element) in self {
             switch element {
             case let target as Target:
-                assert((Mirror(reflecting: element).displayStyle) == .struct, "\(element.self) \(name) on Properties must not be a class")
-                
                 try operation(target, self.namingStrategy(names + [name]) ?? name)
             case let dynamicProperty as DynamicProperty:
-                assert((Mirror(reflecting: element).displayStyle) == .struct, "DynamicProperty \(name) on Properties must not be a class")
+                assert((Mirror(reflecting: element).displayStyle) != .class, "DynamicProperty \(name) on Properties must not be a class")
                 
                 try dynamicProperty.execute(operation, using: names + [name])
             case let traversable as Traversable:
-                assert((Mirror(reflecting: element).displayStyle) == .struct, "Traversable \(name) on Properties must not be a class")
+                assert((Mirror(reflecting: element).displayStyle) != .class, "Traversable \(name) on Properties must not be a class")
             
                 try traversable.execute(operation, using: names + [name])
             default:
@@ -310,8 +304,6 @@ extension Properties: Traversable {
         for (name, element) in self {
             switch element {
             case var target as Target:
-                assert((Mirror(reflecting: element).displayStyle) == .struct, "\(element.self) \(name) on Properties must not be a class")
-    
                 try mutation(&target, self.namingStrategy(names + [name]) ?? name)
                 self.elements[name] = target as? Property
             case var dynamicProperty as DynamicProperty:
@@ -378,7 +370,6 @@ extension Delegate: Traversable {
         try Apodini.apply(mutation, to: &delegate, using: names)
     }
 }
-
 
 // MARK: Helpers
 

--- a/Sources/Apodini/Semantic Model Builder/Traversable.swift
+++ b/Sources/Apodini/Semantic Model Builder/Traversable.swift
@@ -367,7 +367,7 @@ extension FlatInstanceDecoder: Traversable {
 
 extension Delegate: Traversable {
     func execute<Target>(_ operation: (Target, String) throws -> Void, using names: [String]) rethrows {
-        let delegate = storage?.value.delegate ?? delegateModel
+        let delegate = storage?.value.delegateModel ?? delegateModel
         
         // we set the optionality of all delegated parameters according to the delegates optionality
         if Target.self == AnyParameter.self {
@@ -385,10 +385,10 @@ extension Delegate: Traversable {
     }
 
     mutating func apply<Target>(_ mutation: (inout Target, String) throws -> Void, using names: [String]) rethrows {
-        var delegate = storage?.value.delegate ?? delegateModel
+        var delegate = storage?.value.delegateModel ?? delegateModel
         defer {
             if let storage = self.storage {
-                storage.value.delegate = delegate
+                storage.value.delegateModel = delegate
             } else {
                 delegateModel = delegate
             }

--- a/Sources/Apodini/Semantic Model Builder/Traversable.swift
+++ b/Sources/Apodini/Semantic Model Builder/Traversable.swift
@@ -323,6 +323,11 @@ extension Properties: Traversable {
     }
 }
 
+// MARK: InstanceCoder
+
+
+
+
 // MARK: Delegate
 
 extension Delegate: Traversable {

--- a/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
+++ b/Sources/Apodini/SyntaxTreeVisitor/SyntaxTreeVisitor.swift
@@ -97,7 +97,7 @@ public class SyntaxTreeVisitor: HandlerVisitor {
         // across multiple runs of an Apodini web service.
         addContext(HandlerIndexPath.ContextKey.self, value: formHandlerIndexPathForCurrentNode(), scope: .current)
         
-        let responseType = H.Response.Content.self
+        let responseType = H.Response.BodyContent.self
 
         // Content Metadata is currently added to the Context of the Handler.
         // Also, we currently do not recursively parse properties

--- a/Sources/ApodiniDatabase/FileHandlers/MultipleDownloader.swift
+++ b/Sources/ApodiniDatabase/FileHandlers/MultipleDownloader.swift
@@ -19,14 +19,14 @@ public struct MultipleDownloader: Handler {
     @Parameter(.http(.path))
     var fileName: String
     
-    private var config: DownloadConfiguration
+    @Binding private var config: DownloadConfiguration
     
     /// Create a new `Downloader` with a customizable `DownloadConfiguration`.
     ///
     /// - parameters:
     ///     - config: A  `DownloadConfiguration` object
     public init(_ config: DownloadConfiguration) {
-        self.config = config
+        self._config = .constant(config)
     }
     
     public func handle() throws -> EventLoopFuture<[File]> {

--- a/Sources/ApodiniDatabase/FileHandlers/SingleDownloader.swift
+++ b/Sources/ApodiniDatabase/FileHandlers/SingleDownloader.swift
@@ -20,14 +20,14 @@ public struct SingleDownloader: Handler {
     @Parameter(.http(.path))
     var fileName: String
     
-    private var config: DownloadConfiguration
+    @Binding private var config: DownloadConfiguration
     
     /// Create a new `Downloader` with a customizable `DownloadConfiguration`.
     ///
     /// - parameters:
     ///     - config: A  `DownloadConfiguration` object
     public init(_ config: DownloadConfiguration) {
-        self.config = config
+        self._config = .constant(config)
     }
     
     public func handle() throws -> EventLoopFuture<File> {

--- a/Sources/ApodiniDatabase/FileHandlers/Uploader.swift
+++ b/Sources/ApodiniDatabase/FileHandlers/Uploader.swift
@@ -17,14 +17,14 @@ public struct Uploader: Handler {
     @Parameter
     private var file: File
     
-    private var config: UploadConfiguration
+    @Binding private var config: UploadConfiguration
     
     /// Create a new `Uploader` with a customizable `UploadConfiguration`.
     ///
     /// - parameters:
     ///     - config: A  `UploadConfiguration` object
     public init(_ config: UploadConfiguration) {
-        self.config = config
+        self._config = .constant(config)
     }
     
     public func handle() throws -> EventLoopFuture<Response<String>> {

--- a/Sources/ApodiniDatabase/Handlers/Read/ReadAll.swift
+++ b/Sources/ApodiniDatabase/Handlers/Read/ReadAll.swift
@@ -19,12 +19,13 @@ public struct ReadAll<Model: DatabaseModel>: Handler {
     private var dynamics: [String: Apodini.Property]
     
     public init() {
-        var dynamicValues: [String: Parameter<TypeContainer?>] = [:]
+        var properties = Properties()
         let infos = QueryBuilder.info(for: Model.self)
         for info in infos {
-            dynamicValues[info.key.description] = QueryBuilder<Model>.parameter(info.value)
+            properties.with(QueryBuilder<Model>.parameter(info.value), named: info.key.description) as Void
         }
-        _dynamics = Properties(wrappedValue: dynamicValues)
+        
+        _dynamics = properties
     }
 
     public func handle() -> EventLoopFuture<[Model]> {

--- a/Sources/ApodiniDeploy/ApodiniDeployExporterConfiguration.swift
+++ b/Sources/ApodiniDeploy/ApodiniDeployExporterConfiguration.swift
@@ -90,7 +90,7 @@ public struct DeploymentOptionsModifier<C: Component>: Modifier {
     }
 }
 
-extension DeploymentOptionsModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where Self.ModifiedComponent: _Handler {
+extension DeploymentOptionsModifier: HandlerDefiningComponent, HandlerModifier, HandlerMetadataNamespace where Self.ModifiedComponent: HandlerDefiningComponent {
     public typealias Response = ModifiedComponent.Response
 }
 

--- a/Sources/ApodiniDeploy/ApodiniDeployExporterConfiguration.swift
+++ b/Sources/ApodiniDeploy/ApodiniDeployExporterConfiguration.swift
@@ -90,7 +90,7 @@ public struct DeploymentOptionsModifier<C: Component>: Modifier {
     }
 }
 
-extension DeploymentOptionsModifier: Handler, HandlerModifier, HandlerMetadataNamespace where Self.ModifiedComponent: Handler {
+extension DeploymentOptionsModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where Self.ModifiedComponent: _Handler {
     public typealias Response = ModifiedComponent.Response
 }
 

--- a/Sources/ApodiniDeploy/ApodiniDeployExporterConfiguration.swift
+++ b/Sources/ApodiniDeploy/ApodiniDeployExporterConfiguration.swift
@@ -90,7 +90,8 @@ public struct DeploymentOptionsModifier<C: Component>: Modifier {
     }
 }
 
-extension DeploymentOptionsModifier: HandlerDefiningComponent, HandlerModifier, HandlerMetadataNamespace where Self.ModifiedComponent: HandlerDefiningComponent {
+extension DeploymentOptionsModifier: HandlerDefiningComponent, HandlerModifier, HandlerMetadataNamespace
+where Self.ModifiedComponent: HandlerDefiningComponent {
     public typealias Response = ModifiedComponent.Response
 }
 

--- a/Sources/ApodiniDeploy/InternalInvocationResponder.swift
+++ b/Sources/ApodiniDeploy/InternalInvocationResponder.swift
@@ -47,7 +47,7 @@ struct InternalInvocationResponder<H: Handler>: Vapor.Responder {
             internalInterfaceExporter: internalInterfaceExporter,
             on: vaporRequest.eventLoop
         )
-        .map { (handlerResponse: H.Response.Content) -> Vapor.Response in
+        .map { (handlerResponse: H.Response.BodyContent) -> Vapor.Response in
             let vaporResponse = Vapor.Response(status: .ok)
             let encodedHandlerResponse: Data
             do {

--- a/Sources/ApodiniDeployBuildSupport/InvocableHandler.swift
+++ b/Sources/ApodiniDeployBuildSupport/InvocableHandler.swift
@@ -11,7 +11,7 @@ import Apodini
 
 /// An `InvocableHandler` is a `Handler` which can be invoked from within another handler's `handle()` function.
 /// - [Reference](https://github.com/Apodini/Apodini/blob/develop/Documentation/Components/Inter-Component%20Communication.md)
-public protocol InvocableHandler: IdentifiableHandler where Self.Response.Content: Decodable {
+public protocol InvocableHandler: IdentifiableHandler where Self.Response.BodyContent: Decodable {
     /// The protocol a custom arguments storage type has to conform to
     typealias ArgumentsStorageProtocol = InvocableHandlerArgumentsStorageProtocol
     /// The type of this handler's arguments storage object

--- a/Sources/ApodiniDeployRuntimeSupport/DeploymentProviderRuntime.swift
+++ b/Sources/ApodiniDeployRuntimeSupport/DeploymentProviderRuntime.swift
@@ -53,7 +53,7 @@ public protocol DeploymentProviderRuntime: AnyObject {
     /// It can also re-delegate this responsibility back to the caller.
     func handleRemoteHandlerInvocation<H: InvocableHandler>(
         _ invocation: HandlerInvocation<H>
-    ) throws -> RemoteHandlerInvocationRequestResponse<H.Response.Content>
+    ) throws -> RemoteHandlerInvocationRequestResponse<H.Response.BodyContent>
 }
 
 

--- a/Sources/ApodiniDeployTestWebService/ApodiniDeployTestWebService.swift
+++ b/Sources/ApodiniDeployTestWebService/ApodiniDeployTestWebService.swift
@@ -15,12 +15,12 @@ struct WebService: Apodini.WebService {
         Group("aws_rand") {
             TextHandler("")
                 .operation(.create)
-            AWS_RandomNumberGenerator(handlerId: .main)
+            AWS_RandomNumberGenerator(handlerId: .constant(.main))
         }.formDeploymentGroup(withId: "group_aws_rand")
         Group("aws_rand2") {
             TextHandler("")
                 .operation(.create)
-            AWS_RandomNumberGenerator(handlerId: .other)
+            AWS_RandomNumberGenerator(handlerId: .constant(.other))
         }.formDeploymentGroup(withId: "group_aws_rand2")
         Group("aws_greet") {
             AWS_Greeter()

--- a/Sources/ApodiniDeployTestWebService/Handler.swift
+++ b/Sources/ApodiniDeployTestWebService/Handler.swift
@@ -44,7 +44,7 @@ struct LH_TextMut: InvocableHandler {
     class HandlerIdentifier: ScopedHandlerIdentifier<LH_TextMut> {
         static let main = HandlerIdentifier("main")
     }
-    let handlerId: HandlerIdentifier = .main
+    @Binding var handlerId: HandlerIdentifier = .main
     
     @Parameter var text: String
     
@@ -87,8 +87,8 @@ struct AWS_RandomNumberGenerator: InvocableHandler, HandlerWithDeploymentOptions
         static let main = HandlerIdentifier("main")
         static let other = HandlerIdentifier("other")
     }
-    let handlerId: HandlerIdentifier
-    let ugh: Int = 12
+    @Binding var handlerId: HandlerIdentifier
+    @Binding var ugh: Int = 12
     
     @Parameter var lowerBound: Int = 0
     @Parameter var upperBound: Int = .max

--- a/Sources/ApodiniExtension/Evaluation/OneOffEvaluation.swift
+++ b/Sources/ApodiniExtension/Evaluation/OneOffEvaluation.swift
@@ -19,7 +19,7 @@ public extension Request {
     /// Evaluates this `Request` on the given `handler` with the given `state` and returns the
     /// resulting `Response` future.
     func evaluate<H: Handler>(on handler: inout Delegate<H>, _ state: ConnectionState = .end)
-        -> EventLoopFuture<Response<H.Response.Content>> {
+        -> EventLoopFuture<Response<H.Response.BodyContent>> {
         _Internal.prepareIfNotReady(&handler)
         return handler.evaluate(using: self, with: state)
     }
@@ -27,8 +27,8 @@ public extension Request {
     /// Evaluates this `Request` on the given `handler` with the given `state` and returns the
     /// resulting ``ResponseWithRequest``
     func evaluate<H: Handler>(on handler: inout Delegate<H>, _ state: ConnectionState = .end)
-        -> EventLoopFuture<ResponseWithRequest<H.Response.Content>> {
-        self.evaluate(on: &handler, state).map { (response: Response<H.Response.Content>) in
+        -> EventLoopFuture<ResponseWithRequest<H.Response.BodyContent>> {
+        self.evaluate(on: &handler, state).map { (response: Response<H.Response.BodyContent>) in
             ResponseWithRequest(response: response, request: self)
         }
     }
@@ -40,7 +40,7 @@ internal extension Delegate where D: Handler {
     }
     
     func evaluate(using request: Request, with state: ConnectionState = .end)
-        -> EventLoopFuture<Response<D.Response.Content>> {
+        -> EventLoopFuture<Response<D.Response.BodyContent>> {
         request.eventLoop.makeSucceededVoidFuture().flatMap {
             do {
                 let result: D.Response = try self.evaluate(using: request, with: state)
@@ -52,7 +52,7 @@ internal extension Delegate where D: Handler {
     }
     
     func evaluate(_ trigger: TriggerEvent, using request: Request, with state: ConnectionState = .end)
-        -> EventLoopFuture<Response<D.Response.Content>> {
+        -> EventLoopFuture<Response<D.Response.BodyContent>> {
         self.setChanged(to: true, reason: trigger)
         
         guard !trigger.cancelled else {

--- a/Sources/ApodiniExtension/Evaluation/StatefulEvaluation.swift
+++ b/Sources/ApodiniExtension/Evaluation/StatefulEvaluation.swift
@@ -195,7 +195,8 @@ extension Publisher where Output: Request {
         }
     }
     
-    func evaluateAndReturnRequest<H: Handler>(on handler: inout Delegate<H>) -> Publishers.SyncMap<Self, ResponseWithRequest<H.Response.BodyContent>> {
+    func evaluateAndReturnRequest<H: Handler>(on handler: inout Delegate<H>)
+        -> Publishers.SyncMap<Self, ResponseWithRequest<H.Response.BodyContent>> {
         _Internal.prepareIfNotReady(&handler)
         let preparedHandler = handler
         

--- a/Sources/ApodiniExtension/Evaluation/StatefulEvaluation.swift
+++ b/Sources/ApodiniExtension/Evaluation/StatefulEvaluation.swift
@@ -126,7 +126,7 @@ extension CancellablePublisher where Output == Event {
     /// does not follow rules for a valid sequence of ``Event``s as defined on ``Event``, the
     /// `Publisher` might crash at runtime.
     public func evaluate<H: Handler>(on handler: inout Delegate<H>)
-        -> CancellablePublisher<AnyPublisher<Result<Response<H.Response.Content>, Error>, Self.Failure>> {
+        -> CancellablePublisher<AnyPublisher<Result<Response<H.Response.BodyContent>, Error>, Self.Failure>> {
         var lastRequest: Request?
         _Internal.prepareIfNotReady(&handler)
         let preparedHandler = handler
@@ -147,7 +147,7 @@ extension CancellablePublisher where Output == Event {
                 return event
             }
         }
-        .syncMap { (event: Event) -> EventLoopFuture<Response<H.Response.Content>> in
+        .syncMap { (event: Event) -> EventLoopFuture<Response<H.Response.BodyContent>> in
             switch event {
             case let .request(request):
                 lastRequest = request
@@ -186,7 +186,7 @@ extension CancellablePublisher {
 // MARK: Handling Pure Request Evaluation
 
 extension Publisher where Output: Request {
-    func evaluate<H: Handler>(on handler: inout Delegate<H>) -> Publishers.SyncMap<Self, Response<H.Response.Content>> {
+    func evaluate<H: Handler>(on handler: inout Delegate<H>) -> Publishers.SyncMap<Self, Response<H.Response.BodyContent>> {
         _Internal.prepareIfNotReady(&handler)
         let preparedHandler = handler
         
@@ -195,12 +195,12 @@ extension Publisher where Output: Request {
         }
     }
     
-    func evaluateAndReturnRequest<H: Handler>(on handler: inout Delegate<H>) -> Publishers.SyncMap<Self, ResponseWithRequest<H.Response.Content>> {
+    func evaluateAndReturnRequest<H: Handler>(on handler: inout Delegate<H>) -> Publishers.SyncMap<Self, ResponseWithRequest<H.Response.BodyContent>> {
         _Internal.prepareIfNotReady(&handler)
         let preparedHandler = handler
         
         return self.syncMap { request in
-            preparedHandler.evaluate(using: request, with: .open).map { (response: Response<H.Response.Content>) in
+            preparedHandler.evaluate(using: request, with: .open).map { (response: Response<H.Response.BodyContent>) in
                 ResponseWithRequest(response: response, request: request)
             }
         }

--- a/Sources/ApodiniExtension/KnowledgeSources/Delegate.swift
+++ b/Sources/ApodiniExtension/KnowledgeSources/Delegate.swift
@@ -1,0 +1,21 @@
+//
+//  Delegate.swift
+//  
+//
+//  Created by Max Obermeier on 09.07.21.
+//
+
+import Foundation
+import Apodini
+
+extension Delegate: KnowledgeSource where D: Handler {
+    public init<B>(_ blackboard: B) throws where B : Blackboard {
+        self = Delegate(blackboard[EndpointSource<D>.self].handler, .required)
+    }
+}
+
+public extension Endpoint {
+    var delegate: Delegate<H> {
+        self[Delegate<H>.self]
+    }
+}

--- a/Sources/ApodiniExtension/KnowledgeSources/Delegate.swift
+++ b/Sources/ApodiniExtension/KnowledgeSources/Delegate.swift
@@ -9,12 +9,15 @@ import Foundation
 import Apodini
 
 extension Delegate: KnowledgeSource where D: Handler {
-    public init<B>(_ blackboard: B) throws where B : Blackboard {
+    public init<B>(_ blackboard: B) throws where B: Blackboard {
         self = Delegate(blackboard[EndpointSource<D>.self].handler, .required)
     }
 }
 
 public extension Endpoint {
+    /// The a pre-prepared `Delegate` to be used for evaluating `Request`s on this `Endpoint`.
+    ///
+    /// - Note: Copy this instance to to your local connection-context.
     var delegate: Delegate<H> {
         self[Delegate<H>.self]
     }

--- a/Sources/ApodiniExtension/LegacyInterfaceExporter.swift
+++ b/Sources/ApodiniExtension/LegacyInterfaceExporter.swift
@@ -34,7 +34,7 @@ public protocol LegacyInterfaceExporter: InterfaceExporter {
 
 public extension LegacyInterfaceExporter {
     /// The default implementation for exporting Apodini `Blob` for legacy exporters is to export them as a normal endpoint.
-    func export<H>(blob endpoint: Endpoint<H>) -> EndpointExportOutput where H: Handler, H.Response.Content == Blob {
+    func export<H>(blob endpoint: Endpoint<H>) -> EndpointExportOutput where H: Handler, H.Response.BodyContent == Blob {
         export(endpoint)
     }
 }

--- a/Sources/ApodiniExtension/RequestDecoding/DecodingStrategy/DecodingStrategy.swift
+++ b/Sources/ApodiniExtension/RequestDecoding/DecodingStrategy/DecodingStrategy.swift
@@ -18,7 +18,7 @@ import ApodiniUtils
 /// A ``DecodingStrategy`` can be used to transform a certain ``Input`` to an
 /// Apodini `Request`.  While the ``DecodingStrategy`` only helps implementing
 /// the Apodini `Request/retrieveParameter(_:)`, a ``RequestBasis`` can
-/// be used to provide the missing information. This proccess is implemented in
+/// be used to provide the missing information. This process is implemented in
 /// ``DecodingStrategy/decodeRequest(from:with:with:)``.
 public protocol DecodingStrategy {
     /// The type which the ``ParameterDecodingStrategy``s returned by ``strategy(for:)``

--- a/Sources/ApodiniExtension/RequestDecoding/ParameterDecodingStrategy/DecodingPattern.swift
+++ b/Sources/ApodiniExtension/RequestDecoding/ParameterDecodingStrategy/DecodingPattern.swift
@@ -51,24 +51,6 @@ internal class FieldName {
     }
 }
 
-extension String: CodingKey {
-    public init?(intValue: Int) {
-        self = String(describing: intValue)
-    }
-    
-    public init?(stringValue: String) {
-        self = stringValue
-    }
-    
-    public var stringValue: String {
-        self
-    }
-    
-    public var intValue: Int? {
-        Int(self)
-    }
-}
-
 
 /// - Note: Only works with ``IndexedNamedChildPatternStrategy``
 public struct DynamicIndexPattern<E: DecodingPattern>: DecodingPattern {

--- a/Sources/ApodiniGRPC/GRPCMethodNameModifier.swift
+++ b/Sources/ApodiniGRPC/GRPCMethodNameModifier.swift
@@ -11,7 +11,7 @@ struct GRPCMethodNameContextKey: OptionalContextKey {
     typealias Value = String
 }
 
-public struct GRPCMethodModifier<H: Handler>: HandlerModifier {
+public struct GRPCMethodModifier<H: _Handler>: HandlerModifier {
     public let component: H
     let methodName: String
 
@@ -25,7 +25,7 @@ public struct GRPCMethodModifier<H: Handler>: HandlerModifier {
     }
 }
 
-extension Handler {
+extension _Handler {
     /// Explicitly sets the name of the gRPC service that is exposed for this `Handler`
     public func rpcName(_ methodName: String) -> GRPCMethodModifier<Self> {
         GRPCMethodModifier(self, methodName: methodName)

--- a/Sources/ApodiniGRPC/GRPCMethodNameModifier.swift
+++ b/Sources/ApodiniGRPC/GRPCMethodNameModifier.swift
@@ -11,7 +11,7 @@ struct GRPCMethodNameContextKey: OptionalContextKey {
     typealias Value = String
 }
 
-public struct GRPCMethodModifier<H: _Handler>: HandlerModifier {
+public struct GRPCMethodModifier<H: HandlerDefiningComponent>: HandlerModifier {
     public let component: H
     let methodName: String
 
@@ -25,7 +25,7 @@ public struct GRPCMethodModifier<H: _Handler>: HandlerModifier {
     }
 }
 
-extension _Handler {
+extension HandlerDefiningComponent {
     /// Explicitly sets the name of the gRPC service that is exposed for this `Handler`
     public func rpcName(_ methodName: String) -> GRPCMethodModifier<Self> {
         GRPCMethodModifier(self, methodName: methodName)

--- a/Sources/ApodiniGRPC/GRPCService/GRPCServiceClientStreaming.swift
+++ b/Sources/ApodiniGRPC/GRPCService/GRPCServiceClientStreaming.swift
@@ -44,7 +44,7 @@ extension GRPCService {
                     .forEach({ message in
                         let basis = DefaultRequestBasis(base: message, remoteAddress: message.remoteAddress, information: request.information)
                         
-                        let response: EventLoopFuture<Apodini.Response<H.Response.Content>> = strategy
+                        let response: EventLoopFuture<Apodini.Response<H.Response.BodyContent>> = strategy
                             .decodeRequest(from: message, with: basis, with: request.eventLoop)
                             .insertDefaults(with: defaults)
                             .cache()
@@ -62,7 +62,7 @@ extension GRPCService {
                 
                 let basis = DefaultRequestBasis(base: message, remoteAddress: message.remoteAddress, information: request.information)
                 
-                let response: EventLoopFuture<Apodini.Response<H.Response.Content>> = strategy
+                let response: EventLoopFuture<Apodini.Response<H.Response.BodyContent>> = strategy
                     .decodeRequest(from: message, with: basis, with: request.eventLoop)
                     .insertDefaults(with: defaults)
                     .cache()

--- a/Sources/ApodiniGRPC/GRPCService/GRPCServiceUnary.swift
+++ b/Sources/ApodiniGRPC/GRPCService/GRPCServiceUnary.swift
@@ -36,7 +36,7 @@ extension GRPCService {
 
                 let basis = DefaultRequestBasis(base: message, remoteAddress: message.remoteAddress, information: request.information)
                 
-                let response: EventLoopFuture<Apodini.Response<H.Response.Content>> = strategy
+                let response: EventLoopFuture<Apodini.Response<H.Response.BodyContent>> = strategy
                     .decodeRequest(from: message, with: basis, with: request.eventLoop)
                     .insertDefaults(with: defaults)
                     .cache()

--- a/Sources/ApodiniGRPC/GRPCServiceNameModifier.swift
+++ b/Sources/ApodiniGRPC/GRPCServiceNameModifier.swift
@@ -12,7 +12,7 @@ struct GRPCServiceNameContextKey: OptionalContextKey {
     typealias Value = String
 }
 
-public struct GRPCServiceModifier<H: _Handler>: HandlerModifier {
+public struct GRPCServiceModifier<H: HandlerDefiningComponent>: HandlerModifier {
     public let component: H
     let serviceName: String
 
@@ -26,7 +26,7 @@ public struct GRPCServiceModifier<H: _Handler>: HandlerModifier {
     }
 }
 
-extension _Handler {
+extension HandlerDefiningComponent {
     /// Explicitly sets the name of the gRPC service that is exposed for this `Handler`
     public func serviceName(_ serviceName: String) -> GRPCServiceModifier<Self> {
         GRPCServiceModifier(self, serviceName: serviceName)

--- a/Sources/ApodiniGRPC/GRPCServiceNameModifier.swift
+++ b/Sources/ApodiniGRPC/GRPCServiceNameModifier.swift
@@ -12,7 +12,7 @@ struct GRPCServiceNameContextKey: OptionalContextKey {
     typealias Value = String
 }
 
-public struct GRPCServiceModifier<H: Handler>: HandlerModifier {
+public struct GRPCServiceModifier<H: _Handler>: HandlerModifier {
     public let component: H
     let serviceName: String
 
@@ -26,7 +26,7 @@ public struct GRPCServiceModifier<H: Handler>: HandlerModifier {
     }
 }
 
-extension Handler {
+extension _Handler {
     /// Explicitly sets the name of the gRPC service that is exposed for this `Handler`
     public func serviceName(_ serviceName: String) -> GRPCServiceModifier<Self> {
         GRPCServiceModifier(self, serviceName: serviceName)

--- a/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/BidirectionalStreaming.swift
+++ b/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/BidirectionalStreaming.swift
@@ -30,7 +30,7 @@ extension Exporter {
                     description: "Input for client side steaming endpoints must be an array at top level.")
             }
             
-            var delegate = Delegate(endpoint.handler, .required)
+            var delegate = endpoint.delegate
             
             return Array(0..<requestCount)
                 .publisher

--- a/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/BidirectionalStreaming.swift
+++ b/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/BidirectionalStreaming.swift
@@ -48,10 +48,10 @@ extension Exporter {
                     return response.connectionEffect == .close
                 })
                 .collect()
-                .tryMap { (responses: [Apodini.Response<H.Response.Content>]) in
+                .tryMap { (responses: [Apodini.Response<H.Response.BodyContent>]) in
                     let status: Status? = responses.last?.status
                     let information: Set<AnyInformation> = responses.last?.information ?? []
-                    let content: [H.Response.Content] = responses.compactMap { response in
+                    let content: [H.Response.BodyContent] = responses.compactMap { response in
                         response.content
                     }
                     let body = try configuration.encoder.encode(content)

--- a/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/ClientSideStreaming.swift
+++ b/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/ClientSideStreaming.swift
@@ -32,7 +32,7 @@ extension Exporter {
                     description: "Input for client side steaming endpoints must be an array at top level.")
             }
             
-            var delegate = Delegate(endpoint.handler, .required)
+            var delegate = endpoint.delegate
             
             return Array(0..<requestCount)
                 .publisher

--- a/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/ClientSideStreaming.swift
+++ b/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/ClientSideStreaming.swift
@@ -49,14 +49,14 @@ extension Exporter {
                 .cancel(if: { response in
                     response.connectionEffect == .close
                 })
-                .compactMap { (response: Apodini.Response<H.Response.Content>) in
+                .compactMap { (response: Apodini.Response<H.Response.BodyContent>) in
                     if response.connectionEffect == .open && response.content == nil {
                         return nil
                     } else {
                         return response
                     }
                 }
-                .tryMap { (response: Apodini.Response<H.Response.Content>) -> Vapor.Response in
+                .tryMap { (response: Apodini.Response<H.Response.BodyContent>) -> Vapor.Response in
                     return try transformer.transform(input: response)
                 }
                 .firstFuture(on: request.eventLoop)

--- a/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/ServiceSideStreaming.swift
+++ b/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/ServiceSideStreaming.swift
@@ -37,10 +37,10 @@ extension Exporter {
                     response.connectionEffect == .close
                 })
                 .collect()
-                .tryMap { (responses: [Apodini.Response<H.Response.Content>]) in
+                .tryMap { (responses: [Apodini.Response<H.Response.BodyContent>]) in
                     let status: Status? = responses.last?.status
                     let information: Set<AnyInformation> = responses.last?.information ?? []
-                    let content: [H.Response.Content] = responses.compactMap { response in
+                    let content: [H.Response.BodyContent] = responses.compactMap { response in
                         response.content
                     }
                     let body = try configuration.encoder.encode(content)

--- a/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/ServiceSideStreaming.swift
+++ b/Sources/ApodiniHTTP/ClosureBuilders/HTTP1Compatibility/ServiceSideStreaming.swift
@@ -23,7 +23,7 @@ extension Exporter {
         let abortAnyError = AbortTransformer<H>()
         
         return { (request: Vapor.Request) in
-            var delegate = Delegate(endpoint.handler, .required)
+            var delegate = endpoint.delegate
             
             return Just(request)
                 .decode(using: strategy, with: request.eventLoop)

--- a/Sources/ApodiniHTTP/ClosureBuilders/RequestResponse.swift
+++ b/Sources/ApodiniHTTP/ClosureBuilders/RequestResponse.swift
@@ -38,7 +38,7 @@ extension Exporter {
     
     func buildBlobRequestResponseClosure<H: Handler>(
         for endpoint: Endpoint<H>,
-        using defaultValues: DefaultValueStore) -> (Vapor.Request) throws -> EventLoopFuture<Vapor.Response> where H.Response.Content == Blob {
+        using defaultValues: DefaultValueStore) -> (Vapor.Request) throws -> EventLoopFuture<Vapor.Response> where H.Response.BodyContent == Blob {
         let strategy = singleInputDecodingStrategy(for: endpoint)
         
         let transformer = VaporBlobResponseTransformer()

--- a/Sources/ApodiniHTTP/ClosureBuilders/RequestResponse.swift
+++ b/Sources/ApodiniHTTP/ClosureBuilders/RequestResponse.swift
@@ -23,7 +23,7 @@ extension Exporter {
         let transformer = VaporResponseTransformer<H>(configuration.encoder)
         
         return { (request: Vapor.Request) in
-            var delegate = Delegate(endpoint.handler, .required)
+            var delegate = endpoint.delegate
             
             return strategy
                 .decodeRequest(from: request, with: request.eventLoop)
@@ -44,7 +44,7 @@ extension Exporter {
         let transformer = VaporBlobResponseTransformer()
         
         return { (request: Vapor.Request) in
-            var delegate = Delegate(endpoint.handler, .required)
+            var delegate = endpoint.delegate
             
             return strategy
                 .decodeRequest(from: request, with: request.eventLoop)

--- a/Sources/ApodiniHTTP/InterfaceExporter.swift
+++ b/Sources/ApodiniHTTP/InterfaceExporter.swift
@@ -97,7 +97,7 @@ struct Exporter: InterfaceExporter {
         }
     }
     
-    func export<H>(blob endpoint: Endpoint<H>) where H: Handler, H.Response.Content == Blob {
+    func export<H>(blob endpoint: Endpoint<H>) where H: Handler, H.Response.BodyContent == Blob {
         let knowledge = endpoint[VaporEndpointKnowledge.self]
         
         switch knowledge.pattern {
@@ -115,11 +115,11 @@ struct Exporter: InterfaceExporter {
     // MARK: Response Transformers
     
     struct AbortTransformer<H: Handler>: ResultTransformer {
-        func handle(error: ApodiniError) -> ErrorHandlingStrategy<Apodini.Response<H.Response.Content>, Error> {
+        func handle(error: ApodiniError) -> ErrorHandlingStrategy<Apodini.Response<H.Response.BodyContent>, Error> {
             .abort(error)
         }
         
-        func transform(input: Apodini.Response<H.Response.Content>) -> Apodini.Response<H.Response.Content> {
+        func transform(input: Apodini.Response<H.Response.BodyContent>) -> Apodini.Response<H.Response.BodyContent> {
             input
         }
     }

--- a/Sources/ApodiniOpenAPI/Modifier/TagModifier.swift
+++ b/Sources/ApodiniOpenAPI/Modifier/TagModifier.swift
@@ -8,7 +8,7 @@ public struct TagContextKey: OptionalContextKey {
     public typealias Value = [String]
 }
 
-public struct TagModifier<H: Handler>: HandlerModifier {
+public struct TagModifier<H: HandlerDefiningComponent>: HandlerModifier {
     public let component: H
     let tags: [String]
     
@@ -22,7 +22,7 @@ public struct TagModifier<H: Handler>: HandlerModifier {
     }
 }
 
-extension Handler {
+extension HandlerDefiningComponent {
     /// A `tag` modifier can be used to explicitly specify the `tags` for the given `Handler`
     /// - Parameter tags: Arbitrary amount of `tags` that are used for logical grouping of operations, e.g., within the API documentation
     /// - Returns: The modified `Handler` with specific `tags`

--- a/Sources/ApodiniOpenAPI/OpenAPIInterfaceExporter.swift
+++ b/Sources/ApodiniOpenAPI/OpenAPIInterfaceExporter.swift
@@ -71,7 +71,7 @@ final class OpenAPIInterfaceExporter: InterfaceExporter {
         }
     }
     
-    func export<H>(blob endpoint: Endpoint<H>) where H: Handler, H.Response.Content == Blob {
+    func export<H>(blob endpoint: Endpoint<H>) where H: Handler, H.Response.BodyContent == Blob {
         export(endpoint)
     }
     

--- a/Sources/ApodiniProtobuffer/ProtobufferInterfaceExporter.swift
+++ b/Sources/ApodiniProtobuffer/ProtobufferInterfaceExporter.swift
@@ -63,7 +63,7 @@ final class ProtobufferInterfaceExporter: InterfaceExporter {
         }
     }
     
-    func export<H>(blob endpoint: Endpoint<H>) where H: Handler, H.Response.Content == Blob {
+    func export<H>(blob endpoint: Endpoint<H>) where H: Handler, H.Response.BodyContent == Blob {
         export(endpoint)
     }
     

--- a/Sources/ApodiniREST/RESTEndpointHandler.swift
+++ b/Sources/ApodiniREST/RESTEndpointHandler.swift
@@ -48,7 +48,7 @@ struct RESTEndpointHandler<H: Handler> {
     }
 
     func handleRequest(request: Vapor.Request) -> EventLoopFuture<Vapor.Response> {
-        var delegate = Delegate(endpoint.handler, .required)
+        var delegate = endpoint.delegate
         
         return strategy
             .decodeRequest(from: request,

--- a/Sources/ApodiniREST/RESTEndpointHandler.swift
+++ b/Sources/ApodiniREST/RESTEndpointHandler.swift
@@ -56,7 +56,7 @@ struct RESTEndpointHandler<H: Handler> {
             .insertDefaults(with: defaultStore)
             .cache()
             .evaluate(on: &delegate)
-            .map { (responseAndRequest: ResponseWithRequest<H.Response.Content>) in
+            .map { (responseAndRequest: ResponseWithRequest<H.Response.BodyContent>) in
                 let parameters: (UUID) -> Any? = responseAndRequest.unwrapped(to: CachingRequest.self)?.peak(_:) ?? { _ in nil }
                 
                 

--- a/Sources/ApodiniREST/RESTInterfaceExporter.swift
+++ b/Sources/ApodiniREST/RESTInterfaceExporter.swift
@@ -115,7 +115,7 @@ final class RESTInterfaceExporter: InterfaceExporter, TruthAnchor {
         }
     }
     
-    func export<H>(blob endpoint: Endpoint<H>) where H: Handler, H.Response.Content == Blob {
+    func export<H>(blob endpoint: Endpoint<H>) where H: Handler, H.Response.BodyContent == Blob {
         export(endpoint)
     }
 

--- a/Sources/ApodiniUtils/AnyCodable.swift
+++ b/Sources/ApodiniUtils/AnyCodable.swift
@@ -101,3 +101,23 @@ extension Decodable {
         self = try JSONDecoder().decode(Self.self, from: data)
     }
 }
+
+// MARK: String+CodingKey
+
+extension String: CodingKey {
+    public init?(intValue: Int) {
+        self = String(describing: intValue)
+    }
+    
+    public init?(stringValue: String) {
+        self = stringValue
+    }
+    
+    public var stringValue: String {
+        self
+    }
+    
+    public var intValue: Int? {
+        Int(self)
+    }
+}

--- a/Sources/ApodiniVaporSupport/ResultTransformers.swift
+++ b/Sources/ApodiniVaporSupport/ResultTransformers.swift
@@ -16,7 +16,7 @@ public struct VaporResponseTransformer<H: Handler>: ResultTransformer {
         self.encoder = encoder
     }
     
-    public func transform(input: Apodini.Response<H.Response.Content>) throws -> Vapor.Response {
+    public func transform(input: Apodini.Response<H.Response.BodyContent>) throws -> Vapor.Response {
         var body: Vapor.Response.Body
         
         if let content = input.content {

--- a/Sources/ApodiniWebSocket/WebSocketInterfaceExporter.swift
+++ b/Sources/ApodiniWebSocket/WebSocketInterfaceExporter.swift
@@ -68,7 +68,7 @@ final class WebSocketInterfaceExporter: LegacyInterfaceExporter {
                 ) in
             
             // We need a new `Delegate` for each connection
-            var delegate = Delegate(endpoint.handler, .required)
+            var delegate = endpoint.delegate
             
         let output = clientInput
             .reduce()

--- a/Sources/ApodiniWebSocket/WebSocketInterfaceExporter.swift
+++ b/Sources/ApodiniWebSocket/WebSocketInterfaceExporter.swift
@@ -64,7 +64,7 @@ final class WebSocketInterfaceExporter: LegacyInterfaceExporter {
         
         self.router.register({(clientInput: AnyPublisher<SomeInput, Never>, eventLoop: EventLoop, request: Vapor.Request) -> (
                     defaultInput: SomeInput,
-                    output: AnyPublisher<Message<H.Response.Content>, Error>
+                    output: AnyPublisher<Message<H.Response.BodyContent>, Error>
                 ) in
             
             // We need a new `Delegate` for each connection
@@ -104,7 +104,7 @@ final class WebSocketInterfaceExporter: LegacyInterfaceExporter {
     }
     
     struct Transformer<H: Handler>: ResultTransformer {
-        func handle(error: ApodiniError) -> ErrorHandlingStrategy<Message<H.Response.Content>, Error> {
+        func handle(error: ApodiniError) -> ErrorHandlingStrategy<Message<H.Response.BodyContent>, Error> {
             switch error.option(for: .webSocketConnectionConsequence) {
             case .none:
                 return .graceful(.error(error))
@@ -115,7 +115,7 @@ final class WebSocketInterfaceExporter: LegacyInterfaceExporter {
             }
         }
         
-        func transform(input: H.Response.Content) -> Message<H.Response.Content> {
+        func transform(input: H.Response.BodyContent) -> Message<H.Response.BodyContent> {
             Message.message(input)
         }
     }

--- a/Sources/DeploymentTargetAWSLambdaRuntime/LambdaRuntime.swift
+++ b/Sources/DeploymentTargetAWSLambdaRuntime/LambdaRuntime.swift
@@ -42,7 +42,7 @@ public class LambdaRuntime: DeploymentProviderRuntime {
     
     public func handleRemoteHandlerInvocation<H: IdentifiableHandler>(
         _ invocation: HandlerInvocation<H>
-    ) throws -> RemoteHandlerInvocationRequestResponse<H.Response.Content> {
+    ) throws -> RemoteHandlerInvocationRequestResponse<H.Response.BodyContent> {
         guard let url = URL(string: "https://\(lambdaDeploymentContext.apiGatewayHostname)") else {
             throw ApodiniDeployRuntimeSupportError(
                 deploymentProviderId: Self.identifier,

--- a/Sources/DeploymentTargetLocalhostRuntime/LocalhostRuntimeSupport.swift
+++ b/Sources/DeploymentTargetLocalhostRuntime/LocalhostRuntimeSupport.swift
@@ -39,7 +39,7 @@ public class LocalhostRuntime: DeploymentProviderRuntime {
     
     public func handleRemoteHandlerInvocation<H: IdentifiableHandler>(
         _ invocation: HandlerInvocation<H>
-    ) throws -> RemoteHandlerInvocationRequestResponse<H.Response.Content> {
+    ) throws -> RemoteHandlerInvocationRequestResponse<H.Response.BodyContent> {
         guard
             let LLI = invocation.targetNode.readUserInfo(as: LocalhostLaunchInfo.self),
             let url = URL(string: "http://127.0.0.1:\(LLI.port)")

--- a/Sources/XCTApodini/Mocks/MockConnectionContext.swift
+++ b/Sources/XCTApodini/Mocks/MockConnectionContext.swift
@@ -43,7 +43,7 @@ public class ConnectionContext<Input, H: Handler> {
     }
     
     /// Evaluate the inner `Delegate` using the given `request`.
-    public func handle(request: Input, eventLoop: EventLoop, final: Bool = true) -> EventLoopFuture<Apodini.Response<H.Response.Content>> {
+    public func handle(request: Input, eventLoop: EventLoop, final: Bool = true) -> EventLoopFuture<Apodini.Response<H.Response.BodyContent>> {
         self.handleAndReturnParameters(request: request, eventLoop: eventLoop, final: final).map { response, _ in response }
     }
     
@@ -52,7 +52,7 @@ public class ConnectionContext<Input, H: Handler> {
     public func handleAndReturnParameters(
         request: Input,
         eventLoop: EventLoop,
-        final: Bool = true) -> EventLoopFuture<(Apodini.Response<H.Response.Content>, (UUID) -> Any?)> {
+        final: Bool = true) -> EventLoopFuture<(Apodini.Response<H.Response.BodyContent>, (UUID) -> Any?)> {
         if self.observation == nil {
             self.observation = delegate.register { event in
                 self.listeners.forEach { listener in listener.onObservedDidChange(self.delegate, event) }
@@ -74,7 +74,7 @@ public class ConnectionContext<Input, H: Handler> {
     public func handle(
         eventLoop: EventLoop,
         observedObject: AnyObservedObject? = nil,
-        event: TriggerEvent) -> EventLoopFuture<Apodini.Response<H.Response.Content>> {
+        event: TriggerEvent) -> EventLoopFuture<Apodini.Response<H.Response.BodyContent>> {
         guard let request = self.latestRequest else {
             fatalError("Mock ConnectionContext tried to handle event before a Request was present.")
         }
@@ -91,7 +91,7 @@ public class ConnectionContext<Input, H: Handler> {
 
 public extension ConnectionContext where Input: WithEventLoop {
     /// Evaluate the inner `Delegate` using the given `request`.
-    func handle(request: Input, final: Bool = true) -> EventLoopFuture<Apodini.Response<H.Response.Content>> {
+    func handle(request: Input, final: Bool = true) -> EventLoopFuture<Apodini.Response<H.Response.BodyContent>> {
         handle(request: request, eventLoop: request.eventLoop, final: final)
     }
 }

--- a/Sources/XCTApodini/Mocks/MockQuery.swift
+++ b/Sources/XCTApodini/Mocks/MockQuery.swift
@@ -21,7 +21,7 @@ public func mockQuery<Value: Encodable, H: Handler>(
     
     let request = "Mock Request"
     
-    let response: Response<H.Response.Content> = try InterfaceExporterLegacyStrategy(exporter)
+    let response: Response<H.Response.BodyContent> = try InterfaceExporterLegacyStrategy(exporter)
                                                     .applied(to: endpoint)
                                                     .decodeRequest(from: request,
                                                                    with: DefaultRequestBasis(base: request),

--- a/Sources/XCTApodini/ResponseTransformer.swift
+++ b/Sources/XCTApodini/ResponseTransformer.swift
@@ -22,7 +22,6 @@ public extension Handler {
 public extension ResponseTransformer {
     /// A type erased version of a `ResponseTransformer`'s `Response` type
     var transformedResponseContent: Encodable.Type {
-
         Self.Content.self
     }
     

--- a/Sources/XCTApodini/ResponseTransformer.swift
+++ b/Sources/XCTApodini/ResponseTransformer.swift
@@ -22,6 +22,7 @@ public extension Handler {
 public extension ResponseTransformer {
     /// A type erased version of a `ResponseTransformer`'s `Response` type
     var transformedResponseContent: Encodable.Type {
+
         Self.Content.self
     }
     

--- a/TestWebService/Package.resolved
+++ b/TestWebService/Package.resolved
@@ -248,8 +248,8 @@
         "package": "Runtime",
         "repositoryURL": "https://github.com/Supereg/Runtime.git",
         "state": {
-          "branch": "fix/linux-swift5.4-class-metadata-layout",
-          "revision": "c71b275c39094f07fd94832604cf6eddb8479093",
+          "branch": "master",
+          "revision": "596e22a518bb3f8177cd796cd77e5386098a33f8",
           "version": null
         }
       },

--- a/TestWebService/Sources/TestWebService/Guards/LogGuard.swift
+++ b/TestWebService/Sources/TestWebService/Guards/LogGuard.swift
@@ -9,13 +9,13 @@ import Apodini
 import Logging
 
 struct LogGuard: SyncGuard {
-    private let message: String
+    @Binding private var message: String
     
     @Environment(\.logger) var logger: Logger
     
     
     init(_ message: String = "LogGuard 👋") {
-        self.message = message
+        self._message = .constant(message)
     }
     
     

--- a/TestWebService/Sources/TestWebService/Transformers/EmojiTransformer.swift
+++ b/TestWebService/Sources/TestWebService/Transformers/EmojiTransformer.swift
@@ -9,15 +9,15 @@ import Apodini
 
 
 struct EmojiTransformer: ResponseTransformer {
-    private let emojis: String
-    private let growth: Int
+    @Binding private var emojis: String
+    @Binding private var growth: Int
     
     @State var amount: Int = 1
     
     
     init(emojis: String = "✅", growth: Int = 1) {
-        self.emojis = emojis
-        self.growth = growth
+        self._emojis = .constant(emojis)
+        self._growth = .constant(growth)
     }
     
     

--- a/Tests/ApodiniDeployTests/InvocableHandlerTests.swift
+++ b/Tests/ApodiniDeployTests/InvocableHandlerTests.swift
@@ -34,7 +34,7 @@ private struct TestWebService: Apodini.WebService {
         class HandlerIdentifier: ScopedHandlerIdentifier<F> {
             static let main = HandlerIdentifier("main")
         }
-        let handlerId = HandlerIdentifier.main
+        @Binding var handlerId = HandlerIdentifier.main
         func handle() -> String {
             "F"
         }
@@ -70,7 +70,7 @@ private struct TestWebService: Apodini.WebService {
         class HandlerIdentifier: ScopedHandlerIdentifier<TextTransformer> {
             static let main = HandlerIdentifier("main")
         }
-        let handlerId = HandlerIdentifier.main
+        @Binding var handlerId = HandlerIdentifier.main
         
         @Parameter var transformation: Transformation = .identity
         @Parameter var input: String
@@ -145,7 +145,7 @@ private struct TestWebService: Apodini.WebService {
             static let main = HandlerIdentifier("main")
         }
         
-        let handlerId = HandlerIdentifier.main
+        @Binding var handlerId = HandlerIdentifier.main
         
         @Parameter var x: Double
         @Parameter var y: Double

--- a/Tests/ApodiniHTTPTests/EndToEndTests.swift
+++ b/Tests/ApodiniHTTPTests/EndToEndTests.swift
@@ -36,7 +36,7 @@ class EndToEndTests: XCTApodiniTest {
         }
     }
     
-    struct BlobGreeter: Handler {
+    struct BlobGreeter: PIHandler {
         @Parameter(.http(.path)) var name: String
         
         @Parameter(.http(.query)) var greeting: String?

--- a/Tests/ApodiniHTTPTests/EndToEndTests.swift
+++ b/Tests/ApodiniHTTPTests/EndToEndTests.swift
@@ -36,7 +36,7 @@ class EndToEndTests: XCTApodiniTest {
         }
     }
     
-    struct BlobGreeter: PIHandler {
+    struct BlobGreeter: Handler {
         @Parameter(.http(.path)) var name: String
         
         @Parameter(.http(.query)) var greeting: String?

--- a/Tests/ApodiniTests/DelegationTests.swift
+++ b/Tests/ApodiniTests/DelegationTests.swift
@@ -22,7 +22,7 @@ final class DelegationTests: ApodiniTests {
     }
     
     
-    struct TestDelegate {
+    struct TestDelegate: PropertyIterable {
         @Parameter var message: String
         @Apodini.Environment(\.connection) var connection
         @ObservedObject var observable: TestObservable
@@ -215,7 +215,7 @@ final class DelegationTests: ApodiniTests {
         )
     }
     
-    struct BindingTestDelegate {
+    struct BindingTestDelegate: PropertyIterable {
         @Binding var number: Int
     }
     
@@ -237,12 +237,12 @@ final class DelegationTests: ApodiniTests {
         var name: String
     }
     
-    struct NestedEnvironmentDelegate {
+    struct NestedEnvironmentDelegate: PropertyIterable {
         @EnvironmentObject var number: Int
         @Apodini.Environment(\EnvKey.name) var string: String
     }
     
-    struct DelegatingEnvironmentDelegate {
+    struct DelegatingEnvironmentDelegate: PropertyIterable {
         var nestedD = Delegate(NestedEnvironmentDelegate())
         
         func evaluate() throws -> String {
@@ -269,7 +269,7 @@ final class DelegationTests: ApodiniTests {
     }
     
     func testSetters() throws {
-        struct BindingObservedObjectDelegate {
+        struct BindingObservedObjectDelegate: PropertyIterable {
             @ObservedObject var observable = TestObservable()
             @Binding var binding: Int
             
@@ -299,12 +299,12 @@ final class DelegationTests: ApodiniTests {
     }
     
     func testOptionalOptionality() throws {
-        struct OptionalDelegate {
+        struct OptionalDelegate: PropertyIterable {
             @Parameter var name: String
         }
         
-        struct RequiredDelegatingDelegate {
-            let delegate = Delegate(OptionalDelegate())
+        struct RequiredDelegatingDelegate: PropertyIterable {
+            var delegate = Delegate(OptionalDelegate())
         }
         
         struct SomeHandler: Handler {
@@ -325,11 +325,11 @@ final class DelegationTests: ApodiniTests {
     }
     
     func testRequiredOptionality() throws {
-        struct RequiredDelegate {
+        struct RequiredDelegate: PropertyIterable {
             @Parameter var name: String
         }
         
-        struct RequiredDelegatingDelegate {
+        struct RequiredDelegatingDelegate: PropertyIterable {
             var delegate = Delegate(RequiredDelegate(), .required)
         }
         

--- a/Tests/ApodiniTests/DelegationTests.swift
+++ b/Tests/ApodiniTests/DelegationTests.swift
@@ -53,7 +53,7 @@ final class DelegationTests: ApodiniTests {
                 }
             }
             
-            let delegate = try testD()
+            let delegate = try testD.instance()
             
             switch delegate.connection.state {
             case .open:
@@ -228,7 +228,7 @@ final class DelegationTests: ApodiniTests {
         
         bindingD.set(\.$number, to: 1)
         
-        let prepared = try bindingD()
+        let prepared = try bindingD.instance()
         
         XCTAssertEqual(prepared.number, 1)
     }
@@ -246,7 +246,7 @@ final class DelegationTests: ApodiniTests {
         var nestedD = Delegate(NestedEnvironmentDelegate())
         
         func evaluate() throws -> String {
-            let nested = try nestedD()
+            let nested = try nestedD.instance()
             return "\(nested.string):\(nested.number)"
         }
     }
@@ -263,7 +263,7 @@ final class DelegationTests: ApodiniTests {
             .environment(\EnvKey.name, "Max")
             .environmentObject(1)
         
-        let prepared = try envD()
+        let prepared = try envD.instance()
         
         XCTAssertEqual(try prepared.evaluate(), "Max:1")
     }
@@ -292,7 +292,7 @@ final class DelegationTests: ApodiniTests {
             .set(\.$binding, to: 1)
             .setObservable(\.$observable, to: TestObservable())
         
-        let prepared = try envD()
+        let prepared = try envD.instance()
         
         XCTAssertEqual(prepared.binding, 1)
         XCTAssertGreaterThan(prepared.observable.date, afterInitializationBeforeInjection)
@@ -311,7 +311,11 @@ final class DelegationTests: ApodiniTests {
             var delegate = Delegate(RequiredDelegatingDelegate(), .required)
             
             func handle() throws -> some ResponseTransformable {
-                try delegate().delegate().name
+                try delegate
+                    .instance()
+                    .delegate
+                    .instance()
+                    .name
             }
         }
         
@@ -337,7 +341,11 @@ final class DelegationTests: ApodiniTests {
             var delegate = Delegate(RequiredDelegatingDelegate(), .required)
             
             func handle() throws -> some ResponseTransformable {
-                try delegate().delegate().name
+                try delegate
+                    .instance()
+                    .delegate
+                    .instance()
+                    .name
             }
         }
         

--- a/Tests/ApodiniTests/DelegationTests.swift
+++ b/Tests/ApodiniTests/DelegationTests.swift
@@ -152,7 +152,7 @@ final class DelegationTests: ApodiniTests {
         XCTAssertGreaterThan(observableInitializationTime, before)
     }
     
-    class TestListener<H: Handler>: ObservedListener where H.Response.Content: StringProtocol {
+    class TestListener<H: Handler>: ObservedListener where H.Response.BodyContent: StringProtocol {
         var eventLoop: EventLoop
         
         var context: ConnectionContext<String, H>

--- a/Tests/ApodiniTests/DelegationTests.swift
+++ b/Tests/ApodiniTests/DelegationTests.swift
@@ -308,7 +308,7 @@ final class DelegationTests: ApodiniTests {
         }
         
         struct SomeHandler: Handler {
-            let delegate = Delegate(RequiredDelegatingDelegate(), .required)
+            var delegate = Delegate(RequiredDelegatingDelegate(), .required)
             
             func handle() throws -> some ResponseTransformable {
                 try delegate().delegate().name
@@ -334,7 +334,7 @@ final class DelegationTests: ApodiniTests {
         }
         
         struct SomeHandler: Handler {
-            let delegate = Delegate(RequiredDelegatingDelegate(), .required)
+            var delegate = Delegate(RequiredDelegatingDelegate(), .required)
             
             func handle() throws -> some ResponseTransformable {
                 try delegate().delegate().name

--- a/Tests/ApodiniTests/EnvironmentTests/ConnectionTests.swift
+++ b/Tests/ApodiniTests/EnvironmentTests/ConnectionTests.swift
@@ -20,8 +20,8 @@ final class ConnectionTests: ApodiniTests {
         @Apodini.Environment(\.connection)
         var connection: Connection
         
-        var endMessage: String
-        var openMessage: String
+        @Binding var endMessage: String
+        @Binding var openMessage: String
         
         func handle() -> Apodini.Response<String> {
             switch connection.state {
@@ -34,7 +34,7 @@ final class ConnectionTests: ApodiniTests {
     }
     
     func testDefaultConnectionEnvironment() throws {
-        var testHandler = TestHandler(endMessage: endMessage, openMessage: openMessage).inject(app: app)
+        var testHandler = TestHandler(endMessage: .constant(endMessage), openMessage: .constant(openMessage)).inject(app: app)
         activate(&testHandler)
         
         let endpoint = testHandler.mockEndpoint(app: app)
@@ -51,7 +51,7 @@ final class ConnectionTests: ApodiniTests {
     
     func testConnectionInjection() throws {
         let mockRequest = MockRequest.createRequest(running: app.eventLoopGroup.next(), queuedParameters: .none)
-        var testHandler = TestHandler(endMessage: endMessage, openMessage: openMessage).inject(app: app)
+        var testHandler = TestHandler(endMessage: .constant(endMessage), openMessage: .constant(openMessage)).inject(app: app)
         activate(&testHandler)
         
         var connection = Connection(state: .open, request: mockRequest)

--- a/Tests/ApodiniTests/Helper/Components/ResponseTransformers.swift
+++ b/Tests/ApodiniTests/Helper/Components/ResponseTransformers.swift
@@ -5,10 +5,10 @@
 @testable import Apodini
 
 struct EmojiMediator: ResponseTransformer {
-    private let emojis: String
+    @Binding private var emojis: String
 
     init(emojis: String = "✅") {
-        self.emojis = emojis
+        self._emojis = .constant(emojis)
     }
 
     func transform(content string: String) -> String {

--- a/Tests/ApodiniTests/InformationTests/InformationRequestTests.swift
+++ b/Tests/ApodiniTests/InformationTests/InformationRequestTests.swift
@@ -14,7 +14,7 @@ import Vapor
 final class InformationRequestTests: XCTApodiniTest {
     func testInformationRequestWithRESTExporter() throws {
         struct InformationHandler: Handler {
-            let testExpectations: (Set<AnyInformation>) throws -> Void
+            @Binding var testExpectations: (Set<AnyInformation>) throws -> Void
             
             
             @Apodini.Environment(\.connection) var connection: Connection
@@ -32,7 +32,7 @@ final class InformationRequestTests: XCTApodiniTest {
         }
         
         func testHeaders(_ header: [(String, String)], expectations: @escaping (Set<AnyInformation>) throws -> Void) throws {
-            let handler = InformationHandler(testExpectations: expectations)
+            let handler = InformationHandler(testExpectations: .constant(expectations))
             let endpoint = handler.mockEndpoint(app: app)
             
             let exporter = RESTInterfaceExporter(app)

--- a/Tests/ApodiniTests/MetadataTests/HandlerMetadataTests.swift
+++ b/Tests/ApodiniTests/MetadataTests/HandlerMetadataTests.swift
@@ -59,7 +59,7 @@ private struct ReusableTestHandlerMetadata: HandlerMetadataBlock {
 }
 
 private struct TestMetadataHandler: Handler {
-    var state: Bool
+    @Binding var state: Bool
 
     func handle() -> String {
         "Hello Test!"
@@ -196,7 +196,7 @@ final class HandlerMetadataTest: ApodiniTests {
     
     func testDelegatedHandlerMetadata() {
         struct TestDelegatingHandler<D: Handler>: Handler {
-            let delegate: Delegate<D>
+            var delegate: Delegate<D>
             
             func handle() throws -> some ResponseTransformable {
                 ""

--- a/Tests/ApodiniTests/ModifierTests/ConcatenatedResponseTransformerTests.swift
+++ b/Tests/ApodiniTests/ModifierTests/ConcatenatedResponseTransformerTests.swift
@@ -81,10 +81,10 @@ final class ConcatenatedResponseTransformerTests: ApodiniTests {
         ConcatenatedResponseTransformerTests.thirdResponseMediatorExpectation = self.expectation(description: "Third ResponseMediator is executed")
         
         struct Number: Handler {
-            let number: Int
+            @Binding var number: Int
             
             init(_ number: Int) {
-                self.number = number
+                self._number = .constant(number)
             }
             
             func handle() -> Int {

--- a/Tests/ApodiniTests/ModifierTests/ResponseTransformerTests.swift
+++ b/Tests/ApodiniTests/ModifierTests/ResponseTransformerTests.swift
@@ -45,11 +45,11 @@ final class ResponseTransformerTests: ApodiniTests {
     }
     
     private struct EmojiResponseTransformer: ResponseTransformer {
-        private let emojis: String
+        @Binding private var emojis: String
 
 
         init(emojis: String = "✅") {
-            self.emojis = emojis
+            self._emojis = .constant(emojis)
         }
 
 
@@ -60,11 +60,11 @@ final class ResponseTransformerTests: ApodiniTests {
     }
     
     private struct OptionalEmojiResponseTransformer: ResponseTransformer {
-        private let emojis: String
+        @Binding private var emojis: String
 
 
         init(emojis: String = "✅") {
-            self.emojis = emojis
+            self._emojis = .constant(emojis)
         }
 
 

--- a/Tests/ApodiniTests/ModifierTests/ResponseTransformerTests.swift
+++ b/Tests/ApodiniTests/ModifierTests/ResponseTransformerTests.swift
@@ -23,11 +23,11 @@ final class ResponseTransformerTests: ApodiniTests {
     }
     
     private struct OptionalText: Handler {
-        let text: String?
+        @Binding var text: String?
         
         
         init(_ text: String?) {
-            self.text = text
+            self._text = .constant(text)
         }
         
         
@@ -37,7 +37,7 @@ final class ResponseTransformerTests: ApodiniTests {
     }
     
     private struct ResponseHandler: Handler {
-        let response: Apodini.Response<String>
+        @Binding var response: Apodini.Response<String>
         
         func handle() -> Apodini.Response<String> {
             response
@@ -155,19 +155,19 @@ final class ResponseTransformerTests: ApodiniTests {
         struct TestWebService: WebService {
             var content: some Component {
                 Group("nothing") {
-                    ResponseHandler(response: .nothing)
+                    ResponseHandler(response: .constant(.nothing))
                         .response(EmojiResponseTransformer())
                 }
                 Group("send") {
-                    ResponseHandler(response: .send("Paul"))
+                    ResponseHandler(response: .constant(.send("Paul")))
                         .response(EmojiResponseTransformer())
                 }
                 Group("final") {
-                    ResponseHandler(response: .final("Paul"))
+                    ResponseHandler(response: .constant(.final("Paul")))
                         .response(EmojiResponseTransformer())
                 }
                 Group("end") {
-                    ResponseHandler(response: .end)
+                    ResponseHandler(response: .constant(.end))
                         .response(EmojiResponseTransformer())
                 }
             }

--- a/Tests/ApodiniTests/OpenAPITests/OpenAPIDocumentBuilderTests.swift
+++ b/Tests/ApodiniTests/OpenAPITests/OpenAPIDocumentBuilderTests.swift
@@ -15,11 +15,11 @@ final class OpenAPIDocumentBuilderTests: ApodiniTests {
         var someProp = 4
     }
 
-    struct SomeDelegate {
+    struct SomeDelegate: PropertyIterable {
         @Parameter var lazyoptional: String
     }
     
-    struct SomeRequiredDelegate {
+    struct SomeRequiredDelegate: PropertyIterable {
         @Parameter var required: String
         @Parameter var realoptional: String?
     }

--- a/Tests/ApodiniTests/OpenAPITests/OpenAPIDocumentBuilderTests.swift
+++ b/Tests/ApodiniTests/OpenAPITests/OpenAPIDocumentBuilderTests.swift
@@ -27,8 +27,8 @@ final class OpenAPIDocumentBuilderTests: ApodiniTests {
     struct SomeComp: Handler {
         @Parameter var name: String
         
-        let someD = Delegate(SomeDelegate())
-        let requiredD = Delegate(SomeRequiredDelegate(), .required)
+        var someD = Delegate(SomeDelegate())
+        var requiredD = Delegate(SomeRequiredDelegate(), .required)
 
         func handle() -> SomeStruct {
             SomeStruct()

--- a/Tests/ApodiniTests/PropertiesTests/BindingTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/BindingTests.swift
@@ -46,7 +46,10 @@ final class BindingTests: ApodiniTests, EnvironmentAccessible {
         }
         
         func handle() throws -> H.Response {
-            try delegate.environmentObject(language)().handle()
+            try delegate
+                .environmentObject(language)
+                .instance()
+                .handle()
         }
     }
     

--- a/Tests/ApodiniTests/PropertiesTests/ObservedObjectTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/ObservedObjectTests.swift
@@ -315,7 +315,7 @@ class ObservedObjectTests: ApodiniTests {
             
             @State var count: Int = 1
             
-            let secondObservable: TestObservable
+            @Binding var secondObservable: TestObservable
             
             func handle() -> Apodini.Response<String> {
                 defer {
@@ -343,7 +343,7 @@ class ObservedObjectTests: ApodiniTests {
         
         let observable = TestObservable()
         let observable2 = TestObservable(100, "Hello, World!")
-        var testHandler = TestHandler(testObservable: observable, secondObservable: observable2).inject(app: app)
+        var testHandler = TestHandler(testObservable: observable, secondObservable: .constant(observable2)).inject(app: app)
         activate(&testHandler)
         let endpoint = testHandler.mockEndpoint(app: app)
         
@@ -404,7 +404,7 @@ class ObservedObjectTests: ApodiniTests {
             
             @State var count: Int = 1
             
-            let secondObservable: TestObservable
+            @Binding var secondObservable: TestObservable
 
             func handle() -> Apodini.Response<String> {
                 defer {
@@ -430,7 +430,7 @@ class ObservedObjectTests: ApodiniTests {
         
         let observable = TestObservable()
         let observable2 = TestObservable(100, "Hello, World!")
-        let testHandler = TestHandler(secondObservable: observable2).inject(app: app)
+        let testHandler = TestHandler(secondObservable: .constant(observable2)).inject(app: app)
         app.storage.set(\Keys.testObservable, to: observable)
 
         let endpoint = testHandler.mockEndpoint(app: app)
@@ -493,13 +493,13 @@ class ObservedObjectTests: ApodiniTests {
             
             @State var count: Int = 1
             
-            let secondObservable: TestObservable
+            @Binding var secondObservable: TestObservable
             
             init(secondObservable: TestObservable, testObservableObject: TestObservable) {
                 var envObj = EnvironmentObject<TestObservable>()
                 envObj.prepareValue(testObservableObject)
                 self._testObservable = envObj
-                self.secondObservable = secondObservable
+                self._secondObservable = .constant(secondObservable)
             }
             
             func handle() -> Apodini.Response<String> {

--- a/Tests/ApodiniTests/PropertiesTests/PropertiesTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/PropertiesTests.swift
@@ -11,14 +11,24 @@ import XCTest
 
 final class PropertiesTests: ApodiniTests {
     func testTypedPorperties() throws {
+        let number = Parameter<Int>(wrappedValue: 42)
+        let otherNumber = Parameter<Int>(wrappedValue: 0)
+        let string = Parameter<String>(wrappedValue: "Paul")
+        let environment = Apodini.Environment(\.database)
+        
         let elements: [(String, Property)] = [
-            ("number", Parameter<Int>(wrappedValue: 42)),
-            ("anOtherNumber", Parameter<Int>(wrappedValue: 0)),
-            ("string", Parameter<String>(wrappedValue: "Paul")),
-            ("enironment", Apodini.Environment(\.database))
+            ("number", number),
+            ("anOtherNumber", otherNumber),
+            ("string", string),
+            ("environment", environment)
         ]
         
-        let properties = Apodini.Properties(elements)
+        let properties = Apodini.Properties()
+            .with(number, named: "number")
+            .with(otherNumber, named: "anOtherNumber")
+            .with(string, named: "string")
+            .with(environment, named: "environment")
+        
         XCTAssertEqual(properties.wrappedValue.count, elements.count)
         
         for (key, value) in elements {

--- a/Tests/ApodiniTests/PropertiesTests/StateTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/StateTests.swift
@@ -14,7 +14,7 @@ class StateTests: ApodiniTests {
     struct CountGuard: SyncGuard {
         @State var count: Int = 0
         
-        let callback: (Int) -> Void
+        @Binding var callback: (Int) -> Void
         
         func check() {
             callback(count)
@@ -25,9 +25,9 @@ class StateTests: ApodiniTests {
     struct AsyncCountGuard: Guard {
         @State var count: Int = 0
 
-        let callback: (Int) -> Void
+        @Binding var callback: (Int) -> Void
         
-        let eventLoop: EventLoop
+        @Binding var eventLoop: EventLoop
         
         func check() -> EventLoopFuture<Void> {
             callback(count)
@@ -65,7 +65,7 @@ class StateTests: ApodiniTests {
     struct CountGuardUsingClassType: SyncGuard {
         @State var count = IntClass(int: 0)
         
-        let callback: (Int) -> Void
+        @Binding var callback: (Int) -> Void
         
         func check() {
             callback(count.int)
@@ -76,9 +76,9 @@ class StateTests: ApodiniTests {
     struct AsyncCountGuardUsingClassType: Guard {
         @State var count = IntClass(int: 0)
 
-        let callback: (Int) -> Void
+        @Binding var callback: (Int) -> Void
         
-        let eventLoop: EventLoop
+        @Binding var eventLoop: EventLoop
         
         func check() -> EventLoopFuture<Void> {
             callback(count.int)
@@ -114,8 +114,8 @@ class StateTests: ApodiniTests {
         
         let handler = TestHandler()
                         .transformed(CountTransformer())
-                        .guarded(CountGuard(callback: assertion))
-                        .guarded(AsyncCountGuard(callback: assertion, eventLoop: eventLoop))
+                        .guarded(CountGuard(callback: .constant(assertion)))
+                        .guarded(AsyncCountGuard(callback: .constant(assertion), eventLoop: .constant(eventLoop)))
         
         let endpoint = handler.mockEndpoint()
 
@@ -155,8 +155,8 @@ class StateTests: ApodiniTests {
 
         let handler = TestHandlerUsingClassType()
             .transformed(CountTransformerUsingClassType())
-            .guarded(CountGuard(callback: assertion))
-            .guarded(AsyncCountGuard(callback: assertion, eventLoop: eventLoop))
+            .guarded(CountGuard(callback: .constant(assertion)))
+            .guarded(AsyncCountGuard(callback: .constant(assertion), eventLoop: .constant(eventLoop)))
         
         let endpoint = handler.mockEndpoint()
 
@@ -185,8 +185,8 @@ class StateTests: ApodiniTests {
 
         let handler = TestHandlerUsingClassType()
             .transformed(CountTransformerUsingClassType())
-            .guarded(CountGuard(callback: assertion))
-            .guarded(AsyncCountGuard(callback: assertion, eventLoop: eventLoop))
+            .guarded(CountGuard(callback: .constant(assertion)))
+            .guarded(AsyncCountGuard(callback: .constant(assertion), eventLoop: .constant(eventLoop)))
         
         let endpoint = handler.mockEndpoint()
 
@@ -216,8 +216,8 @@ class StateTests: ApodiniTests {
 
         let handler = TestHandler()
             .transformed(CountTransformer())
-            .guarded(CountGuard(callback: assertion))
-            .guarded(AsyncCountGuard(callback: assertion, eventLoop: eventLoop))
+            .guarded(CountGuard(callback: .constant(assertion)))
+            .guarded(AsyncCountGuard(callback: .constant(assertion), eventLoop: .constant(eventLoop)))
         
         let endpoint = handler.mockEndpoint()
 
@@ -246,8 +246,8 @@ class StateTests: ApodiniTests {
 
         let handler = TestHandler()
             .transformed(CountTransformer())
-            .guarded(CountGuard(callback: assertion))
-            .guarded(AsyncCountGuard(callback: assertion, eventLoop: eventLoop))
+            .guarded(CountGuard(callback: .constant(assertion)))
+            .guarded(AsyncCountGuard(callback: .constant(assertion), eventLoop: .constant(eventLoop)))
         
         let endpoint = handler.mockEndpoint()
 

--- a/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
@@ -205,8 +205,6 @@ final class TraversableTests: ApodiniTests {
 
         try element.encode(to: mutator)
         
-        print(mutator.baseStore.debugDescription)
-        
         let decoded1 = try Element(from: mutator)
 
         print(decoded1)

--- a/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
@@ -201,17 +201,19 @@ final class TraversableTests: ApodiniTests {
 
         print(element)
 
-        let mutator = Coder()
+        let encoder = FlatInstanceEncoder()
 
-        try element.encode(to: mutator)
+        try element.encode(to: encoder)
         
-        let decoded1 = try Element(from: mutator)
+        let decoder = encoder.freezed
+        
+        let decoded1 = try Element(from: decoder)
 
         print(decoded1)
         
         XCTAssertEqual(decoded1, element)
 
-        let decoded2 = try Element(from: mutator)
+        let decoded2 = try Element(from: decoder)
 
         print(decoded2)
         

--- a/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
@@ -13,7 +13,7 @@ import ApodiniUtils
 final class TraversableTests: ApodiniTests {
     // swiftlint:disable identifier_name type_name
     @propertyWrapper
-    struct Param<T>: Apodini.Property, InstanceCodable {
+    struct Param<T>: Apodini.Property, _InstanceCodable {
         var _value: T?
         
         var wrappedValue: T? {

--- a/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
@@ -204,23 +204,23 @@ final class TraversableTests: ApodiniTests {
         }, to: &container)
     }
     
-//    func testInstanceCoder() throws {
-//        let element = Element()
-//
-//        print(element)
-//
-//        let mutator = Mutator()
-//
-//        try element.encode(to: mutator)
-//
-//        let decoded1 = try Element(from: mutator)
-//
-//        print(decoded1)
-//
-//        mutator.reset()
-//
-//        let decoded2 = try Element(from: mutator)
-//
-//        print(decoded2)
-//    }
+    func testInstanceCoder() throws {
+        let element = Element()
+
+        print(element)
+
+        let mutator = Mutator()
+
+        try element.encode(to: mutator)
+
+        let decoded1 = try Element(from: mutator)
+
+        print(decoded1)
+
+        mutator.reset()
+
+        let decoded2 = try Element(from: mutator)
+
+        print(decoded2)
+    }
 }

--- a/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
@@ -199,8 +199,6 @@ final class TraversableTests: ApodiniTests {
     func testInstanceCoder() throws {
         let element = Element()
 
-        print(element)
-
         let encoder = FlatInstanceEncoder()
 
         try element.encode(to: encoder)
@@ -208,16 +206,24 @@ final class TraversableTests: ApodiniTests {
         let decoder = encoder.freezed
         
         let decoded1 = try Element(from: decoder)
-
-        print(decoded1)
         
         XCTAssertEqual(decoded1, element)
 
         let decoded2 = try Element(from: decoder)
-
-        print(decoded2)
         
         XCTAssertEqual(decoded2, element)
+    }
+    
+    func testStringKey() throws {
+        let intBased = String(intValue: 12)
+        let stringBased = String(stringValue: "x")
+        
+        XCTAssertEqual(intBased, "12")
+        XCTAssertEqual(intBased?.stringValue, "12")
+        XCTAssertEqual(intBased?.intValue, 12)
+        XCTAssertEqual(stringBased, "x")
+        XCTAssertEqual(stringBased?.stringValue, "x")
+        XCTAssertEqual(stringBased?.intValue, nil)
     }
 }
 

--- a/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
+++ b/Tests/ApodiniTests/PropertiesTests/TraversableTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class TraversableTests: ApodiniTests {
     // swiftlint:disable identifier_name type_name
     @propertyWrapper
-    struct Param<T>: Apodini.Property {
+    struct Param<T>: Apodini.Property, InstanceCodable {
         var _value: T?
         
         var wrappedValue: T? {
@@ -20,7 +20,7 @@ final class TraversableTests: ApodiniTests {
         }
     }
     
-    struct Element {
+    struct Element: Codable {
         @Param var a: String?
         @BCD var bcd: String
         var efg: Properties = [
@@ -203,4 +203,24 @@ final class TraversableTests: ApodiniTests {
             XCTAssertEqual("theNameDynamicProperty", name)
         }, to: &container)
     }
+    
+//    func testInstanceCoder() throws {
+//        let element = Element()
+//
+//        print(element)
+//
+//        let mutator = Mutator()
+//
+//        try element.encode(to: mutator)
+//
+//        let decoded1 = try Element(from: mutator)
+//
+//        print(decoded1)
+//
+//        mutator.reset()
+//
+//        let decoded2 = try Element(from: mutator)
+//
+//        print(decoded2)
+//    }
 }

--- a/Tests/ApodiniTests/RelationshipTests/StructuralRelationshipTests.swift
+++ b/Tests/ApodiniTests/RelationshipTests/StructuralRelationshipTests.swift
@@ -12,6 +12,7 @@ class RelationshipTests: ApodiniTests {
     var id2: String
 
     struct TextParameterized: Handler {
+        @Binding
         var text: String
         @Binding
         var id: String
@@ -22,6 +23,7 @@ class RelationshipTests: ApodiniTests {
     }
 
     struct TextParameterized2: Handler {
+        @Binding
         var text: String
         @Binding
         var id: String

--- a/Tests/ApodiniTests/ResponseTests/ResponseTests.swift
+++ b/Tests/ApodiniTests/ResponseTests/ResponseTests.swift
@@ -13,7 +13,7 @@ import XCTApodini
 
 final class ResponseTests: ApodiniTests {
     struct ResponseHandler: Handler {
-        var message: String
+        @Binding var message: String
 
         func handle() -> Response<String> {
             .final(message)
@@ -32,8 +32,8 @@ final class ResponseTests: ApodiniTests {
     }
     
     struct FutureBasedHandler: Handler {
-        var eventLoop: EventLoop
-        var message: String
+        @Binding var eventLoop: EventLoop
+        @Binding var message: String
 
         func handle() -> EventLoopFuture<EventLoopFuture<EventLoopFuture<Response<String>>>> {
             // Test if `ResponseTransformable` unwraps multiple nested EventLoopFutures
@@ -52,7 +52,7 @@ final class ResponseTests: ApodiniTests {
     func testResponseRequestHandling() throws {
         let expectedContent = "ResponseWithRequest"
         
-        let handler = ResponseHandler(message: expectedContent)
+        let handler = ResponseHandler(message: .constant(expectedContent))
         let endpoint = handler.mockEndpoint()
 
         let exporter = MockExporter<String>()
@@ -68,7 +68,7 @@ final class ResponseTests: ApodiniTests {
     func testEventLoopFutureRequestHandling() throws {
         let expectedContent = "ResponseWithRequest"
         
-        let handler = FutureBasedHandler(eventLoop: app.eventLoopGroup.next(), message: expectedContent)
+        let handler = FutureBasedHandler(eventLoop: .constant(app.eventLoopGroup.next()), message: .constant(expectedContent))
         let endpoint = handler.mockEndpoint()
 
         let exporter = MockExporter<String>()

--- a/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
+++ b/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
@@ -67,7 +67,7 @@ struct IntModifier<C: Component>: Modifier {
     }
 }
 
-extension IntModifier: Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: Handler {
+extension IntModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: _Handler {
     typealias Response = ModifiedComponent.Response
 }
 
@@ -88,7 +88,7 @@ struct OptionalIntModifier<C: Component>: Modifier {
     }
 }
 
-extension OptionalIntModifier: Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: Handler {
+extension OptionalIntModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: _Handler {
     typealias Response = ModifiedComponent.Response
 }
 
@@ -109,7 +109,7 @@ struct IntAdditionModifier<C: Component>: Modifier {
     }
 }
 
-extension IntAdditionModifier: Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: Handler {
+extension IntAdditionModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: _Handler {
     typealias Response = ModifiedComponent.Response
 }
 
@@ -129,7 +129,7 @@ struct StringModifier<C: Component>: Modifier {
     }
 }
 
-extension StringModifier: Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: Handler {
+extension StringModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: _Handler {
     typealias Response = ModifiedComponent.Response
 }
 
@@ -149,7 +149,7 @@ struct IntArrayModifier<C: Component>: Modifier {
     }
 }
 
-extension IntArrayModifier: Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: Handler {
+extension IntArrayModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: _Handler {
     typealias Response = ModifiedComponent.Response
 }
 

--- a/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
+++ b/Tests/ApodiniTests/SyntaxTreeVisitorTests/ContextNodeTests.swift
@@ -67,7 +67,7 @@ struct IntModifier<C: Component>: Modifier {
     }
 }
 
-extension IntModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: _Handler {
+extension IntModifier: HandlerDefiningComponent, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: HandlerDefiningComponent {
     typealias Response = ModifiedComponent.Response
 }
 
@@ -88,7 +88,7 @@ struct OptionalIntModifier<C: Component>: Modifier {
     }
 }
 
-extension OptionalIntModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: _Handler {
+extension OptionalIntModifier: HandlerDefiningComponent, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: HandlerDefiningComponent {
     typealias Response = ModifiedComponent.Response
 }
 
@@ -109,7 +109,7 @@ struct IntAdditionModifier<C: Component>: Modifier {
     }
 }
 
-extension IntAdditionModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: _Handler {
+extension IntAdditionModifier: HandlerDefiningComponent, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: HandlerDefiningComponent {
     typealias Response = ModifiedComponent.Response
 }
 
@@ -129,7 +129,7 @@ struct StringModifier<C: Component>: Modifier {
     }
 }
 
-extension StringModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: _Handler {
+extension StringModifier: HandlerDefiningComponent, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: HandlerDefiningComponent {
     typealias Response = ModifiedComponent.Response
 }
 
@@ -149,7 +149,7 @@ struct IntArrayModifier<C: Component>: Modifier {
     }
 }
 
-extension IntArrayModifier: _Handler, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: _Handler {
+extension IntArrayModifier: HandlerDefiningComponent, HandlerModifier, HandlerMetadataNamespace where ModifiedComponent: HandlerDefiningComponent {
     typealias Response = ModifiedComponent.Response
 }
 

--- a/Tests/ApodiniTests/SyntaxTreeVisitorTests/EndpointIdentifierTests.swift
+++ b/Tests/ApodiniTests/SyntaxTreeVisitorTests/EndpointIdentifierTests.swift
@@ -37,7 +37,7 @@ final class HandlerIdentifierTests: ApodiniTests {
 
     struct TestHandlerType: IdentifiableHandler {
         typealias Response = Never
-        let handlerId = ScopedHandlerIdentifier<Self>("main")
+        @Binding var handlerId = ScopedHandlerIdentifier<Self>("main")
     }
     
     

--- a/Tests/ApodiniTests/UniqueIdentifierTests.swift
+++ b/Tests/ApodiniTests/UniqueIdentifierTests.swift
@@ -36,7 +36,7 @@ final class UniqueIdentifierTests: ApodiniTests {
                 _ = endpoint[AnyHandlerIdentifier.self]
             }
             
-            func export<H>(blob endpoint: Endpoint<H>) where H: Handler, H.Response.Content == Blob {
+            func export<H>(blob endpoint: Endpoint<H>) where H: Handler, H.Response.BodyContent == Blob {
                 export(endpoint)
             }
         }

--- a/Tests/ApodiniTests/WebSocketInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/WebSocketInterfaceExporterTests.swift
@@ -38,7 +38,7 @@ class WebSocketInterfaceExporterTests: XCTApodiniTest {
             }
         }
         Group("bidirectional") {
-            BidirectionalHandler(observed: self.testObservable, eventLoop: self.app.eventLoopGroup.next(), app: self.app)
+            BidirectionalHandler(observed: self.testObservable, eventLoop: .constant(self.app.eventLoopGroup.next()), app: .constant(self.app))
         }
         Group("address") {
             RemoteAddressChecker()
@@ -436,9 +436,9 @@ struct BidirectionalHandler: Handler {
     
     @Environment(\.connection) var connection: Connection
     
-    let eventLoop: EventLoop
+    @Binding var eventLoop: EventLoop
     
-    let app: Application
+    @Binding var app: Application
     
     @State var finalState = false
     


### PR DESCRIPTION
# Codable Based Traversal

## :recycle: Current situation & Problem
Currently, the `Runtime` library is used to provide mutating access to all of our `Property`s on a `Handler` (or other object passed into a `Delegate`). This works fine, however the runtime performance of `Runtime` is quite bad (about the same as Mirror's). This is relevant, as Apodini requires mutating access to the `Handler`s properties at least **once upon initialization of a connection context**. That is, for each request-response pair, we need exactly **one** mutating access to all properties. For all streaming patterns, we also only need **one** mutating access per connection. This mutating access is the call to `Activatable.activate()`. Afterwards, all access is non-mutating (we currently make multiple accesses for injecting different types, such as `RequestInjectable`, or equivalences for `Environment` and `AnyObservableObject`s). While non-mutating access has a slightly better performance, it is still overhead that limits the throughput of an Apodini-webservice.

## :bulb: Proposed solution
Reflective programming is expensive at runtime. However, we also don't want to keep our simple interface for defining `Handler`s and not basically having the service-developer have to implement `Traversable` on every `Handler` themselves.

There are two solutions to this problem, both of which have pros and cons: The first is capturing an autoclosure of each `Handler` and initializing a new instance each and every time one is required. With this approach one could even achieve a solution that does not require usage of `Mirror` or `Runtime` at all. However, there are also a couple of downsides:
* The structure of the `Handler`s could change during runtime (especially with all our reusability features (e.g. `Binding`) this could easily be achieved) . We'd basically have to trust the developer that their `Handler`-closure always returns the same `Handler`. This is only really problematic for structural document-creation (e.g. OpenAPI).
* The second problem is that we have to trust on the developer that their `Handler`-closure never returns the same **instance**. Otherwise, those instances share knowledge resulting in everything from unexpected behavior to catastrophic information leaks. One might be able to validate that this is not the case at runtime.
* A `Handler` might be expensive to initialize.
* Initialization of a `Handler` might have unintended side-effects (e.g. when initialized for creating OpenAPI docs).

This concept can be seen in a very similar project: https://github.com/khanlou/Meridian.

The other solution (implemented in this PR) is usage of code generation. The problem here is that we don't want to require the developer take care of this using some command/script. Instead we want this process to be transparent in a way that no Swift-code is generated. Instead the compiler should generate the machine-code for traversing the `Handler` automatically. The only way to do this using the standard Swift toolchain is via `Codable`. We thus require `Handler`s to conform to `Codable`:

```swift
// MARK: FlatInstanceCoding Concept

/// Flat instance coding is a concept for providing fast (faster than what the `Runtime` library can do) mutating
/// access to a struct's properties by first encoding the properties into an array, then performing mutations on
/// that array, and finally decoding the struct from that array.
///
/// Flat instance coding works on three assumptions:
///     1. The order of the calls to `decode`/`encode` and the accompanying container-construction
///     are done in the same order for encoding and decoding.
///     2. Both encoding and decoding are non-failable.
///     3. The only properties that may exist on the encoded/decoded element as well as its recursive
///     children are ``DynamicProperty``, ``Properties`` and `_InstanceCodable` objects.
///     This is the requirement expressed via the ``PropertyIterable`` protocol. Encoding will fail
///     if any other (even `Codable`) object is encountered.
///
/// The whole object is encoded into an array of tuples containing the **instance** and its **name**.
/// The name is calculated from the coding-keys and the `namingStrategy` valid for the current scope.
/// The `namingStrategy` is ``Properties/defaultNamingStrategy`` by default, but is overridden
/// when in the context of a ``DynamicProperty`` or ``Properties`` element (which both provide their
/// own `namingStrategy`).
///
/// On this array `[(String, Any)]`, `Traversable` can be implemented in a very performant manner.
``` 

The advantage is the performance: decoding only has to be performed once at startup-time. Encoding once per connection-context. All the `Traversable` access is as performant as it could be as it is just iterating over an array.

I created a benchmark testing this concept in comparison to `Runtime`: https://gist.github.com/theMomax/7c9621c3b775923f90f50893a43fc32d

The downside is all `Handler`s have to conform to `Codable` (see release notes), meaning that you cannot use plain constants on `Handler`s anymore, but have to wrap them inside a `Binding.constant`.

## :gear: Release Notes 
All `Handler`s and other objects used within a `Delegate` must now conform to `PropertyIterable`. This requires every every (stored) element of the `Handler` to be an Apodini `Property` (This includes `Properties` and `DynamicProperty`) or a Delegate. If you currently use a non-`Property` element on a `Handler` (or other object used within a `Delegate`), wrap this element in a `Binding.constant`.

Furthermore, the callAsFunction on Delegate was renamed to „instance“.

## ➕ Additional Information

I had to rename the `Content` associatedtype on `Response` as it conflicted with `Component.Content` on the `Encodable` type (there are now default implementations on `Encodable` for both types).

### Related Issues
#11 discovered the need to have mutating access to properties in the first place.

### Testing
I wrote a new test for explicitly testing the capabilities of the FlatInstanceEncoder/-Decoder, but since it is used in `Delegate` is has very good coverage anyways.

### Reviewer Nudging
Start with `InstanceCodable.swift`. Get an idea of how the encoder/decoder work and what requirements this Codable conformance bings to `Handler`. Then look at the `Traversable` implementation for the decoder in `Traversable.swift` and the usage in `Delegate`. Then the new definition of `Handler` and the new protocol `HandlerDefiningComponent`, equals the old `Handler` and enables interfacing between the new `Handler` and `HandlerModifier`s. The rest is basically just refactoring and adaptions. 
