### PR TITLE
Use a port range for the LocalhostDeploymentProvider that can not be registered at IANA

### DIFF
--- a/Sources/DeploymentTargetLocalhost/LocalhostDeploymentProvider.swift
+++ b/Sources/DeploymentTargetLocalhost/LocalhostDeploymentProvider.swift
@@ -32,7 +32,7 @@ private struct LocalhostDeploymentProviderCLI: ParsableCommand {
     var port: Int = 80
     
     @Option(help: "The port number for the first-launched child process")
-    var endpointProcessesBasePort: Int = 5000
+    var endpointProcessesBasePort: Int = 52000
     
     @Option(help: "Name of the web service's SPM target/product")
     var productName: String

--- a/Tests/ApodiniDeployTests/LocalhostDeploymentProviderTests.swift
+++ b/Tests/ApodiniDeployTests/LocalhostDeploymentProviderTests.swift
@@ -63,12 +63,12 @@ class LocalhostDeploymentProviderTests: ApodiniDeployTestCase {
         }
         
         runShellCommand(.killPort(80))
-        runShellCommand(.killPort(5000))
-        runShellCommand(.killPort(5001))
-        runShellCommand(.killPort(5002))
-        runShellCommand(.killPort(5003))
-        runShellCommand(.killPort(5004))
-        runShellCommand(.killPort(5005))
+        runShellCommand(.killPort(52000))
+        runShellCommand(.killPort(52001))
+        runShellCommand(.killPort(52002))
+        runShellCommand(.killPort(52003))
+        runShellCommand(.killPort(52004))
+        runShellCommand(.killPort(52005))
         
         precondition(task == nil)
         
@@ -154,8 +154,8 @@ class LocalhostDeploymentProviderTests: ApodiniDeployTestCase {
             handleOutput(text, printToStdout: true)
             
             // We're in the phase which is checking whether the web service sucessfully launched.
-            // This is determined by finding the text `Server starting on http://localhost:5001` three times,
-            // with the port numbers matching the expected output values (i.e. 5000, 5001, 5002 if no explicit port was specified).
+            // This is determined by finding the text `Server starting on http://localhost:52001` three times,
+            // with the port numbers matching the expected output values (i.e. 52000, 52001, 52002 if no explicit port was specified).
             
             let serverLaunchedRegex = try! NSRegularExpression( // swiftlint:disable:this force_try
                 pattern: #"Server starting on http://(\d+\.\d+\.\d+\.\d+):(\d+)$"#,
@@ -183,12 +183,12 @@ class LocalhostDeploymentProviderTests: ApodiniDeployTestCase {
                     // the gateway
                     StartedServerInfo(ipAddress: "0.0.0.0", port: 80),
                     // the nodes
-                    StartedServerInfo(ipAddress: "0.0.0.0", port: 5000),
-                    StartedServerInfo(ipAddress: "0.0.0.0", port: 5001),
-                    StartedServerInfo(ipAddress: "0.0.0.0", port: 5002),
-                    StartedServerInfo(ipAddress: "0.0.0.0", port: 5003),
-                    StartedServerInfo(ipAddress: "0.0.0.0", port: 5004),
-                    StartedServerInfo(ipAddress: "0.0.0.0", port: 5005)
+                    StartedServerInfo(ipAddress: "0.0.0.0", port: 52000),
+                    StartedServerInfo(ipAddress: "0.0.0.0", port: 52001),
+                    StartedServerInfo(ipAddress: "0.0.0.0", port: 52002),
+                    StartedServerInfo(ipAddress: "0.0.0.0", port: 52003),
+                    StartedServerInfo(ipAddress: "0.0.0.0", port: 52004),
+                    StartedServerInfo(ipAddress: "0.0.0.0", port: 52005)
                 ])
                 launchDPExpectation.fulfill()
             } else if startedServers.count < expectedNumberOfNodes {

--- a/Tests/ApodiniDeployTests/WebServiceStructureExportTests.swift
+++ b/Tests/ApodiniDeployTests/WebServiceStructureExportTests.swift
@@ -124,7 +124,7 @@ class WebServiceStructureExportTests: ApodiniDeployTestCase {
                 "--identifier",
                 StaticDeploymentProvider.identifier.rawValue,
                 "--endpoint-processes-base-port",
-                "5000"
+                "52000"
             ], as: LocalhostDeployedSystem.self)
         
         let exportedEndpoints = deployedSystem.nodes


### PR DESCRIPTION
# Use a port range for the LocalhostDeploymentProvider that can not be registered at IANA

## :recycle: Current situation & Problem
As noted in #384 we currently rely on a port range that is e.g. used by Apple AirPlay and might be potentially be registered at the IANA for the LocalhostDeploymentProvider. @lukaskollmer changed this in his PR (https://github.com/Apodini/Apodini/pull/384/commits/4b5914a52725de725000ce1127e2011fc2591086), this PR only incorporates this change as a single PR to block other non-building PRs such as #388.

## :bulb: Proposed solution
Moves the LocalhostDeploymentProvider ports to the ["Dynamic, private or ephemeral ports"-range](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers) of 52000 and onwards.

## :gear: Release Notes 
Moves the LocalhostDeploymentProvider ports to the ["Dynamic, private or ephemeral ports"-range](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers) of 52000 and onwards.

### Related PRs
#384 & #388 
