### PR TITLE
Remove Unsafe Build Flags

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -156,9 +156,6 @@ let package = Package(
                 .target(name: "Apodini"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log")
-            ],
-            swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"])
             ]
         ),
 
@@ -183,9 +180,6 @@ let package = Package(
             ],
             resources: [
                 .process("Resources")
-            ],
-            swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"])
             ]
         ),
 


### PR DESCRIPTION
# Remove Unsafe Build Flags

## :recycle: Current situation & Problem
The `Package.swift` file contains unsafe build flags which prevent Swift packages from using Apodini as a dependency.

## :bulb: Proposed solution
The unsafe build flags are not needed. They can be removed.

## :gear: Release Notes 
Removes unsafe build flags which prevent Swift packages from using Apodini as a dependency