### PR TITLE
Add a Default Value for the Address of the BindAddress

### DIFF
--- a/Sources/Apodini/Application/Application+HTTP.swift
+++ b/Sources/Apodini/Application/Application+HTTP.swift
@@ -25,7 +25,7 @@ public enum HTTPVersionMajor: Equatable, Hashable {
 
 /// BindAddress
 public enum BindAddress: Equatable {
-    case interface(_ address: String, port: Int? = nil)
+    case interface(_ address: String = HTTPConfiguration.Defaults.bindAddress, port: Int? = nil)
     case unixDomainSocket(path: String)
     
     public static func address(_ address: String) -> BindAddress {


### PR DESCRIPTION
# Add a Default Value for the Address of the BindAddress

## :recycle: Current situation & Problem
The user currently needs to pass in a bind address for the BindAddress without the availability of a reasonable default value.

## :bulb: Proposed solution
Adds a default value of "0.0.0.0".