### PR TITLE
Filter process list to only include TCP state LISTEN

### DIFF
--- a/Sources/ApodiniUtils/Shell.swift
+++ b/Sources/ApodiniUtils/Shell.swift
@@ -18,8 +18,8 @@ public enum ShellCommand {
 
     var method: String {
         switch self {
-        case let .killPort(port): return "kill $(lsof -ti:\(port))"
-        case let .getProcessesAtPort(port): return "lsof -ti:\(port)"
+        case let .killPort(port): return "kill $(lsof -t -i :\(port) -sTCP:LISTEN)"
+        case let .getProcessesAtPort(port): return "lsof -t -i :\(port) -sTCP:LISTEN"
         }
     }
 }


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Filter process list to only include TCP state LISTEN

## :recycle: Current situation & Problem
While trying to run all the tests, I noticed that a lot of them failed on my machine with the following error:
> A web service is running at port 8080 after running the test case.
   All processes at port 8080 must be shut down after running the test case.

After a bit of investigating, I found that `homed` keeps a TCP connection to my Philips Hue bridge which is listening **on port 8080**. See the following `lsof` output:
```
$ lsof -i -P
COMMAND     PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
homed       485 moritz   19u  IPv4 0x23e9f33eeb800865      0t0  TCP fitz.mst.haus:49182->philips-hue.mst.haus:8080 (ESTABLISHED)
...
```

The currently implemented calls to `lsof` to get PIDs of processes listening on a specific port don't filter for connections in the in the TCP state LISTEN. This makes the output include PIDs of the processes that established connections to the specified port.

## :bulb: Proposed solution
As connections like the one I described above are not relevant to check if a process is listening on a specific port, I changed the `lsof` flags to provide the correct output.

For more information, see the documentation of the `-s` flag in [the `lsof` man page](https://linux.die.net/man/8/lsof).

After applying the patch, all tests are green for me, regardless of the established TCP connection.
