### PR TITLE
Adjust visibility of the initializer of HandlerMetadataModifier

### DIFF
--- a/Sources/Apodini/Metadata/Modifier/HandlerMetadataModifier.swift
+++ b/Sources/Apodini/Metadata/Modifier/HandlerMetadataModifier.swift
@@ -27,7 +27,11 @@ public struct HandlerMetadataModifier<H: Handler>: HandlerModifier {
     // property is not called `metadata` as it would conflict with the Metadata Declaration block
     let handlerMetadata: AnyHandlerMetadata
 
-    init<Metadata: HandlerMetadataDefinition>(modifies handler: H, with metadata: Metadata) {
+    /// Creates a new `HandlerMetadataModifier` used to modify the Metadata of a given ``Handler``.
+    /// - Parameters:
+    ///   - handler: The ``Handler`` which is to be modified.
+    ///   - metadata: The Metadata used to modify the ``Handler``.
+    public init<Metadata: HandlerMetadataDefinition>(modifies handler: H, with metadata: Metadata) {
         self.component = handler
         self.handlerMetadata = metadata
     }


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# 🔧 Adjust visibility of the initializer of `HandlerMetadataModifier`

## :recycle: Current situation & Problem

Currently, the `init(modifies:with:)` of the `HandlerMetadataModifier` has `internal` visibility, although it is considered to be part of the public interface (similar to `ComponentMetadataModifier`).
Therefore, other entities cannot directly initialize a `HandlerMetadataModifier` e.g. used when creating a Handler Modifier for your custom Metadata. Such a construction typically looks like follows:
```swift
extension Handler {
    public func optional(_ value: Value) -> HandlerMetadataModifier<Self> {
        HandlerMetadataModifier(modifies: self, with: YourCustomMadeMetadata(value: value))
    }
}
```

## :bulb: Proposed solution

This PR properly marks the initializer as `public`.

## :gear: Release Notes 
* Fixed an issue where `HandlerMetadataModifier` couldn't be directly instantiated, due to erroneous visibility of `init(modifies:with:)`.

## :heavy_plus_sign: Additional Information

As a workaround for current and previous versions of Apodini, one can use the `metadata(_:)` modifier to indirectly instantiate a `HandlerMetadataModifier`. A typical construction would then look like follows:
```swift
extension Handler {
    public func optional(_ value: Value) -> HandlerMetadataModifier<Self> {
        self.metadata(YourCustomMadeMetadata(value: value))
    }
}
```


### Testing
No changes.

### Reviewer Nudging
Hope this to be an easy one :)
