### PR TITLE
Fix Blob Responses Containing Information for the REST and HTTP Exporters

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-postgres-driver.git",
         "state": {
           "branch": null,
-          "revision": "11d4fce0c5d8a027a5d131439c9c94dd3230cb8e",
-          "version": "2.1.2"
+          "revision": "afe159ce915e752ab5f5b76479dc78a17051ce73",
+          "version": "2.1.3"
         }
       },
       {
@@ -456,8 +456,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "f94f0bff47c1c07df6e404e889f5c71c4270a9ea",
-          "version": "4.47.2"
+          "revision": "4aafa9f859e4b011739e3232495e0375d2b8418d",
+          "version": "4.48.1"
         }
       },
       {

--- a/Sources/Apodini/Response/MimeType.swift
+++ b/Sources/Apodini/Response/MimeType.swift
@@ -7,7 +7,7 @@
 
 
 /// MIME type (Multipurpose Internet Mail Extensions) that expresses the format of a `Blob`
-public enum MimeType: Codable, Equatable {
+public enum MimeType: Codable, Equatable, CustomStringConvertible {
     enum CodingKeys: CodingKey {
         case type
         case subtype
@@ -47,6 +47,7 @@ public enum MimeType: Codable, Equatable {
     case text(TextSubtype, parameters: [String: String] = [:])
     case application(ApplicationSubtype, parameters: [String: String] = [:])
     case image(ImageSubtype, parameters: [String: String] = [:])
+    case custom(type: String, subtype: String, parameters: [String: String] = [:])
     
     
     var type: String {
@@ -57,6 +58,8 @@ public enum MimeType: Codable, Equatable {
             return "application"
         case .image:
             return "image"
+        case let .custom(type, _, _):
+            return type
         }
     }
     
@@ -68,6 +71,8 @@ public enum MimeType: Codable, Equatable {
             return subtype.rawValue
         case let .image(subtype, _):
             return subtype.rawValue
+        case let .custom(_, subtype, _):
+            return subtype
         }
     }
     
@@ -79,36 +84,67 @@ public enum MimeType: Codable, Equatable {
             return parameters
         case let .image(_, parameters):
             return parameters
+        case let .custom(_, _, parameters):
+            return parameters
         }
     }
     
+    public var description: String {
+        "\(type)/\(subtype)\(parameters.isEmpty ? "" : ";")\(parameters.map { "\($0.0)=\($0.1)" }.joined(separator: ";"))"
+    }
+    
+    
+    public init?(_ description: String) {
+        let splits = description.split(separator: ";")
+        guard let typeAndSubtype = splits.first?.split(separator: "/"),
+              typeAndSubtype.count == 2,
+              let type = typeAndSubtype.first,
+              let subType = typeAndSubtype.last
+        else {
+            return nil
+        }
+        let parametersArray: [(String, String)] = splits
+            .dropFirst()
+            .compactMap { substring in
+                let parameterSpiit = substring.split(separator: "=")
+                guard parameterSpiit.count == 2, let key = parameterSpiit.first, let value = parameterSpiit.last else {
+                    return nil
+                }
+                return (String(key), String(value))
+            }
+        let parameters = parametersArray.reduce(into: [:]) { $0[$1.0] = $1.1 }
+        
+        self = MimeType(type: String(type), subtype: String(subType), parameters: parameters)
+    }
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let type = try container.decode(String.self, forKey: .type)
+        let subType = try container.decode(String.self, forKey: .subtype)
+        let parameters = try container.decodeIfPresent([String: String].self, forKey: .parameters) ?? [:]
+        
+        self = MimeType(type: type, subtype: subType, parameters: parameters)
+    }
+    
+    init(type: String, subtype: String, parameters: [String: String] = [:]) {
         switch type {
         case "text":
-            self = .text(
-                try container.decode(TextSubtype.self, forKey: .subtype),
-                parameters: try container.decodeIfPresent([String: String].self, forKey: .parameters) ?? [:]
-            )
+            guard let textSubtype = TextSubtype(rawValue: subtype) else {
+                fallthrough
+            }
+            self = .text(textSubtype, parameters: parameters)
         case "application":
-            self = .application(
-                try container.decode(ApplicationSubtype.self, forKey: .subtype),
-                parameters: try container.decodeIfPresent([String: String].self, forKey: .parameters) ?? [:]
-            )
+            guard let applicationSubtype = ApplicationSubtype(rawValue: subtype) else {
+                fallthrough
+            }
+            self = .application(applicationSubtype, parameters: parameters)
         case "image":
-            self = .image(
-                try container.decode(ImageSubtype.self, forKey: .subtype),
-                parameters: try container.decodeIfPresent([String: String].self, forKey: .parameters) ?? [:]
-            )
+            guard let imageSubtype = ImageSubtype(rawValue: subtype) else {
+                fallthrough
+            }
+            self = .image(imageSubtype, parameters: parameters)
         default:
-            var codingPath = decoder.codingPath
-            codingPath.append(CodingKeys.type)
-            throw DecodingError.valueNotFound(
-                Status.self,
-                DecodingError.Context(codingPath: codingPath, debugDescription: "Could not find a correct Mime Type, found: \(type)")
-            )
+            self = .custom(type: type, subtype: subtype, parameters: parameters)
         }
     }
     

--- a/Sources/ApodiniREST/RESTEndpointHandler.swift
+++ b/Sources/ApodiniREST/RESTEndpointHandler.swift
@@ -75,9 +75,16 @@ struct RESTEndpointHandler<H: Handler> {
                 if let blob = response.content?.response.typed(Blob.self) {
                     let vaporResponse = Vapor.Response()
                     
+                    var information = response.information
+                    if let contentType = blob.type?.description {
+                        information = information.union([AnyHTTPInformation(key: "Content-Type", rawValue: contentType)])
+                    }
+                    vaporResponse.headers = HTTPHeaders(information)
+                    
                     if let status = response.status {
                         vaporResponse.status = HTTPStatus(status)
                     }
+                    
                     vaporResponse.body = Vapor.Response.Body(buffer: blob.byteBuffer)
                     
                     return request.eventLoop.makeSucceededFuture(vaporResponse)

--- a/Sources/ApodiniVaporSupport/ResultTransformers.swift
+++ b/Sources/ApodiniVaporSupport/ResultTransformers.swift
@@ -25,9 +25,11 @@ public struct VaporResponseTransformer<H: Handler>: ResultTransformer {
             body = Vapor.Response.Body()
         }
         
-        return Vapor.Response(status: input.responseStatus,
-                              headers: HTTPHeaders(input.information),
-                              body: body)
+        return Vapor.Response(
+            status: input.responseStatus,
+            headers: HTTPHeaders(input.information),
+            body: body
+        )
     }
     
     public func handle(error: ApodiniError) -> ErrorHandlingStrategy<Vapor.Response, ApodiniError> {
@@ -41,15 +43,22 @@ public struct VaporBlobResponseTransformer: ResultTransformer {
     public func transform(input: Apodini.Response<Blob>) -> Vapor.Response {
         var body: Vapor.Response.Body
         
+        var information = input.information
+        
         if let content = input.content {
             body = Vapor.Response.Body(buffer: content.byteBuffer)
+            if let contentType = content.type?.description {
+                information = information.union([AnyHTTPInformation(key: "Content-Type", rawValue: contentType)])
+            }
         } else {
             body = Vapor.Response.Body()
         }
         
-        return Vapor.Response(status: input.responseStatus,
-                              headers: HTTPHeaders(input.information),
-                              body: body)
+        return Vapor.Response(
+            status: input.responseStatus,
+            headers: HTTPHeaders(information),
+            body: body
+        )
     }
     
     public func handle(error: ApodiniError) -> ErrorHandlingStrategy<Vapor.Response, ApodiniError> {

--- a/TestWebService/Package.resolved
+++ b/TestWebService/Package.resolved
@@ -2,7 +2,7 @@
   "object": {
     "pins": [
       {
-        "package": "apnswift",
+        "package": "APNSwift",
         "repositoryURL": "https://github.com/kylebrowning/APNSwift.git",
         "state": {
           "branch": null,
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-postgres-driver.git",
         "state": {
           "branch": null,
-          "revision": "11d4fce0c5d8a027a5d131439c9c94dd3230cb8e",
-          "version": "2.1.2"
+          "revision": "afe159ce915e752ab5f5b76479dc78a17051ce73",
+          "version": "2.1.3"
         }
       },
       {
@@ -182,7 +182,7 @@
         }
       },
       {
-        "package": "DNSClient",
+        "package": "NioDNS",
         "repositoryURL": "https://github.com/OpenKitten/NioDNS.git",
         "state": {
           "branch": null,
@@ -344,6 +344,15 @@
         }
       },
       {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections",
+        "state": {
+          "branch": null,
+          "revision": "3426dba9ee5c9f8e4981b0fc9d39a818d36eec28",
+          "version": "0.0.4"
+        }
+      },
+      {
         "package": "swift-crypto",
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
@@ -429,8 +438,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "f94f0bff47c1c07df6e404e889f5c71c4270a9ea",
-          "version": "4.47.2"
+          "revision": "4aafa9f859e4b011739e3232495e0375d2b8418d",
+          "version": "4.48.1"
         }
       },
       {

--- a/Tests/ApodiniHTTPTests/EndToEndTests.swift
+++ b/Tests/ApodiniHTTPTests/EndToEndTests.swift
@@ -40,9 +40,17 @@ class EndToEndTests: XCTApodiniTest {
         @Parameter(.http(.path)) var name: String
         
         @Parameter(.http(.query)) var greeting: String?
-
-        func handle() -> Blob {
-            Blob("\(greeting ?? "Hello"), \(name)!".data(using: .utf8)!)
+        
+        
+        var metadata: Metadata {
+            Pattern(.requestResponse)
+        }
+        
+        func handle() -> Apodini.Response<Blob> {
+            Response.send(
+                Blob(Data("\(greeting ?? "Hello"), \(name)!".utf8), type: .text(.plain)),
+                information: [AnyHTTPInformation(key: "Test", rawValue: "Test")]
+            )
         }
     }
 
@@ -232,11 +240,15 @@ class EndToEndTests: XCTApodiniTest {
         try app.vapor.app.testable(method: .inMemory).test(.GET, "/blob/Paul", body: nil) { response in
             XCTAssertEqual(response.status, .ok)
             XCTAssertEqual(response.body.string, "Hello, Paul!")
+            XCTAssertEqual(response.headers["Content-Type"].first, "text/plain")
+            XCTAssertEqual(response.headers["Test"].first, "Test")
         }
         
         try app.vapor.app.testable(method: .inMemory).test(.GET, "/blob/Andi?greeting=Wuzzup", body: nil) { response in
             XCTAssertEqual(response.status, .ok)
             XCTAssertEqual(response.body.string, "Wuzzup, Andi!")
+            XCTAssertEqual(response.headers["Content-Type"].first, "text/plain")
+            XCTAssertEqual(response.headers["Test"].first, "Test")
         }
     }
 }

--- a/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
@@ -383,7 +383,7 @@ class RESTInterfaceExporterTests: ApodiniTests {
     }
     
     func testRESTInformation() throws {
-        struct BlobInformationHandler: Handler {
+        struct InformationHandler: Handler {
             func handle() -> Apodini.Response<String> {
                 Response.send(
                     "Paul",
@@ -395,7 +395,7 @@ class RESTInterfaceExporterTests: ApodiniTests {
         
         struct TestWebService: WebService {
             var content: some Component {
-                BlobInformationHandler()
+                InformationHandler()
             }
             
             var configuration: Configuration {

--- a/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/RESTInterfaceExporterTests.swift
@@ -409,9 +409,8 @@ class RESTInterfaceExporterTests: ApodiniTests {
             XCTAssertEqual(response.headers["Content-Type"].first, "application/json; charset=utf-8")
             XCTAssertEqual(response.headers["Test"].first, "Test")
             XCTAssertEqual(response.status, .created)
-            XCTAssertEqual(
-                response.body.string,
-                """
+            
+            let firstPossibleJSON = """
                 {
                   "data" : "Paul",
                   "_links" : {
@@ -419,7 +418,16 @@ class RESTInterfaceExporterTests: ApodiniTests {
                   }
                 }
                 """
-            )
+            let secondPossibleJSON = """
+                {
+                  "_links" : {
+                    "self" : "http://127.0.0.1:8080/v1"
+                  },
+                  "data" : "Paul"
+                }
+                """
+            
+            XCTAssertTrue(response.body.string == firstPossibleJSON || response.body.string == secondPossibleJSON)
         }
     }
     

--- a/Tests/ApodiniTests/ResponseTests/BlobTests.swift
+++ b/Tests/ApodiniTests/ResponseTests/BlobTests.swift
@@ -136,6 +136,14 @@ final class BlobTests: ApodiniTests {
         XCTAssertEqual(simpleEtringEncodedMimeType.type, "text")
         XCTAssertEqual(simpleEtringEncodedMimeType.subtype, "plain")
         XCTAssertEqual(simpleEtringEncodedMimeType.description, "text/plain")
+        
+        
+        XCTAssertNil(MimeType("text"))
+        XCTAssertEqual(MimeType("text/plain;parameter"), MimeType(type: "text", subtype: "plain"))
+        XCTAssertEqual(MimeType("text/markdown"), MimeType(type: "text", subtype: "markdown"))
+        XCTAssertEqual(MimeType("application/widget"), MimeType(type: "application", subtype: "widget"))
+        XCTAssertEqual(MimeType("image/tiff"), MimeType(type: "image", subtype: "tiff"))
+        XCTAssertEqual(MimeType("video/mp4"), MimeType(type: "video", subtype: "mp4"))
     }
     
     func testMIMEDecoding() throws {

--- a/Tests/ApodiniTests/ResponseTests/BlobTests.swift
+++ b/Tests/ApodiniTests/ResponseTests/BlobTests.swift
@@ -127,7 +127,10 @@ final class BlobTests: ApodiniTests {
         XCTAssertEqual(stringEncodedMimeType.subtype, "plain")
         XCTAssertEqual(stringEncodedMimeType.parameters["test"], "test")
         XCTAssertEqual(stringEncodedMimeType.parameters["test2"], "test")
-        XCTAssertEqual(stringEncodedMimeType.description, "text/plain;test=test;test2=test")
+        XCTAssertTrue(
+            stringEncodedMimeType.description == "text/plain;test=test;test2=test"
+            || stringEncodedMimeType.description == "text/plain;test2=test;test=test"
+        )
         
         let simpleEtringEncodedMimeType = try XCTUnwrap(MimeType("text/plain"))
         XCTAssertEqual(simpleEtringEncodedMimeType.type, "text")

--- a/Tests/ApodiniTests/ResponseTests/BlobTests.swift
+++ b/Tests/ApodiniTests/ResponseTests/BlobTests.swift
@@ -137,6 +137,10 @@ final class BlobTests: ApodiniTests {
         XCTAssertEqual(simpleEtringEncodedMimeType.subtype, "plain")
         XCTAssertEqual(simpleEtringEncodedMimeType.description, "text/plain")
         
+        let customMimeType = MimeType.custom(type: "video", subtype: "mp4")
+        XCTAssertEqual(customMimeType.type, "video")
+        XCTAssertEqual(customMimeType.subtype, "mp4")
+        XCTAssertEqual(customMimeType.parameters, [:])
         
         XCTAssertNil(MimeType("text"))
         XCTAssertEqual(MimeType("text/plain;parameter"), MimeType(type: "text", subtype: "plain"))

--- a/Tests/ApodiniTests/ResponseTests/BlobTests.swift
+++ b/Tests/ApodiniTests/ResponseTests/BlobTests.swift
@@ -28,10 +28,11 @@ final class BlobTests: ApodiniTests {
         let mimeTypes = [
             MimeType.text(.html, parameters: ["Test": "Test"]),
             MimeType.application(.json),
-            MimeType.image(.gif)
+            MimeType.image(.gif),
+            MimeType.custom(type: "application", subtype: "pkcs8", parameters: ["Test": "Test"])
         ]
         
-        let exporter = MockExporter<String>(queued: mimeTypes[0], mimeTypes[1], mimeTypes[2])
+        let exporter = MockExporter<String>(queued: mimeTypes[0], mimeTypes[1], mimeTypes[2], mimeTypes[3])
         let context = endpoint.createConnectionContext(for: exporter)
 
         try XCTCheckResponse(
@@ -49,6 +50,12 @@ final class BlobTests: ApodiniTests {
         try XCTCheckResponse(
             context.handle(request: "", eventLoop: app.eventLoopGroup.next()),
             content: Blob(Data(), type: mimeTypes[2]),
+            connectionEffect: .close
+        )
+        
+        try XCTCheckResponse(
+            context.handle(request: "", eventLoop: app.eventLoopGroup.next()),
+            content: Blob(Data(), type: mimeTypes[3]),
             connectionEffect: .close
         )
     }
@@ -72,13 +79,14 @@ final class BlobTests: ApodiniTests {
             withExporterConfiguration: REST.ExporterConfiguration(),
             for: endpoint,
             rendpoint,
-            on: exporter)
+            on: exporter
+        )
         
         
         func makeRequest(blobContent: String, mimeType: MimeType) throws {
             let request = Vapor.Request(
                 application: app.vapor.app,
-                method: .GET,
+                method: .POST,
                 url: URI("https://ase.in.tum.de/schmiedmayer?name=\(blobContent)"),
                 collectedBody: ByteBuffer(data: try JSONEncoder().encode(mimeType)),
                 on: app.eventLoopGroup.next()
@@ -112,6 +120,21 @@ final class BlobTests: ApodiniTests {
         XCTAssert(encodedBlob.contains(#""subtype" : "plain""#))
     }
     
+    func testMIMEToAndFromString() throws {
+        let stringEncodedMimeType = try XCTUnwrap(MimeType("text/plain;test=test;test2=test"))
+        
+        XCTAssertEqual(stringEncodedMimeType.type, "text")
+        XCTAssertEqual(stringEncodedMimeType.subtype, "plain")
+        XCTAssertEqual(stringEncodedMimeType.parameters["test"], "test")
+        XCTAssertEqual(stringEncodedMimeType.parameters["test2"], "test")
+        XCTAssertEqual(stringEncodedMimeType.description, "text/plain;test=test;test2=test")
+        
+        let simpleEtringEncodedMimeType = try XCTUnwrap(MimeType("text/plain"))
+        XCTAssertEqual(simpleEtringEncodedMimeType.type, "text")
+        XCTAssertEqual(simpleEtringEncodedMimeType.subtype, "plain")
+        XCTAssertEqual(simpleEtringEncodedMimeType.description, "text/plain")
+    }
+    
     func testMIMEDecoding() throws {
         let validMIMEJSON =
             """
@@ -136,7 +159,7 @@ final class BlobTests: ApodiniTests {
             """
             {
               "type" : "myFancyType",
-              "subtype" : "plain",
+              "subtypes" : "plain",
               "parameters" : {
             
               }


### PR DESCRIPTION
# Fix Blob Responses containing Information for the REST and HTTP exporters

## :recycle: Current situation & Problem
The Information carried with the `MimeType` of the `Blob` response type was not translated into HTTP header information in the REST and HTTP exporters. In addition any information passed down to the REST exporter when returning a `Blob` was lost in the exporting process.

## :bulb: Proposed solution
This PRs adds and tests the functionality that Information attached to a `Response<Blob>` as well as the `Blob`s MimeType is correctly passed to the HTTP response in the `HTTP` and the `REST` exporters. 

## :gear: Release Notes 
Adds a `.custom(type: String, subtype: String, parameters: [String: String])` `MimeType` that can be used to express `MimeType`s outside of the ones defined in `Apodini`.

### Related Issues
While creating the PR I have encountered an interesting behavior in the automatic detection of the communication pattern that is documented in #318.

### Testing
Added tests that cover the HTTP and REST exporter and test the behavior with `Blob`s and `Information`.
