### PR TITLE
Reenable negative compile tests

### DIFF
--- a/Tests/ApodiniNegativeCompileTests/Cases/Metadata/ComponentMetadataTests.swift
+++ b/Tests/ApodiniNegativeCompileTests/Cases/Metadata/ComponentMetadataTests.swift
@@ -17,9 +17,6 @@ private struct TestComponent: Component {
         // error: Argument type 'AnyHandlerMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
         TestVoidHandlerMetadata()
 
-        // error: Argument type 'AnyWebServiceMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
-        TestVoidWebServiceMetadata()
-
         TestVoidComponentOnlyMetadata()
 
         TestVoidComponentMetadata()
@@ -33,22 +30,9 @@ private struct TestComponent: Component {
             TestVoidComponentMetadata()
         }
 
-        // error: Argument type 'AnyHandlerMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
-        StandardHandlerMetadataBlock {
-            TestVoidHandlerMetadata()
-        }
-
-        // error: Argument type 'AnyWebServiceMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
-        StandardWebServiceMetadataBlock {
-            TestVoidWebServiceMetadata()
-        }
-
         StandardComponentOnlyMetadataBlock {
             // error: Argument type 'AnyHandlerMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
             TestVoidHandlerMetadata()
-
-            // error: Argument type 'AnyWebServiceMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
-            TestVoidWebServiceMetadata()
 
             TestVoidComponentOnlyMetadata()
 
@@ -77,6 +61,38 @@ private struct TestComponent: Component {
         // error: No exact matches in call to static method 'buildExpression'
         StandardContentMetadataBlock {
             TestVoidContentMetadata()
+        }
+    }
+}
+
+private struct TestComponent2: Component {
+    var content: some Component {
+        Text("Hello World!")
+    }
+
+    var metadata: Metadata {
+        TestVoidComponentOnlyMetadata()
+
+        // error: Argument type 'AnyWebServiceMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
+        TestVoidWebServiceMetadata()
+
+        // error: Argument type 'AnyHandlerMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
+        StandardHandlerMetadataBlock {
+            TestVoidHandlerMetadata()
+        }
+
+        // error: Argument type 'AnyWebServiceMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
+        StandardWebServiceMetadataBlock {
+            TestVoidWebServiceMetadata()
+        }
+
+        StandardComponentOnlyMetadataBlock {
+            TestVoidComponentOnlyMetadata()
+
+            // error: Argument type 'AnyWebServiceMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
+            TestVoidWebServiceMetadata()
+
+            TestVoidComponentOnlyMetadata()
         }
     }
 }

--- a/Tests/ApodiniNegativeCompileTests/Cases/Metadata/RestrictedMetadata/RestrictedComponentMetadataTests.swift
+++ b/Tests/ApodiniNegativeCompileTests/Cases/Metadata/RestrictedMetadata/RestrictedComponentMetadataTests.swift
@@ -35,14 +35,24 @@ private struct TestComponent: Component {
             TestVoidHandlerMetadata()
         }
 
-        // error: Argument type 'AnyWebServiceMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
-        WebServiceVoids {
-            TestVoidWebServiceMetadata()
-        }
-
         // error: no exact matches in call to static method 'buildExpression'
         ContentVoids {
             TestVoidContentMetadata()
+        }
+    }
+}
+
+private struct TestComponent2: Component {
+    var content: some Component {
+        Text("Hello World!")
+    }
+
+    var metadata: Metadata {
+        TestVoidComponentOnlyMetadata()
+
+        // error: Argument type 'AnyWebServiceMetadata' does not conform to expected type 'AnyComponentOnlyMetadata'
+        WebServiceVoids {
+            TestVoidWebServiceMetadata()
         }
     }
 }

--- a/Tests/ApodiniNegativeCompileTests/Cases/Metadata/RestrictedMetadata/RestrictedWebServiceMetadataTests.swift
+++ b/Tests/ApodiniNegativeCompileTests/Cases/Metadata/RestrictedMetadata/RestrictedWebServiceMetadataTests.swift
@@ -32,14 +32,24 @@ private struct TestWebService: WebService {
             TestVoidComponentMetadata()
         }
 
-        // error: Argument type 'AnyComponentOnlyMetadata' does not conform to expected type 'AnyWebServiceMetadata'
-        ComponentOnlyVoids {
-            TestVoidComponentOnlyMetadata()
-        }
-
         // error: no exact matches in call to static method 'buildExpression'
         ContentVoids {
             TestVoidContentMetadata()
+        }
+    }
+}
+
+private struct TestWebService2: WebService {
+    var content: some Component {
+        Text("Hello World!")
+    }
+
+    var metadata: Metadata {
+        TestVoidWebServiceMetadata()
+
+        // error: Argument type 'AnyComponentOnlyMetadata' does not conform to expected type 'AnyWebServiceMetadata'
+        ComponentOnlyVoids {
+            TestVoidComponentOnlyMetadata()
         }
     }
 }

