### PR TITLE
Dependency maintenance: Swift NIO and Swift Collections

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -183,11 +183,11 @@
       },
       {
         "package": "Runtime",
-        "repositoryURL": "https://github.com/Supereg/Runtime.git",
+        "repositoryURL": "https://github.com/wickwirew/Runtime.git",
         "state": {
           "branch": null,
-          "revision": "596e22a518bb3f8177cd796cd77e5386098a33f8",
-          "version": "2.2.3"
+          "revision": "dad03135d7701a4e7b3a4051e75d6b37bd8e178e",
+          "version": "2.2.4"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-kit.git",
         "state": {
           "branch": null,
-          "revision": "06a6939ff486cb6abae08b2e025b02291cff0da0",
-          "version": "1.15.3"
+          "revision": "9fbef6bad614e0b1bf3083f629b40574c97ab0b9",
+          "version": "1.16.0"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/soto-project/soto.git",
         "state": {
           "branch": null,
-          "revision": "3a8e82ac86a75e548504b6f5aeeeda209a4e7c27",
-          "version": "5.8.1"
+          "revision": "c735c22ce67c78b39664fb6f63e3b340c97d024c",
+          "version": "5.10.0"
         }
       },
       {
@@ -204,8 +204,8 @@
         "repositoryURL": "https://github.com/soto-project/soto-core.git",
         "state": {
           "branch": null,
-          "revision": "283f0de557995848c1fea5893124956084b433f8",
-          "version": "5.6.0"
+          "revision": "41f4beb6396ad8c8fdff6092bcdba018d9b87f4e",
+          "version": "5.7.2"
         }
       },
       {
@@ -276,8 +276,8 @@
         "repositoryURL": "https://github.com/swift-server/swift-aws-lambda-runtime.git",
         "state": {
           "branch": null,
-          "revision": "a9e15b13b30b6700056c4cfbdcf6a69382a9fb6f",
-          "version": "0.5.0"
+          "revision": "699ada1724459582303c15aae64fa12ca4d33809",
+          "version": "0.5.2"
         }
       },
       {
@@ -294,8 +294,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections",
         "state": {
           "branch": null,
-          "revision": "9d8719c8bebdc79740b6969c912ac706eb721d7a",
-          "version": "0.0.7"
+          "revision": "2d33a0ea89c961dcb2b3da2157963d9c0370347e",
+          "version": "1.0.1"
         }
       },
       {
@@ -339,8 +339,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "1d425b0851ffa2695d488cce1d68df2539f42500",
-          "version": "2.31.2"
+          "revision": "6aa9347d9bc5bbfe6a84983aec955c17ffea96ef",
+          "version": "2.33.0"
         }
       },
       {
@@ -366,8 +366,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "2e74773972bd6254c41ceeda827f229bccbf1c0f",
-          "version": "2.15.0"
+          "revision": "5e68c1ded15619bb281b273fa8c2d8fd7f7b2b7d",
+          "version": "2.16.1"
         }
       },
       {
@@ -384,8 +384,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "27119271502bf266be293be5325f0fb72435e8fd",
-          "version": "4.49.2"
+          "revision": "68233685fd1a943e8772634e02abfec076dcb8f4",
+          "version": "4.52.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -79,10 +79,7 @@ let package = Package(
         // CLI-Argument parsing in the WebService and ApodiniDeploy
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.4.0")),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
-        .package(url: "https://github.com/Supereg/Runtime.git", from: "2.2.3"),
-        // restore original package url once https://github.com/wickwirew/Runtime/pull/93
-        // and https://github.com/wickwirew/Runtime/pull/95 are merged
-        // .package(url: "https://github.com/wickwirew/Runtime.git", from: "2.2.3"),
+        .package(url: "https://github.com/wickwirew/Runtime.git", from: "2.2.4"),
         
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
         // Used for testing of the new ExporterConfiguration
@@ -90,10 +87,6 @@ let package = Package(
         
         // Deploy
         .package(url: "https://github.com/vapor-community/vapor-aws-lambda-runtime.git", .upToNextMinor(from: "0.6.2")),
-        // vapor-aws-lambda-runtime isn't currently updated to include the latest swift-aws-lambda-runtime which is required
-        // to use the latest swift-nio package. Therefore we pin the version manually. May be removed with an updated
-        // version of the above package.
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", .upToNextMajor(from: "0.5.2")),
         .package(url: "https://github.com/soto-project/soto.git", from: "5.10.0"),
         .package(url: "https://github.com/soto-project/soto-s3-file-transfer", from: "0.4.0"),
         
@@ -605,10 +598,7 @@ let package = Package(
                 .target(name: "DeploymentTargetAWSLambdaCommon"),
                 .target(name: "ApodiniDeployRuntimeSupport"),
                 .target(name: "ApodiniOpenAPI"),
-                .product(name: "VaporAWSLambdaRuntime", package: "vapor-aws-lambda-runtime"),
-
-                // Only added to silence the 'warning: dependency 'swift-aws-lambda-runtime' is not used by any target'
-                .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime")
+                .product(name: "VaporAWSLambdaRuntime", package: "vapor-aws-lambda-runtime")
             ]
         ),
         

--- a/Package.swift
+++ b/Package.swift
@@ -55,13 +55,13 @@ let package = Package(
         .library(name: "ApodiniMigration", targets: ["ApodiniMigration"])
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.45.0"),
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.13.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.52.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.16.0"),
         .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.1.0"),
         // Used by the `NotificationCenter` to send push notifications to `APNS`.
-        .package(name: "apnswift", url: "https://github.com/kylebrowning/APNSwift.git", from: "3.0.0"),
+        .package(name: "apnswift", url: "https://github.com/kylebrowning/APNSwift.git", from: "3.2.0"),
         // Used by the `NotificationCenter` to send push notifications to `FCM`.
-        .package(url: "https://github.com/MihaelIsaev/FCM.git", from: "2.10.0"),
+        .package(url: "https://github.com/MihaelIsaev/FCM.git", from: "2.11.0"),
         // Use to navigate around some of the existentials limitations of the Swift Compiler
         // As AssociatedTypeRequirementsKit does not follow semantic versioning we constraint it to the current minor version
         .package(url: "https://github.com/nerdsupremacist/AssociatedTypeRequirementsKit.git", .upToNextMinor(from: "0.3.2")),
@@ -69,17 +69,16 @@ let package = Package(
         .package(url: "https://github.com/MihaelIsaev/SwifCron.git", from: "1.3.0"),
         .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "2.4.0"),
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
-        // Update to 2.32 or higher once https://github.com/swift-server/swift-aws-lambda-runtime tags a new release with swift-nio 2.32 or higher
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMinor(from: "2.31.0")),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.33.0")),
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.13.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.16.0"),
         // HTTP/2 support for SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.17.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.18.0"),
         // Swift logging API
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
         // CLI-Argument parsing in the WebService and ApodiniDeploy
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.4.0")),
-        .package(url: "https://github.com/apple/swift-collections", .upToNextMinor(from: "0.0.4")),
+        .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
         .package(url: "https://github.com/Supereg/Runtime.git", from: "2.2.3"),
         // restore original package url once https://github.com/wickwirew/Runtime/pull/93
         // and https://github.com/wickwirew/Runtime/pull/95 are merged
@@ -87,12 +86,16 @@ let package = Package(
         
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
         // Used for testing of the new ExporterConfiguration
-        .package(url: "https://github.com/soto-project/soto-core.git", from: "5.3.0"),
+        .package(url: "https://github.com/soto-project/soto-core.git", from: "5.7.0"),
         
         // Deploy
         .package(url: "https://github.com/vapor-community/vapor-aws-lambda-runtime.git", .upToNextMinor(from: "0.6.2")),
-        .package(url: "https://github.com/soto-project/soto.git", from: "5.5.0"),
-        .package(url: "https://github.com/soto-project/soto-s3-file-transfer", from: "0.3.0"),
+        // vapor-aws-lambda-runtime isn't currently updated to include the latest swift-aws-lambda-runtime which is required
+        // to use the latest swift-nio package. Therefore we pin the version manually. May be removed with an updated
+        // version of the above package.
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", .upToNextMajor(from: "0.5.2")),
+        .package(url: "https://github.com/soto-project/soto.git", from: "5.10.0"),
+        .package(url: "https://github.com/soto-project/soto-s3-file-transfer", from: "0.4.0"),
         
         // testing runtime crashes
         .package(url: "https://github.com/norio-nomura/XCTAssertCrash.git", from: "0.2.0"),
@@ -101,7 +104,7 @@ let package = Package(
         .package(url: "https://github.com/Apodini/MetadataSystem.git", .upToNextMinor(from: "0.1.0")),
 
         // Apodini Authorization
-        .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0"),
+        .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.3.0"),
         
         // Apodini Migrator
         .package(url: "https://github.com/Apodini/ApodiniMigrator.git", .upToNextMinor(from: "0.1.0")),
@@ -150,7 +153,6 @@ let package = Package(
                 .target(name: "ApodiniUtils"),
                 .target(name: "Apodini"),
                 .product(name: "NIO", package: "swift-nio"),
-                .product(name: "_NIOConcurrency", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log")
             ]
         ),
@@ -603,7 +605,10 @@ let package = Package(
                 .target(name: "DeploymentTargetAWSLambdaCommon"),
                 .target(name: "ApodiniDeployRuntimeSupport"),
                 .target(name: "ApodiniOpenAPI"),
-                .product(name: "VaporAWSLambdaRuntime", package: "vapor-aws-lambda-runtime")
+                .product(name: "VaporAWSLambdaRuntime", package: "vapor-aws-lambda-runtime"),
+
+                // Only added to silence the 'warning: dependency 'swift-aws-lambda-runtime' is not used by any target'
+                .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime")
             ]
         ),
         

--- a/Sources/ApodiniExtension/AsyncSequenceHelpers/ConvenienceFunctions.swift
+++ b/Sources/ApodiniExtension/AsyncSequenceHelpers/ConvenienceFunctions.swift
@@ -9,7 +9,6 @@
 
 import _Concurrency
 import NIO
-import _NIOConcurrency
 
 public extension AsyncSequence {
     /// A shorthand for combining this sequence and ``Tail`` using `flatMap`.
@@ -36,7 +35,7 @@ public extension AsyncSequence {
     func firstFuture(on eventLoop: EventLoop) -> EventLoopFuture<Element?> {
         let promise = eventLoop.makePromise(of: Element?.self)
         
-        promise.completeWithAsync {
+        promise.completeWithTask {
             try await self.first(where: { _ in true })
         }
     

--- a/Sources/ApodiniExtension/Evaluation/OneOffEvaluation.swift
+++ b/Sources/ApodiniExtension/Evaluation/OneOffEvaluation.swift
@@ -9,7 +9,7 @@
 import Apodini
 import ApodiniUtils
 import Foundation
-import _NIOConcurrency
+import NIO
 
 /// A wrapper which contains the input-output pair of a `Delegate`'s evaluation.
 public struct ResponseWithRequest<C: Encodable>: WithRequest {
@@ -53,10 +53,10 @@ internal extension Delegate where D: Handler {
         try await _Internal.evaluate(delegate: self, using: request, with: state)
     }
     
-        func evaluate(using request: Request, with state: ConnectionState = .end) -> EventLoopFuture<Response<D.Response.Content>> {
+    func evaluate(using request: Request, with state: ConnectionState = .end) -> EventLoopFuture<Response<D.Response.Content>> {
         let promise = request.eventLoop.makePromise(of: Response<D.Response.Content>.self)
         
-        promise.completeWithAsync {
+        promise.completeWithTask {
             try await self.evaluate(using: request, with: state)
         }
         
@@ -73,7 +73,7 @@ internal extension Delegate where D: Handler {
                       with state: ConnectionState = .end) -> EventLoopFuture<Response<D.Response.Content>> {
         let promise = request.eventLoop.makePromise(of: Response<D.Response.Content>.self)
         
-        promise.completeWithAsync {
+        promise.completeWithTask {
             try await self.evaluate(trigger, using: request, with: state)
         }
         

--- a/Sources/ApodiniExtension/Exports.swift
+++ b/Sources/ApodiniExtension/Exports.swift
@@ -8,4 +8,3 @@
 
 @_exported import protocol ApodiniUtils.AnyDecoder
 @_exported import protocol ApodiniUtils.AnyEncoder
-@_exported import _NIOConcurrency

--- a/Sources/ApodiniGRPC/GRPCInterfaceExporter.swift
+++ b/Sources/ApodiniGRPC/GRPCInterfaceExporter.swift
@@ -26,7 +26,7 @@ public final class GRPC: Configuration {
     }
     
     public func configure(_ app: Apodini.Application) {
-        /// Instanciate exporter
+        /// Instantiate exporter
         let grpcExporter = GRPCInterfaceExporter(app, self.configuration)
         
         /// Insert exporter into `InterfaceExporterStorage`
@@ -44,7 +44,7 @@ final class GRPCInterfaceExporter: LegacyInterfaceExporter {
     var services: [String: GRPCService]
     var parameters: [UUID: Int]
 
-    /// Initalize `GRPCInterfaceExporter` from `Application`
+    /// Initialize `GRPCInterfaceExporter` from `Application`
     init(_ app: Apodini.Application,
          _ exporterConfiguration: GRPC.ExporterConfiguration = GRPC.ExporterConfiguration()) {
         self.app = app
@@ -68,7 +68,7 @@ final class GRPCInterfaceExporter: LegacyInterfaceExporter {
             }
 
         // expose the new component via a GRPCService
-        // currently unary enpoints are considered here
+        // currently unary endpoints are considered here
         let service: GRPCService
         if let existingService = services[serviceName] {
             service = existingService
@@ -113,7 +113,7 @@ final class GRPCInterfaceExporter: LegacyInterfaceExporter {
             // If this occurs, something went fundamentally wrong in usage
             // of the GRPC exporter.
             // Each parameter should get a default field tag assigned
-            // above in the export() funtction.
+            // above in the export() function.
             fatalError("No default or explicit field tag available")
         }
 
@@ -126,7 +126,7 @@ final class GRPCInterfaceExporter: LegacyInterfaceExporter {
 
         do {
             // we need to wrap the type into a struct to
-            // actually have a messsage.
+            // actually have a message.
             let wrappedType = RequestWrapper<Type>.self
             // set the fieldNumber to the one annotated at the
             // parameter, or use default interference if none is

--- a/Sources/ApodiniProtobuffer/ProtobufferInterfaceExporter.swift
+++ b/Sources/ApodiniProtobuffer/ProtobufferInterfaceExporter.swift
@@ -21,10 +21,10 @@ public final class Protobuffer: GRPCDependentStaticConfiguration {
     }
     
     public func configure(_ app: Apodini.Application, parentConfiguration: GRPC.ExporterConfiguration) {
-        /// Set configartion of parent
+        /// Set configuration of parent
         self.configuration.parentConfiguration = parentConfiguration
         
-        /// Instanciate exporter
+        /// Instantiate exporter
         let protobufferExporter = ProtobufferInterfaceExporter(app, self.configuration)
         
         /// Insert exporter into `InterfaceExporterStorage`
@@ -186,7 +186,7 @@ private extension ProtobufferInterfaceExporter {
                 .init(
                     name: gRPCMethodName(from: endpoint),
                     input: handlerMessage,
-                    ouput: outputNode.value
+                    ouput: outputNode.value // TODO rename output!?
                 )
             ]
         )

--- a/Sources/ApodiniProtobuffer/ProtobufferInterfaceExporter.swift
+++ b/Sources/ApodiniProtobuffer/ProtobufferInterfaceExporter.swift
@@ -186,7 +186,7 @@ private extension ProtobufferInterfaceExporter {
                 .init(
                     name: gRPCMethodName(from: endpoint),
                     input: handlerMessage,
-                    ouput: outputNode.value // TODO rename output!?
+                    ouput: outputNode.value
                 )
             ]
         )

--- a/TestWebService/Package.resolved
+++ b/TestWebService/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Apodini/ApodiniMigrator.git",
         "state": {
           "branch": null,
-          "revision": "7daeaf83310f53bc4e5a124a987f7dba95c72666",
-          "version": "0.1.0"
+          "revision": "c2bb44275a82ec61de70e114d07eafc803d73f41",
+          "version": "0.1.4"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Apodini/ApodiniTypeInformation.git",
         "state": {
           "branch": null,
-          "revision": "b5b9a4d56f8b4fc28fff159e3e9349c41baf40a4",
-          "version": "0.2.0"
+          "revision": "95109a6f3cf93a828d1b0adf2cdc299e31fe5e87",
+          "version": "0.2.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "8fa7f082b155ea325bcf7b2dbffaf81d4eea1ae4",
-          "version": "1.5.1"
+          "revision": "1081b0b0541f535ca088acdb56f5ca5598bc6247",
+          "version": "1.6.3"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/vapor/async-kit.git",
         "state": {
           "branch": null,
-          "revision": "f6f92e6d3704bd72ffb4d00e302c98476fe65854",
-          "version": "1.9.0"
+          "revision": "748c026f4dc93c0b9d05fe43a07d3922ca126744",
+          "version": "1.10.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-kit.git",
         "state": {
           "branch": null,
-          "revision": "06a6939ff486cb6abae08b2e025b02291cff0da0",
-          "version": "1.15.3"
+          "revision": "9fbef6bad614e0b1bf3083f629b40574c97ab0b9",
+          "version": "1.16.0"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/vapor/jwt.git",
         "state": {
           "branch": null,
-          "revision": "46eddb526fa70fd9d765a3bdffac73b2be487cfc",
-          "version": "4.0.0"
+          "revision": "f18aa4f69d9ec781d79b7b89352de326f82e17a9",
+          "version": "4.1.0"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/Apodini/MetadataSystem.git",
         "state": {
           "branch": null,
-          "revision": "5c5b7f0a01017785e3d265fa5d04f0e0b5b3a733",
-          "version": "0.1.0"
+          "revision": "06cac46a958fdf700054f12f682b5c8f27577c9f",
+          "version": "0.1.1"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/vapor/multipart-kit.git",
         "state": {
           "branch": null,
-          "revision": "82f255699b1de9ba1f34dfc6b99e99aba5a1f8eb",
-          "version": "4.5.0"
+          "revision": "2dd9368a3c9580792b77c7ef364f3735909d9996",
+          "version": "4.5.1"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
         }
       },
       {
@@ -174,11 +174,11 @@
       },
       {
         "package": "Runtime",
-        "repositoryURL": "https://github.com/Supereg/Runtime.git",
+        "repositoryURL": "https://github.com/wickwirew/Runtime.git",
         "state": {
           "branch": null,
-          "revision": "596e22a518bb3f8177cd796cd77e5386098a33f8",
-          "version": "2.2.3"
+          "revision": "dad03135d7701a4e7b3a4051e75d6b37bd8e178e",
+          "version": "2.2.4"
         }
       },
       {
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/soto-project/soto.git",
         "state": {
           "branch": null,
-          "revision": "3a8e82ac86a75e548504b6f5aeeeda209a4e7c27",
-          "version": "5.8.1"
+          "revision": "c735c22ce67c78b39664fb6f63e3b340c97d024c",
+          "version": "5.10.0"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/soto-project/soto-core.git",
         "state": {
           "branch": null,
-          "revision": "283f0de557995848c1fea5893124956084b433f8",
-          "version": "5.6.0"
+          "revision": "988f0d906f5c76cf93c88fa5820f7c72e4b8fd98",
+          "version": "5.8.0"
         }
       },
       {
@@ -213,8 +213,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
-          "version": "0.9.2"
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
         }
       },
       {
@@ -249,8 +249,8 @@
         "repositoryURL": "https://github.com/swift-server/swift-aws-lambda-runtime.git",
         "state": {
           "branch": null,
-          "revision": "a9e15b13b30b6700056c4cfbdcf6a69382a9fb6f",
-          "version": "0.5.0"
+          "revision": "699ada1724459582303c15aae64fa12ca4d33809",
+          "version": "0.5.2"
         }
       },
       {
@@ -267,8 +267,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections",
         "state": {
           "branch": null,
-          "revision": "9d8719c8bebdc79740b6969c912ac706eb721d7a",
-          "version": "0.0.7"
+          "revision": "2d33a0ea89c961dcb2b3da2157963d9c0370347e",
+          "version": "1.0.1"
         }
       },
       {
@@ -276,8 +276,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
-          "version": "1.1.6"
+          "revision": "127d3745c37b5705e4bc8d16c7951c48dcc3332c",
+          "version": "2.0.0"
         }
       },
       {
@@ -312,8 +312,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "1d425b0851ffa2695d488cce1d68df2539f42500",
-          "version": "2.31.2"
+          "revision": "6aa9347d9bc5bbfe6a84983aec955c17ffea96ef",
+          "version": "2.33.0"
         }
       },
       {
@@ -321,8 +321,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f72c4688f89c28502105509186eadc49a49cb922",
-          "version": "1.10.0"
+          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
+          "version": "1.10.2"
         }
       },
       {
@@ -330,8 +330,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "f6cde03ef8ad57e3bd25743d1e678efd1e5239f7",
-          "version": "1.18.1"
+          "revision": "326f7f9a8c8c8402e3691adac04911cac9f9d87f",
+          "version": "1.18.4"
         }
       },
       {
@@ -339,8 +339,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "2e74773972bd6254c41ceeda827f229bccbf1c0f",
-          "version": "2.15.0"
+          "revision": "5e68c1ded15619bb281b273fa8c2d8fd7f7b2b7d",
+          "version": "2.16.1"
         }
       },
       {
@@ -348,8 +348,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "39587bceccda72780e2a8a8c5e857e42a9df2fa8",
-          "version": "1.11.0"
+          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
+          "version": "1.11.3"
         }
       },
       {
@@ -357,8 +357,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "27119271502bf266be293be5325f0fb72435e8fd",
-          "version": "4.49.2"
+          "revision": "68233685fd1a943e8772634e02abfec076dcb8f4",
+          "version": "4.52.1"
         }
       },
       {

--- a/TestWebService/Sources/TestWebService/WeatherSubsystem/RouteModifier.swift
+++ b/TestWebService/Sources/TestWebService/WeatherSubsystem/RouteModifier.swift
@@ -8,7 +8,7 @@
 
 import Apodini
 import Foundation
-import _NIOConcurrency
+import NIO
 
 
 extension Component {

--- a/Tests/ApodiniTests/EnvironmentTests/ConnectionTests.swift
+++ b/Tests/ApodiniTests/EnvironmentTests/ConnectionTests.swift
@@ -12,7 +12,7 @@ import XCTApodini
 import XCTVapor
 import XCTest
 
-import _NIOConcurrency
+import NIO
 
 final class ConnectionTests: ApodiniTests {
     let endMessage = "End"

--- a/Tests/ApodiniTests/ResponseTests/ResponseTests.swift
+++ b/Tests/ApodiniTests/ResponseTests/ResponseTests.swift
@@ -10,7 +10,7 @@
 import ApodiniUtils
 import XCTest
 import XCTApodini
-import _NIOConcurrency
+import NIO
 
 final class ResponseTests: ApodiniTests {
     struct ResponseHandler: Handler {


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Dependency maintenance: Swift NIO and Swift Collections

## :recycle: Current situation & Problem

Currently Apodini pins the Swift NIO dependency to `2.31.x` a version where async/await features aren't yet finalized.
A source code comment suggested that this pin was due to `swift-aws-lambda-runtime` which hasn't yet upgraded to the new version. An updated version is now out.

This is starting to be a problem, as more and more dependencies are moving to the updated `swift-nio` package (e.g. vapors async-kit) which is incompatible with the previous releases (particularly the method name change from `completeWithAsync` to `completeWithTask`). To my experience, this made it impossible to use Apodini as a dependency without relying on similar workarounds.

Additionally, Swift Collections now reached at a [source stable version](https://github.com/apple/swift-collections/releases/tag/1.0.0).

Lastly, the Runtime library finally tagged a new version (`2.2.4`) making my fork obsolete.

## :bulb: Proposed solution
This PR upgrades both dependencies to their latest version and updates source code accordingly.

## :gear: Release Notes 

Updated dependencies, particularly bumped `swift-nio` to `2.33.0` and `swift-collections` to `1.0.1`.

## :heavy_plus_sign: Additional Information

### Related PRs
--

### Testing
Testing wasn't changed.

### Reviewer Nudging
-- 