### PR TITLE
Make Authorised a property wrapper

### DIFF
--- a/Sources/ApodiniAuthorization/AuthorizedProperty.swift
+++ b/Sources/ApodiniAuthorization/AuthorizedProperty.swift
@@ -8,16 +8,16 @@
 
 import Apodini
 
-/// The ``Authorized`` `DynamicProperty` can be used to access the ``Authenticatable``
-/// instance created through a authorization Metadata.
+/// The ``Authorized`` property wrapper can be used to access the ``Authenticatable``
+/// instance created through an authorization Metadata.
 ///
 /// Given the example of an `ExampleUser` ``Authenticatable``, the following code may be used to
 /// access the authenticated and authorized instance.
 /// ```swift
 /// struct ExampleHandler: Handler {
-///     var authorizedUser = Authorized<ExampleUser>()
+///     @Authorized(ExampleUser.self) var authorizedUser
 ///
-///     func handle() -> String {
+///     func handle() throws -> String {
 ///         // you might want to use `authorizedUser.isAuthorized` if using optional authorization
 ///
 ///         let user = try authorizedUser()
@@ -26,7 +26,15 @@ import Apodini
 ///     }
 /// }
 /// ```
+@propertyWrapper
 public struct Authorized<Element: Authenticatable>: DynamicProperty {
+    public var wrappedValue = AuthorizedAuthenticatable<Element>()
+
+    public init(_: Element.Type = Element.self) {}
+}
+
+/// The wrapped value of the ``Authorized`` property wrapper. See according docs.
+public struct AuthorizedAuthenticatable<Element: Authenticatable>: DynamicProperty {
     @Environment(\.authorizationStateContainer)
     private var stateContainer
 
@@ -38,8 +46,6 @@ public struct Authorized<Element: Authenticatable>: DynamicProperty {
     public var isAuthorized: Bool {
         stateContainer.contains(element: Element.self)
     }
-
-    public init(_: Element.Type = Element.self) {}
 
     /// Returns the ``Authenticatable`` instance.
     /// - Returns: The ``Authenticatable`` instance.

--- a/Sources/ApodiniAuthorization/Delegates/Authenticator.swift
+++ b/Sources/ApodiniAuthorization/Delegates/Authenticator.swift
@@ -28,7 +28,7 @@ struct Authenticator<H: Handler, Configuration: AuthorizationConfiguration>: Han
     @Throws(.forbidden, options: .authorizationErrorReason(.failedAuthorization))
     var failedAuthorization
 
-    let authenticatable: Authorized<Configuration.Authenticatable> = .init()
+    @Authorized(Configuration.Authenticatable.self) var authenticatable
 
     init(_ configuration: Configuration, _ requirements: AuthorizationRequirements<Configuration.Authenticatable>, _ handler: H) {
         self.type = configuration.type

--- a/Sources/ApodiniAuthorization/Delegates/AuthorizationRequirementsChecker.swift
+++ b/Sources/ApodiniAuthorization/Delegates/AuthorizationRequirementsChecker.swift
@@ -26,7 +26,7 @@ struct AuthorizationRequirementsChecker<H: Handler, Element: Authenticatable>: H
     @Throws(.forbidden, options: .authorizationErrorReason(.failedAuthorization))
     var failedAuthorization
 
-    let authenticatable: Authorized<Element> = .init()
+    @Authorized(Element.self) var authenticatable
 
     init(type: AuthorizationType, _ requirements: AuthorizationRequirements<Element>, _ handler: H) {
         self.type = type

--- a/Tests/ApodiniAuthorizationTests/ApodiniAuthorizationTests.swift
+++ b/Tests/ApodiniAuthorizationTests/ApodiniAuthorizationTests.swift
@@ -44,7 +44,7 @@ class ApodiniAuthorizationTests: XCTApodiniTest {
     }
 
     struct EmptyHandler: Handler {
-        var user = Authorized(MockCredentials<Int>.self)
+        @Authorized(MockCredentials<Int>.self) var user
 
         func handle() throws -> String {
             let instance = try user()
@@ -59,7 +59,7 @@ class ApodiniAuthorizationTests: XCTApodiniTest {
     }
 
     struct ExampleHandler: Handler {
-        var user = Authorized(MockCredentials<Int>.self)
+        @Authorized(MockCredentials<Int>.self) var user
 
         func handle() throws -> String {
             let instance = try user()
@@ -97,7 +97,7 @@ class ApodiniAuthorizationTests: XCTApodiniTest {
         @Throws(.unauthenticated, options: .bearerErrorResponse(.init(.invalidToken)))
         var invalidToken
 
-        var token = Authorized(MockToken.self)
+        @Authorized(MockToken.self) var token
 
         func handle() throws -> String {
             let instance = try token()
@@ -150,7 +150,7 @@ class ApodiniAuthorizationTests: XCTApodiniTest {
     }
 
     struct HandlerWithOptionalAuth: Handler {
-        var token = Authorized<MockToken>()
+        @Authorized(MockToken.self) var token
 
         func handle() throws -> String {
             _ = try token()

--- a/Tests/ApodiniAuthorizationTests/JWTTests.swift
+++ b/Tests/ApodiniAuthorizationTests/JWTTests.swift
@@ -60,7 +60,7 @@ class JWTTests: XCTApodiniTest {
     }
 
     struct OptionallyAuthorizedHandler: Handler {
-        var token = Authorized<ExampleJWTToken>()
+        @Authorized(ExampleJWTToken.self) var token
 
         func handle() throws -> String {
             guard token.isAuthorized else {


### PR DESCRIPTION
# Make Authorised a property wrapper

## :recycle: Current situation & Problem

Explained in https://github.com/Apodini/ApodiniXpenseExample/pull/1#discussion_r686726564 in great detail, a simple `@Authorized var user: ExampleUser` approach cannot be used for the Authorized property, as the [[SE-0310]](https://github.com/kavon/swift-evolution/blob/main/proposals/0310-effectful-readonly-properties.md#extensions-considered) proposal doesn't include support for the `wrappedValue` of property wrappers.
Therefore a plain property based solution was originally chosen in #314.
@PSchmiedmayer noted in the above linked discussion that nonetheless a property wrapper based solution would be preferable from a consistency standpoint.

## :bulb: Proposed solution

This PR refactors the `Authorized` property to an property wrapper, which exposes a wrapper around the Authencitatable instance in its `wrappedValue`.

Should Swift ever get support for throwing `wrappedValues` one would change the implementation, such that `wrappedValue` returns the user instance directly. Attributes like `isAuthorized` could be accessed via the projected value of the property wrapper.

## :gear: Release Notes 

Instead of writing ...
```swift
var authorizedUser = Authorized<ExampleUser>()
// ...

// `isAuthorized` access
authorizedUser.isAuthorized

// user instance access
try authorizedUser()
```

... the declaration was changed to be based in a property wrapper with a `wrappedValue` exposing the same interface as the original Authorized property:

```swift
@Authorized(ExampleUser.self) var authorizedUser
// ...

// `isAuthorized` access
authorizedUser.isAuthorized

// user instance access
try authorizedUser()
```


## :heavy_plus_sign: Additional Information

### Related PRs
- #314 
- https://github.com/Apodini/ApodiniXpenseExample/pull/1

### Testing
No further testing was added.

### Reviewer Nudging
I hope this will be a quick and easy review.
