### PR TITLE
Remove Unneeded Build Flags

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -104,10 +104,10 @@ jobs:
       run: swift --version
     - name: Release Build # Ensuring release build runs successfully without -enable-testing flag
       if: matrix.configuration == 'release'
-      run: swift build -Xswiftc -Xfrontend -Xswiftc -sil-verify-none -c release
+      run: swift build -c release
     - name: Release Build & Test
       if: matrix.configuration == 'release_testing'
-      run: swift test -Xswiftc -DWORKAROUND -Xswiftc -Xfrontend -Xswiftc -sil-verify-none -c release -Xswiftc -enable-testing -Xswiftc -DRELEASE_TESTING
+      run: swift test -c release -Xswiftc -enable-testing -Xswiftc -DRELEASE_TESTING
     - name: Debug Build & Test
       if: matrix.configuration == 'debug'
-      run: swift test -Xswiftc -DWORKAROUND -Xswiftc -Xfrontend -Xswiftc -sil-verify-none -c debug
+      run: swift test -c debug

--- a/.github/workflows/test-webservice.yml
+++ b/.github/workflows/test-webservice.yml
@@ -82,10 +82,10 @@ jobs:
       run: swift --version
     - name: Release Build # Ensuring release build runs successfully without -enable-testing flag
       if: matrix.configuration == 'release'
-      run: swift build -Xswiftc -Xfrontend -Xswiftc -sil-verify-none -c release
+      run: swift build -c release
     - name: Release Build & Test
       if: matrix.configuration == 'release_testing'
-      run: swift test -Xswiftc -Xfrontend -Xswiftc -sil-verify-none -c release -Xswiftc -enable-testing -Xswiftc -DRELEASE_TESTING
+      run: swift test -c release -Xswiftc -enable-testing -Xswiftc -DRELEASE_TESTING
     - name: Debug Build & Test
       if: matrix.configuration == 'debug'
-      run: swift test -Xswiftc -Xfrontend -Xswiftc -sil-verify-none -c debug
+      run: swift test -c debug

--- a/Documentation/Testing/NegativeCompileTests.md
+++ b/Documentation/Testing/NegativeCompileTests.md
@@ -83,7 +83,3 @@ Those are:
 - When using the `--enable-code-coverage` flag we require that the Active Compilation Condition `COVERAGE` is also 
   set by supplying `-Xswiftc -DCOVERAGE`. When detecting `COVERAGE` we therefore
   append `--enable-code-coverage -Xswiftc -DCOVERAGE`
-- When detecting the `WORKAROUND` Active Compilation Condition we pass the
-  `-Xswiftc -DWORKAROUND -Xswiftc -Xfrontend -Xswiftc -sil-verify-none` arguments to the compiler.
-  Those are part of a workaround introduced in [#294](https://github.com/Apodini/Apodini/pull/294) in order
-  to compile on linux platforms with swift 5.4.

--- a/Sources/Apodini/Apodini.docc/Advanced/Testing/NegativeCompileTest.md
+++ b/Sources/Apodini/Apodini.docc/Advanced/Testing/NegativeCompileTest.md
@@ -87,10 +87,6 @@ Those are:
 - When using the `--enable-code-coverage` flag we require that the Active Compilation Condition `COVERAGE` is also 
   set by supplying `-Xswiftc -DCOVERAGE`. When detecting `COVERAGE` we therefore
   append `--enable-code-coverage -Xswiftc -DCOVERAGE`
-- When detecting the `WORKAROUND` Active Compilation Condition we pass the
-  `-Xswiftc -DWORKAROUND -Xswiftc -Xfrontend -Xswiftc -sil-verify-none` arguments to the compiler.
-  Those are part of a workaround introduced in [#294](https://github.com/Apodini/Apodini/pull/294) in order
-  to compile on linux platforms with swift 5.4.
 
 
 ## Topics

--- a/Sources/DeploymentTargetAWSLambda/Commands/DeployWebServiceCommand.swift
+++ b/Sources/DeploymentTargetAWSLambda/Commands/DeployWebServiceCommand.swift
@@ -247,7 +247,7 @@ struct LambdaDeploymentProviderImpl: DeploymentProvider {
         let filePath = ".build/\(tmpDirName)/\(filename)"
         try runInDocker(
             imageName: dockerImageName,
-            bashCommand: "swift run -Xswiftc -Xfrontend -Xswiftc -sil-verify-none \(productName) deploy export-ws-structure aws \(filePath) --identifier \(Self.identifier.rawValue) --aws-api-gateway-api-id \(awsApiGatewayApiId) --aws-region \(awsRegion)"
+            bashCommand: "swift run \(productName) deploy export-ws-structure aws \(filePath) --identifier \(Self.identifier.rawValue) --aws-api-gateway-api-id \(awsApiGatewayApiId) --aws-region \(awsRegion)"
         )
         let url = tmpDirUrl.appendingPathComponent(filename, isDirectory: false)
         return try LambdaDeployedSystem(decodingJSONAt: url)
@@ -268,7 +268,7 @@ struct LambdaDeploymentProviderImpl: DeploymentProvider {
         try runInDocker(
             imageName: dockerImageName,
             bashCommand:
-                "swift build -Xswiftc -Xfrontend -Xswiftc -sil-verify-none --product \(productName) && .build/\(tmpDirName)/\(scriptFilename) .build/debug/\(productName) .build/lambda/\(productName)/"
+                "swift build --product \(productName) && .build/\(tmpDirName)/\(scriptFilename) .build/debug/\(productName) .build/lambda/\(productName)/"
         )
         let outputUrl = buildFolderUrl
             .appendingPathComponent("debug", isDirectory: true)

--- a/Tests/NegativeCompileTestsRunner/NegativeTestRunner.swift
+++ b/Tests/NegativeCompileTestsRunner/NegativeTestRunner.swift
@@ -288,12 +288,6 @@ class NegativeTestRunner {
         arguments += " --enable-code-coverage -Xswiftc -DCOVERAGE"
         #endif
 
-        // custom defined Active Compilation Condition for the workaround compiler arguments
-        // introduced in https://github.com/Apodini/Apodini/pull/294
-        #if WORKAROUND
-        arguments += " -Xswiftc -DWORKAROUND -Xswiftc -Xfrontend -Xswiftc -sil-verify-none"
-        #endif
-
         let stdOutput = try runCommand(command: "swift", arguments: arguments, expectedStatus: 1)
 
         print("[\(identifier)] Scanning results for target \(target.name)...")


### PR DESCRIPTION
# Remove Unneeded Build Flags

## :recycle: Current situation & Problem
As noted in the release notes of [Apodini 0.3.0](https://github.com/Apodini/Apodini/releases/tag/0.3.0) there is a bug in Swift 5.4 that prevents OpenAPIKit from compiler on Swift 5.4 and 5.5. It seems this bug has been solved with the latest Swift 5.5 builds.
Therefore the noted additional compiler flags can be removed.

## :bulb: Proposed solution
Remove the compiler flags

## :gear: Release Notes 
It is no longer needed to add the `-Xswiftc -Xfrontend -Xswiftc -sil-verify-none` to a `swift build`, `swift test`, or `swift run` command when using Swift 5.5.

### Related PRs
#294 

### Testing
All existing tests verify what the program behavior is the same without the additional flags.