--- a/Tests/ApodiniNegativeCompileTests/Cases/Metadata/WebServiceMetadataTests.swift
+++ b/Tests/ApodiniNegativeCompileTests/Cases/Metadata/WebServiceMetadataTests.swift
@@ -19,9 +19,6 @@ private struct TestWebService: WebService {
 
         TestVoidWebServiceMetadata()
 
-        // error: Argument type 'AnyComponentOnlyMetadata' does not conform to expected type 'AnyWebServiceMetadata'
-        TestVoidComponentOnlyMetadata()
-
         TestVoidComponentMetadata()
 
         // error: No exact matches in call to static method 'buildExpression'
@@ -31,29 +28,16 @@ private struct TestWebService: WebService {
             TestVoidWebServiceMetadata()
         }
 
-        // error: Argument type 'AnyHandlerMetadata' does not conform to expected type 'AnyWebServiceMetadata'
-        StandardHandlerMetadataBlock {
-            TestVoidHandlerMetadata()
-        }
-
         StandardWebServiceMetadataBlock {
             // error: Argument type 'AnyHandlerMetadata' does not conform to expected type 'AnyWebServiceMetadata'
             TestVoidHandlerMetadata()
 
             TestVoidWebServiceMetadata()
 
-            // error: Argument type 'AnyComponentOnlyMetadata' does not conform to expected type 'AnyWebServiceMetadata'
-            TestVoidComponentOnlyMetadata()
-
             TestVoidComponentMetadata()
 
             // error: No exact matches in call to static method 'buildExpression'
             TestVoidContentMetadata()
-        }
-
-        // error: Argument type 'AnyComponentOnlyMetadata' does not conform to expected type 'AnyWebServiceMetadata'
-        StandardComponentOnlyMetadataBlock {
-            TestVoidComponentOnlyMetadata()
         }
 
         StandardComponentMetadataBlock {
@@ -63,6 +47,38 @@ private struct TestWebService: WebService {
         // error: No exact matches in call to static method 'buildExpression'
         StandardContentMetadataBlock {
             TestVoidContentMetadata()
+        }
+    }
+}
+
+private struct TestWebService2: WebService {
+    var content: some Component {
+        Text("Hello World!")
+    }
+
+    var metadata: Metadata {
+        TestVoidWebServiceMetadata()
+
+        // error: Argument type 'AnyComponentOnlyMetadata' does not conform to expected type 'AnyWebServiceMetadata'
+        TestVoidComponentOnlyMetadata()
+
+        // error: Argument type 'AnyHandlerMetadata' does not conform to expected type 'AnyWebServiceMetadata'
+        StandardHandlerMetadataBlock {
+            TestVoidHandlerMetadata()
+        }
+
+        TestVoidWebServiceMetadata()
+
+        StandardWebServiceMetadataBlock {
+            TestVoidWebServiceMetadata()
+
+            // error: Argument type 'AnyComponentOnlyMetadata' does not conform to expected type 'AnyWebServiceMetadata'
+            TestVoidComponentOnlyMetadata()
+        }
+
+        // error: Argument type 'AnyComponentOnlyMetadata' does not conform to expected type 'AnyWebServiceMetadata'
+        StandardComponentOnlyMetadataBlock {
+            TestVoidComponentOnlyMetadata()
         }
     }
 }

--- a/Tests/NegativeCompileTestsRunner/NegativeTestRunner.swift
+++ b/Tests/NegativeCompileTestsRunner/NegativeTestRunner.swift
@@ -12,10 +12,6 @@ import XCTest
 
 class XCTBootstrap: XCTestCase {
     func testRunner() throws {
-        throw XCTSkip("""
-            The NegativeTests are failing since Xcode 13 Beta 5.
-            @Supereg will take a look at this as noted here: https://github.com/Apodini/Apodini/pull/326#issuecomment-899036636
-        """)
         print("Bootstrapping negative test runner...")
         let runner = try NegativeTestRunner()
 

--- a/Tests/NegativeCompileTestsRunner/configurations.swift
+++ b/Tests/NegativeCompileTestsRunner/configurations.swift
@@ -13,7 +13,8 @@ let configurations: TestRunnerConfiguration = [
     .target(
         name: "ApodiniNegativeCompileTests",
         configurations: [
-            .testCase("Metadata")
+            // linux platform is disabled for now. Compiler crashes randomly with segfault
+            .testCase("Metadata", .exclude(.linux))
         ]
     )
 ]

--- a/Tests/NegativeCompileTestsRunner/configurations.swift
+++ b/Tests/NegativeCompileTestsRunner/configurations.swift
@@ -14,7 +14,7 @@ let configurations: TestRunnerConfiguration = [
         name: "ApodiniNegativeCompileTests",
         configurations: [
             // linux platform is disabled for now. Compiler crashes randomly with segfault
-            .testCase("Metadata", .exclude(.linux))
+            .testCase("Metadata", runningOn: .exclude(.linux))
         ]
     )
 ]

--- a/Tests/NegativeCompileTestsRunner/configurations.swift
+++ b/Tests/NegativeCompileTestsRunner/configurations.swift
@@ -13,10 +13,7 @@ let configurations: TestRunnerConfiguration = [
     .target(
         name: "ApodiniNegativeCompileTests",
         configurations: [
-            // Linux has issues compiling malformed resultBuilders, resulting in one compiler error
-            // "failed to produce diagnostic for expression; please file a bug report" for the whole block
-            // when too many errors occurred inside. Therefore linux platform is excluded.
-            .testCase("Metadata", runningOn: .exclude(.linux))
+            .testCase("Metadata")
         ]
     )
 ]


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Reenable negative compile tests

## :recycle: Current situation & Problem

Due to changes in the compiler of the toolchain shipped with Xcode Beta 5 we disabled the Negative Compile Tests in #331.

## :bulb: Proposed solution
This PR reenables those tests by splitting the problematic cases into multiple Metadata Blocks. The compiler previously seemed to have struggles to flag all compiler errors if certain scenarios where it encountered multiple compiler errors in a single result builder closure.

## :gear: Release Notes 
--

## :heavy_plus_sign: Additional Information

### Related PRs
- Introduction of the feature: #285 
- Temporarily disabled in: #331 

### Testing
--
### Reviewer Nudging
--
