### PR TITLE
ApodiniAuthorization: Adding more natural init overloads to conditional AuthorizationRequirements

### DIFF
--- a/Sources/ApodiniAuthorization/AuthorizationRequirements/ConditionalAuthorizationRequirement.swift
+++ b/Sources/ApodiniAuthorization/AuthorizationRequirements/ConditionalAuthorizationRequirement.swift
@@ -87,14 +87,14 @@ public extension ConditionalAuthorizationRequirement {
 
     /// Creates an ``AuthorizationCondition`` which evaluates to `true` if the `Bool` property
     /// pointed to by the `KeyPath` holds the value `true`.
-    /// - Parameter keyPath: The `KeyPath`.
+    /// - Parameter boolKeyPath: The `KeyPath`.
     init(if boolKeyPath: KeyPath<Element, Bool>) {
         self.init(if: AuthorizationCondition { instance in instance[keyPath: boolKeyPath] })
     }
 
     /// Creates an ``AuthorizationCondition`` which evaluates to `true` if the `Bool` property
     /// pointed to by the `KeyPath` holds the value `false`.
-    /// - Parameter keyPath: The `KeyPath`.
+    /// - Parameter boolKeyPath: The `KeyPath`.
     init(ifNot boolKeyPath: KeyPath<Element, Bool>) {
         self.init(if: AuthorizationCondition { instance in !instance[keyPath: boolKeyPath] })
     }

--- a/Sources/ApodiniAuthorization/AuthorizationRequirements/Verify.swift
+++ b/Sources/ApodiniAuthorization/AuthorizationRequirements/Verify.swift
@@ -22,3 +22,41 @@ public struct Verify<Element: Authenticatable>: ConditionalAuthorizationRequirem
             : .rejected(cause: .result(self))
     }
 }
+
+public extension Verify {
+    /// Creates an ``AuthorizationCondition`` which evaluates to `true` if the optional property
+    /// pointed to by the `KeyPath` is not `nil`.
+    ///
+    /// ``init(isPresent:)`` is equivalent to ``init(ifPresent:)`` and only available in the ``Verify`` ``ConditionalAuthorizationRequirement``.
+    /// - Parameter keyPath: The `KeyPath`.
+    init<Value>(isPresent keyPath: KeyPath<Element, Value?>) {
+        self.init(ifPresent: keyPath)
+    }
+
+    /// Creates an ``AuthorizationCondition`` which evaluates to `true` if the optional property
+    /// pointed to by the `KeyPath` is `nil`.
+    ///
+    /// ``init(isNil:):)`` is equivalent to ``init(ifNil:):)`` and only available in the ``Verify`` ``ConditionalAuthorizationRequirement``.
+    /// - Parameter keyPath: The `KeyPath`.
+    init<Value>(notPresent keyPath: KeyPath<Element, Value?>) {
+        self.init(ifNil: keyPath)
+    }
+
+    /// Creates an ``AuthorizationCondition`` which evaluates to `true` if the `Bool` property
+    /// pointed to by the `KeyPath` holds the value `true`.
+    ///
+    /// ``init(that:)`` is equivalent to ``init(if:)`` and only available in the ``Verify`` ``ConditionalAuthorizationRequirement``.
+    /// - Parameter boolKeyPath: The `KeyPath`.
+    init(that boolKeyPath: KeyPath<Element, Bool>) {
+        self.init(if: boolKeyPath)
+    }
+
+    /// Creates an ``AuthorizationCondition`` which evaluates to `true` if the `Bool` property
+    /// pointed to by the `KeyPath` holds the value `false`.
+    ///
+    /// ``init(not:)`` is equivalent to ``init(ifNot:)`` and only available in the ``Verify`` ``ConditionalAuthorizationRequirement``.
+    /// - Parameter boolKeyPath: The `KeyPath`.
+    init(not boolKeyPath: KeyPath<Element, Bool>) {
+        self.init(ifNot: boolKeyPath)
+    }
+}

--- a/Sources/ApodiniAuthorizationJWT/AuthenticationRequirements/Verify+BoolClaim.swift
+++ b/Sources/ApodiniAuthorizationJWT/AuthenticationRequirements/Verify+BoolClaim.swift
@@ -1,0 +1,39 @@
+//
+// Created by Andreas Bauer on 18.08.21.
+//
+
+import Apodini
+import ApodiniAuthorization
+import JWTKit
+
+public extension ConditionalAuthorizationRequirement {
+    /// Creates an ``AuthorizationCondition`` which evaluates to `true` if the JWT `BoolClaim` property
+    /// pointed to by the `KeyPath` holds the value `true`.
+    /// - Parameter boolKeyPath: The `KeyPath`.
+    init(if boolKeyPath: KeyPath<Element, BoolClaim>) {
+        self.init { element in element[keyPath: boolKeyPath].value }
+    }
+
+    /// Creates an ``AuthorizationCondition`` which evaluates to `true` if the JWT `BoolClaim` property
+    /// pointed to by the `KeyPath` holds the value `false`.
+    /// - Parameter boolKeyPath: The `KeyPath`.
+    init(ifNot boolKeyPath: KeyPath<Element, BoolClaim>) {
+        self.init { element in !element[keyPath: boolKeyPath].value }
+    }
+}
+
+public extension Verify {
+    /// Creates an ``AuthorizationCondition`` which evaluates to `true` if the JWT `BoolClaim` property
+    /// pointed to by the `KeyPath` holds the value `true`.
+    /// - Parameter boolKeyPath: The `KeyPath`.
+    init(that boolKeyPath: KeyPath<Element, BoolClaim>) {
+        self.init(if: boolKeyPath)
+    }
+
+    /// Creates an ``AuthorizationCondition`` which evaluates to `true` if the JWT `BoolClaim` property
+    /// pointed to by the `KeyPath` holds the value `false`.
+    /// - Parameter boolKeyPath: The `KeyPath`.
+    init(not boolKeyPath: KeyPath<Element, BoolClaim>) {
+        self.init(ifNot: boolKeyPath)
+    }
+}

--- a/Sources/ApodiniAuthorizationJWT/AuthenticationRequirements/Verify+BoolClaim.swift
+++ b/Sources/ApodiniAuthorizationJWT/AuthenticationRequirements/Verify+BoolClaim.swift
@@ -1,5 +1,9 @@
 //
-// Created by Andreas Bauer on 18.08.21.
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
 //
 
 import Apodini

--- a/Tests/ApodiniAuthorizationTests/AuthorizationRequirementsTests.swift
+++ b/Tests/ApodiniAuthorizationTests/AuthorizationRequirementsTests.swift
@@ -47,6 +47,29 @@ class AuthorizationRequirementsTests: XCTApodiniTest {
         XCTAssertEqual(try condition.evaluate(for: StringAuthenticatable("TEST")), .fulfilled())
     }
 
+    func testVerifyOverloads() throws {
+        @AuthorizationRequirementsBuilder<StringAuthenticatable>
+        var condition0: AuthorizationRequirements<StringAuthenticatable> {
+            Verify(isPresent: \.someStringOptional)
+            Verify(that: \.someBool)
+        }
+
+        XCTAssertEqual(try condition0.evaluate(for: StringAuthenticatable("asdf")), .rejected())
+        XCTAssertEqual(try condition0.evaluate(for: StringAuthenticatable(optional: "some Value", bool: false)), .rejected())
+        XCTAssertEqual(try condition0.evaluate(for: StringAuthenticatable(optional: "some Value", bool: true)), .undecided())
+
+
+        @AuthorizationRequirementsBuilder<StringAuthenticatable>
+        var condition1: AuthorizationRequirements<StringAuthenticatable> {
+            Verify(notPresent: \.someStringOptional)
+            Verify(not: \.someBool)
+        }
+
+        XCTAssertEqual(try condition1.evaluate(for: StringAuthenticatable("asdf")), .undecided())
+        XCTAssertEqual(try condition1.evaluate(for: StringAuthenticatable(optional: "some Value", bool: false)), .rejected())
+        XCTAssertEqual(try condition1.evaluate(for: StringAuthenticatable(optional: "some Value", bool: true)), .rejected())
+    }
+
     func testAlwaysAllow() throws {
         @AuthorizationRequirementsBuilder<StringAuthenticatable>
         var condition: AuthorizationRequirements<StringAuthenticatable> {
@@ -80,6 +103,7 @@ class AuthorizationRequirementsTests: XCTApodiniTest {
                 case true:
                     Deny(ifNil: \.someStringOptional)
                 case false:
+                    // bVerify(isNil: \.someStringOptional) // same thing as below, just testing a different init
                     Allow(ifNil: \.someStringOptional)
                 }
 

--- a/Tests/ApodiniAuthorizationTests/JWTTests.swift
+++ b/Tests/ApodiniAuthorizationTests/JWTTests.swift
@@ -47,6 +47,9 @@ class JWTTests: XCTApodiniTest {
                 Verify(notBefore: \.nbf)
 
                 Verify(issuer: \.iss, is: "https://other-option.org", "https://example.org")
+
+                Verify(that: \.adminFlag)
+                Deny(ifNot: \.adminFlag) // the same thing, just testing a different init
             }
             Authorize(ExampleJWTToken.self) {
                 Deny { element in
@@ -98,7 +101,8 @@ class JWTTests: XCTApodiniTest {
                 nbf: .init(value: notBefore),
                 aud: .init(value: audience),
                 iss: "https://example.org",
-                email: email
+                email: email,
+                adminFlag: true
             )
             
             return try signers.sign(payload)
@@ -112,6 +116,7 @@ class JWTTests: XCTApodiniTest {
         var iss: IssuerClaim
 
         var email: String?
+        var adminFlag: BoolClaim
     }
 
     // swiftlint:disable:next implicitly_unwrapped_optional


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# ApodiniAuthorization: Adding more natural init overloads to conditional AuthorizationRequirements

## :recycle: Current situation & Problem

* Currently some `ConditionalAuthorizationRequirement` init overloads read weird for the `Verify` requirement: eg `Verify(if: \.someBool)` might not be properly deliver what is meant.
* Currently no overloads exists for JWTKits `BoolClaim` introducing some overhead to unwrap the `value`.

## :bulb: Proposed solution
* Added some additional overloads to the `Verify` requirement: `Verify(that:)`, `Verify(not:)`, `Verify(isPresent:)`, `Verify(notPresent:)` which should enable writing more clear authorization requirements
* Added `ConditionalAuthorizationRequirement` inits for KeyPaths pointing to a `BoolClaim` of a JWT Token.

## :gear: Release Notes 

* **ApodiniAuthorization**: Added the following new overloads to the `Verify` requirement to allow a more precise formulation of authorization requirements: `Verify(that:)`, `Verify(not:)`, `Verify(isPresent:)`, `Verify(notPresent:)`
* **ApodiniAuthorizationJWT**: Added the new overloads for all conditional authorization requirements (`Allow`, `Deny`, `Verify`) for KeyPaths pointing toward a `BoolClaim`: `init(if:)`, `init(ifNot:)`.

## :heavy_plus_sign: Additional Information

### Related PRs
- Introduction of ApodiniAuthorization #314 

### Testing
Testing for those new initialisers was added.

### Reviewer Nudging
--
