### PR TITLE
Update ApodiniMigration to ApodiniMigrator 0.2.0; bump ApodiniTypeInformation to 0.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "8fa7f082b155ea325bcf7b2dbffaf81d4eea1ae4",
-          "version": "1.5.1"
+          "revision": "70826d038d5bdc3142a386b735792d87ef7a5dfc",
+          "version": "1.8.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/vapor/async-kit.git",
         "state": {
           "branch": null,
-          "revision": "f6f92e6d3704bd72ffb4d00e302c98476fe65854",
-          "version": "1.9.0"
+          "revision": "3b1e7e9069a62295151c6c1609050cd38a0a7af5",
+          "version": "1.11.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/grpc/grpc-swift.git",
         "state": {
           "branch": null,
-          "revision": "14e1ea3350892a864386517c037e11fb68baf818",
-          "version": "1.3.0"
+          "revision": "5cc08ebf77e68598bfe4c793927d0f2838598607",
+          "version": "1.6.1"
         }
       },
       {
@@ -177,8 +177,8 @@
         "repositoryURL": "https://github.com/soto-project/soto-core.git",
         "state": {
           "branch": null,
-          "revision": "988f0d906f5c76cf93c88fa5820f7c72e4b8fd98",
-          "version": "5.8.0"
+          "revision": "032375fb9882a06c5edbc41e5e174bf308f5870c",
+          "version": "5.9.0"
         }
       },
       {
@@ -204,8 +204,8 @@
         "repositoryURL": "https://github.com/vapor/sql-kit.git",
         "state": {
           "branch": null,
-          "revision": "8587674e7e2499fd2017840973f416182025b02d",
-          "version": "3.12.1"
+          "revision": "9cc30f8cef132e91a07e36005612b37f918731fc",
+          "version": "3.16.0"
         }
       },
       {
@@ -213,8 +213,8 @@
         "repositoryURL": "https://github.com/vapor/sqlite-kit.git",
         "state": {
           "branch": null,
-          "revision": "2ec279b9c845cec254646834b66338551a024561",
-          "version": "4.0.2"
+          "revision": "0b3b12b032991de3ab5999b428a652ec29139746",
+          "version": "4.1.0"
         }
       },
       {
@@ -267,8 +267,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
-          "version": "1.1.6"
+          "revision": "9c53b7a758bb849a7df1bd2314395f5f0c14306f",
+          "version": "2.0.3"
         }
       },
       {
@@ -348,8 +348,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f72c4688f89c28502105509186eadc49a49cb922",
-          "version": "1.10.0"
+          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
+          "version": "1.10.2"
         }
       },
       {
@@ -357,8 +357,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "f6cde03ef8ad57e3bd25743d1e678efd1e5239f7",
-          "version": "1.18.1"
+          "revision": "6e94a7be32891d1b303a3fcfde8b5bf64d162e74",
+          "version": "1.19.1"
         }
       },
       {
@@ -375,8 +375,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "39587bceccda72780e2a8a8c5e857e42a9df2fa8",
-          "version": "1.11.0"
+          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
+          "version": "1.11.3"
         }
       },
       {
@@ -402,8 +402,8 @@
         "repositoryURL": "https://github.com/vapor/websocket-kit.git",
         "state": {
           "branch": null,
-          "revision": "b1c4df8f6c848c2e977726903bbe6578eed723ad",
-          "version": "2.2.0"
+          "revision": "ff8fbce837ef01a93d49c6fb49a72be0f150dac7",
+          "version": "2.3.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Apodini/ApodiniMigrator.git",
         "state": {
           "branch": null,
-          "revision": "c2bb44275a82ec61de70e114d07eafc803d73f41",
-          "version": "0.1.4"
+          "revision": "b224604bedf270e4c08ba94bbfc1ebfd99c6b9ae",
+          "version": "0.2.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Apodini/ApodiniTypeInformation.git",
         "state": {
           "branch": null,
-          "revision": "95109a6f3cf93a828d1b0adf2cdc299e31fe5e87",
-          "version": "0.2.1"
+          "revision": "b4e73a6f92bd0930c9f1f8a857504b85b943dd88",
+          "version": "0.3.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "70826d038d5bdc3142a386b735792d87ef7a5dfc",
-          "version": "1.8.1"
+          "revision": "8fa7f082b155ea325bcf7b2dbffaf81d4eea1ae4",
+          "version": "1.5.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/vapor/async-kit.git",
         "state": {
           "branch": null,
-          "revision": "3b1e7e9069a62295151c6c1609050cd38a0a7af5",
-          "version": "1.11.0"
+          "revision": "f6f92e6d3704bd72ffb4d00e302c98476fe65854",
+          "version": "1.9.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/grpc/grpc-swift.git",
         "state": {
           "branch": null,
-          "revision": "5cc08ebf77e68598bfe4c793927d0f2838598607",
-          "version": "1.6.1"
+          "revision": "14e1ea3350892a864386517c037e11fb68baf818",
+          "version": "1.3.0"
         }
       },
       {
@@ -177,8 +177,8 @@
         "repositoryURL": "https://github.com/soto-project/soto-core.git",
         "state": {
           "branch": null,
-          "revision": "032375fb9882a06c5edbc41e5e174bf308f5870c",
-          "version": "5.9.0"
+          "revision": "988f0d906f5c76cf93c88fa5820f7c72e4b8fd98",
+          "version": "5.8.0"
         }
       },
       {
@@ -204,8 +204,8 @@
         "repositoryURL": "https://github.com/vapor/sql-kit.git",
         "state": {
           "branch": null,
-          "revision": "9cc30f8cef132e91a07e36005612b37f918731fc",
-          "version": "3.16.0"
+          "revision": "8587674e7e2499fd2017840973f416182025b02d",
+          "version": "3.12.1"
         }
       },
       {
@@ -213,8 +213,8 @@
         "repositoryURL": "https://github.com/vapor/sqlite-kit.git",
         "state": {
           "branch": null,
-          "revision": "0b3b12b032991de3ab5999b428a652ec29139746",
-          "version": "4.1.0"
+          "revision": "2ec279b9c845cec254646834b66338551a024561",
+          "version": "4.0.2"
         }
       },
       {
@@ -267,8 +267,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "9c53b7a758bb849a7df1bd2314395f5f0c14306f",
-          "version": "2.0.3"
+          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
+          "version": "1.1.6"
         }
       },
       {
@@ -348,8 +348,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-          "version": "1.10.2"
+          "revision": "f72c4688f89c28502105509186eadc49a49cb922",
+          "version": "1.10.0"
         }
       },
       {
@@ -357,8 +357,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "6e94a7be32891d1b303a3fcfde8b5bf64d162e74",
-          "version": "1.19.1"
+          "revision": "f6cde03ef8ad57e3bd25743d1e678efd1e5239f7",
+          "version": "1.18.1"
         }
       },
       {
@@ -375,8 +375,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
-          "version": "1.11.3"
+          "revision": "39587bceccda72780e2a8a8c5e857e42a9df2fa8",
+          "version": "1.11.0"
         }
       },
       {
@@ -402,8 +402,8 @@
         "repositoryURL": "https://github.com/vapor/websocket-kit.git",
         "state": {
           "branch": null,
-          "revision": "ff8fbce837ef01a93d49c6fb49a72be0f150dac7",
-          "version": "2.3.0"
+          "revision": "b1c4df8f6c848c2e977726903bbe6578eed723ad",
+          "version": "2.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -111,10 +111,10 @@ let package = Package(
         .package(url: "https://github.com/slashmo/opentelemetry-swift.git", .upToNextMinor(from: "0.1.1")),
         
         // Apodini Migrator
-        .package(url: "https://github.com/Apodini/ApodiniMigrator.git", .upToNextMinor(from: "0.1.4")),
+        .package(url: "https://github.com/Apodini/ApodiniMigrator.git", .upToNextMinor(from: "0.2.0")),
 
         // TypeInformation
-        .package(url: "https://github.com/Apodini/ApodiniTypeInformation.git", .upToNextMinor(from: "0.2.1"))
+        .package(url: "https://github.com/Apodini/ApodiniTypeInformation.git", .upToNextMinor(from: "0.3.0"))
     ],
     targets: [
         .target(name: "CApodiniUtils"),
@@ -174,6 +174,7 @@ let package = Package(
                 .target(name: "ApodiniWebSocket"),
                 .target(name: "ApodiniAuthorization"),
                 .target(name: "ApodiniMigration"),
+                .product(name: "RESTMigrator", package: "ApodiniMigrator"),
                 .target(name: "ApodiniAuthorizationBearerScheme"),
                 .target(name: "ApodiniAuthorizationBasicScheme"),
                 .target(name: "ApodiniAuthorizationJWT"),

--- a/Sources/Apodini/Application/Application+HTTP.swift
+++ b/Sources/Apodini/Application/Application+HTTP.swift
@@ -52,8 +52,8 @@ public enum BindAddress: Equatable {
 
 /// Hostname
 public struct Hostname {
-    let address: String
-    let port: Int?
+    public let address: String
+    public let port: Int?
     
     /// Create a new `Hostname`
     ///

--- a/Sources/ApodiniMigration/ApodiniMigrator+Apodini.swift
+++ b/Sources/ApodiniMigration/ApodiniMigrator+Apodini.swift
@@ -61,6 +61,21 @@ extension ApodiniMigratorCore.Operation {
     }
 }
 
+extension ApodiniMigratorCore.CommunicationalPattern {
+    init(_ from: Apodini.CommunicationalPattern) {
+        switch from {
+        case .requestResponse:
+            self = .requestResponse
+        case .serviceSideStream:
+            self = .serviceSideStream
+        case .clientSideStream:
+            self = .clientSideStream
+        case .bidirectionalStream:
+            self = .bidirectionalStream
+        }
+    }
+}
+
 // MARK: - ApodiniMigratorCore.ParameterType
 extension ApodiniMigratorCore.ParameterType {
     init(_ from: Apodini.ParameterType) {

--- a/Sources/ApodiniMigration/ApodiniMigratorInterfaceExporter.swift
+++ b/Sources/ApodiniMigration/ApodiniMigratorInterfaceExporter.swift
@@ -15,7 +15,7 @@ import ApodiniNetworking
 
 /// Identifying storage key for `ApodiniMigrator` ``Document``
 public struct MigratorDocumentStorageKey: Apodini.StorageKey {
-    public typealias Value = Document
+    public typealias Value = APIDocument
 }
 
 /// Identifying storage key for `ApodiniMigrator` ``MigrationGuide``
@@ -48,7 +48,7 @@ protocol MigratorItem: Encodable {
 }
 
 // MARK: - Document + MigratorItem
-extension Document: MigratorItem {
+extension APIDocument: MigratorItem {
     static var itemName: String {
         "API Document"
     }
@@ -70,10 +70,11 @@ final class ApodiniMigratorInterfaceExporter: InterfaceExporter {
     static var parameterNamespace: [ParameterNamespace] = .global
 
     private let app: Apodini.Application
-    private var document = Document()
     private let documentConfig: DocumentConfiguration?
     private let migrationGuideConfig: MigrationGuideConfiguration?
     private let logger = Logger(label: "org.apodini.migrator")
+
+    private var endpoints: [ApodiniMigratorCore.Endpoint] = []
 
     init<W: WebService>(_ app: Apodini.Application, configuration: MigratorConfiguration<W>) {
         self.app = app
@@ -84,6 +85,7 @@ final class ApodiniMigratorInterfaceExporter: InterfaceExporter {
     func export<H>(_ endpoint: Apodini.Endpoint<H>) where H: Handler {
         let handlerName = endpoint[HandlerDescription.self]
         let operation = endpoint[Apodini.Operation.self]
+        let communicationalPattern = endpoint[Apodini.CommunicationalPattern.self]
         let identifier = endpoint[AnyHandlerIdentifier.self]
         let params = endpoint.parameters.migratorParameters(of: H.self, with: logger)
 
@@ -114,13 +116,14 @@ final class ApodiniMigratorInterfaceExporter: InterfaceExporter {
             handlerName: handlerName,
             deltaIdentifier: identifier.rawValue,
             operation: .init(operation),
+            communicationalPattern: .init(communicationalPattern),
             absolutePath: absolutePath,
             parameters: params,
             response: response,
             errors: errors
         )
 
-        document.add(endpoint: migratorEndpoint)
+        endpoints.append(migratorEndpoint)
     }
 
     func export<H>(blob endpoint: Apodini.Endpoint<H>) where H: Handler, H.Response.Content == Blob {
@@ -128,15 +131,37 @@ final class ApodiniMigratorInterfaceExporter: InterfaceExporter {
     }
 
     func finishedExporting(_ webService: WebServiceModel) {
-        document.setServerPath(app.httpConfiguration.uriPrefix)
-        document.setVersion(.init(with: webService.context.get(valueFor: APIVersionContextKey.self)))
+        let http = HTTPInformation(
+            hostname: app.httpConfiguration.hostname.address,
+            port: app.httpConfiguration.hostname.port ?? (
+                app.httpConfiguration.tlsConfiguration == nil
+                    ? HTTPConfiguration.Defaults.httpPort
+                    : HTTPConfiguration.Defaults.httpsPort
+            )
+        )
+        let serviceInformation = ServiceInformation(
+            version: .init(with: webService.context.get(valueFor: APIVersionContextKey.self)),
+            http: http
+        )
+
+        var document = APIDocument(serviceInformation: serviceInformation)
+
+        // for now we assume existence of REST. Currently REST is the only supported anyways.
+        // we move to a dynamic approach once we fully support gRPC client generation.
+        document.add(exporter: RESTExporterConfiguration(encoderConfiguration: .default, decoderConfiguration: .default))
+
+        for endpoint in endpoints {
+            document.add(endpoint: endpoint)
+        }
+        endpoints.removeAll()
+
         app.storage.set(MigratorDocumentStorageKey.self, to: document)
         
-        handleDocument()
-        handleMigrationGuide()
+        handleDocument(document: document)
+        handleMigrationGuide(document: document)
     }
     
-    private func handleDocument() {
+    private func handleDocument(document: APIDocument) {
         guard let exportOptions = documentConfig?.exportOptions else {
             return logger.notice("No configuration provided to handle the document of the current version")
         }
@@ -144,7 +169,7 @@ final class ApodiniMigratorInterfaceExporter: InterfaceExporter {
         handle(document, with: exportOptions)
     }
     
-    private func handleMigrationGuide() {
+    private func handleMigrationGuide(document: APIDocument) {
         guard let migrationGuideConfig = migrationGuideConfig else {
             return logger.notice("No migration guide configurations provided")
         }
@@ -153,9 +178,9 @@ final class ApodiniMigratorInterfaceExporter: InterfaceExporter {
             let exportOptions = migrationGuideConfig.exportOptions
             var migrationGuide: MigrationGuide?
             if let migrationGuidePath = migrationGuideConfig.migrationGuidePath {
-                migrationGuide = try MigrationGuide.decode(from: migrationGuidePath.asPath)
+                migrationGuide = try MigrationGuide.decode(from: Path(migrationGuidePath))
             } else if let oldDocumentPath = migrationGuideConfig.oldDocumentPath {
-                migrationGuide = MigrationGuide(for: try Document.decode(from: oldDocumentPath.asPath), rhs: document)
+                migrationGuide = MigrationGuide(for: try APIDocument.decode(from: Path(oldDocumentPath)), rhs: document)
             }
             if let migrationGuide = migrationGuide {
                 handle(migrationGuide, with: exportOptions)

--- a/Sources/ApodiniMigration/ApodiniMigratorInterfaceExporter.swift
+++ b/Sources/ApodiniMigration/ApodiniMigratorInterfaceExporter.swift
@@ -133,11 +133,8 @@ final class ApodiniMigratorInterfaceExporter: InterfaceExporter {
     func finishedExporting(_ webService: WebServiceModel) {
         let http = HTTPInformation(
             hostname: app.httpConfiguration.hostname.address,
-            port: app.httpConfiguration.hostname.port ?? (
-                app.httpConfiguration.tlsConfiguration == nil
-                    ? HTTPConfiguration.Defaults.httpPort
-                    : HTTPConfiguration.Defaults.httpsPort
-            )
+            port: app.httpConfiguration.hostname.port ??
+                (app.httpConfiguration.tlsConfiguration == nil ? HTTPConfiguration.Defaults.httpPort : HTTPConfiguration.Defaults.httpsPort)
         )
         let serviceInformation = ServiceInformation(
             version: .init(with: webService.context.get(valueFor: APIVersionContextKey.self)),

--- a/Sources/ApodiniREST/RESTDependentStaticConfiguration.swift
+++ b/Sources/ApodiniREST/RESTDependentStaticConfiguration.swift
@@ -8,12 +8,12 @@
 
 import Apodini
 
-/// `RESTDependentStaticConfiguration`s are used to register static services dependend on the `RESTInterfaceExporter`
+/// `RESTDependentStaticConfiguration`s are used to register static services dependent on the `RESTInterfaceExporter`
 public protocol RESTDependentStaticConfiguration {
-    /// A method that handels the configuration of dependend static exporters
+    /// A method that handles the configuration of dependent static exporters
     /// - Parameters:
     ///    - app: The `Application` which is used to register the configuration in Apodini
-    ///    - parentConfiguration: The `RESTExporterConfiguration` of the parent of the dependend exporter
+    ///    - parentConfiguration: The `RESTExporterConfiguration` of the parent of the dependent exporter
     func configure(_ app: Application, parentConfiguration: REST.ExporterConfiguration)
 }
 
@@ -25,10 +25,10 @@ public struct EmptyRESTDependentStaticConfiguration: RESTDependentStaticConfigur
 }
 
 extension Array where Element == RESTDependentStaticConfiguration {
-    /// A method that handels the configuration of dependend static exporters
+    /// A method that handles the configuration of dependent static exporters
     /// - Parameters:
     ///    - app: The `Application` which is used to register the configuration in Apodini
-    ///    - parentConfiguration: The `Configuration` of the parent of the dependend static exporters
+    ///    - parentConfiguration: The `Configuration` of the parent of the dependent static exporters
     func configure(_ app: Application, parentConfiguration: REST.ExporterConfiguration) {
         forEach {
             $0.configure(app, parentConfiguration: parentConfiguration)

--- a/Sources/ApodiniREST/RESTDependentStaticConfigurationBuilder.swift
+++ b/Sources/ApodiniREST/RESTDependentStaticConfigurationBuilder.swift
@@ -11,7 +11,7 @@
 public enum RESTDependentStaticConfigurationBuilder {
     /// A method that transforms multiple `RESTDependentStaticConfiguration`s
     ///
-    /// - Parameter configs: A variadic number of `RESTDependentStaticConfiguration`
+    /// - Parameter staticConfigurations: A variadic number of `RESTDependentStaticConfiguration`
     ///
     /// - Returns: An `AnyConfigurationCollection` which consists of `ConfigurationConvertible`s
     public static func buildBlock(_ staticConfigurations: RESTDependentStaticConfiguration...) -> [RESTDependentStaticConfiguration] {

--- a/Sources/ApodiniREST/RESTInterfaceExporter.swift
+++ b/Sources/ApodiniREST/RESTInterfaceExporter.swift
@@ -34,14 +34,14 @@ public final class REST: Configuration {
     /// - Parameters:
     ///    - encoder: The to be used `AnyEncoder`, defaults to a `JSONEncoder`
     ///    - decoder: The to be used `AnyDecoder`, defaults to a `JSONDecoder`
-    ///    - caseInsensitiveRouting: Indicates whether the HTTP route is interpreted case-sensitivly
+    ///    - caseInsensitiveRouting: Indicates whether the HTTP route is interpreted case-sensitively
     public init(encoder: AnyEncoder = defaultEncoder, decoder: AnyDecoder = defaultDecoder, caseInsensitiveRouting: Bool = false) {
         self.configuration = REST.ExporterConfiguration(encoder: encoder, decoder: decoder, caseInsensitiveRouting: caseInsensitiveRouting)
         self.staticConfigurations = [EmptyRESTDependentStaticConfiguration()]
     }
     
     public func configure(_ app: Apodini.Application) {
-        /// Instanciate exporter
+        /// Instantiate exporter
         let restExporter = RESTInterfaceExporter(app, self.configuration)
         
         /// Insert exporter into `InterfaceExporterStorage`
@@ -57,8 +57,8 @@ extension REST {
     /// - Parameters:
     ///    - encoder: The to be used `JSONEncoder`, defaults to a `JSONEncoder`
     ///    - decoder: The to be used `JSONDecoder`, defaults to a `JSONDecoder`
-    ///    - caseInsensitiveRouting: Indicates whether the HTTP route is interpreted case-sensitivly
-    ///    - staticConfiguraiton: A result builder that allows passing dependend static Exporters like the OpenAPI Exporter
+    ///    - caseInsensitiveRouting: Indicates whether the HTTP route is interpreted case-sensitively
+    ///    - staticConfigurations: A result builder that allows passing dependent static Exporters like the OpenAPI Exporter
     public convenience init(encoder: JSONEncoder = defaultEncoder as! JSONEncoder,
                             decoder: JSONDecoder = defaultDecoder as! JSONDecoder,
                             caseInsensitiveRouting: Bool = false,

--- a/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
@@ -179,7 +179,7 @@ class GRPCInterfaceExporterTests: XCTApodiniTest {
             """
         ]
         XCTAssert(responseParts.allSatisfy { describeServices.output.contains($0) })
-        XCTAssertEqual(describeServices.output.split(string: " is a service:").count - 1, responseParts.count)
+        XCTAssertEqual(describeServices.output.components(separatedBy: " is a service:").count - 1, responseParts.count)
     }
 }
 

--- a/Tests/ApodiniTests/MigratorTests/ApodiniMigratorTests.swift
+++ b/Tests/ApodiniTests/MigratorTests/ApodiniMigratorTests.swift
@@ -356,4 +356,11 @@ final class ApodiniMigratorTests: ApodiniTests {
         XCTAssert(swiftFiles.contains("NetworkingService.swift"))
         XCTAssert(swiftFiles.contains("TestPackageTests.swift"))
     }
+
+    func testPatternMapping() {
+        XCTAssertEqual(ApodiniMigratorCore.CommunicationalPattern(.requestResponse), .requestResponse)
+        XCTAssertEqual(ApodiniMigratorCore.CommunicationalPattern(.serviceSideStream), .serviceSideStream)
+        XCTAssertEqual(ApodiniMigratorCore.CommunicationalPattern(.clientSideStream), .clientSideStream)
+        XCTAssertEqual(ApodiniMigratorCore.CommunicationalPattern(.bidirectionalStream), .bidirectionalStream)
+    }
 }

--- a/Tests/ApodiniTests/MigratorTests/ApodiniMigratorTests.swift
+++ b/Tests/ApodiniTests/MigratorTests/ApodiniMigratorTests.swift
@@ -7,8 +7,10 @@
 //
 
 import XCTest
+import XCTApodini
 @testable import Apodini
 @testable import ApodiniMigration
+@testable import RESTMigrator
 @testable import ApodiniMigrator
 @_implementationOnly import PathKit
 @testable import ApodiniNetworking
@@ -106,12 +108,12 @@ final class ApodiniMigratorTests: ApodiniTests {
         XCTAssert(app.storage.get(MigrationGuideStorageKey.self) == nil)
         
         let document = try XCTUnwrap(app.storage.get(MigratorDocumentStorageKey.self))
-        let multiplyEndpoint = try XCTUnwrap(document.endpoints.first { $0.deltaIdentifier == "multiplyHandler" })
+        let multiplyEndpoint = try XCTUnwrap(document.endpoints.first { $0.deltaIdentifier == "MultiplyHandler" })
         
         XCTAssertEqual(multiplyEndpoint.response, .scalar(.int))
         XCTAssertEqual(multiplyEndpoint.path, .init("/v1/{rhs}"))
         XCTAssertEqual(multiplyEndpoint.operation, .read)
-        XCTAssertEqual(multiplyEndpoint.deltaIdentifier.rawValue, multiplyEndpoint.handlerName.lowerFirst)
+        XCTAssertEqual(multiplyEndpoint.deltaIdentifier.rawValue, multiplyEndpoint.handlerName.rawValue)
         
         let blob = try XCTUnwrap(document.endpoints.first { $0.deltaIdentifier == "blob" })
         XCTAssertEqual(blob.response, .scalar(.data))
@@ -126,7 +128,7 @@ final class ApodiniMigratorTests: ApodiniTests {
         start()
         
         let document = try XCTUnwrap(app.storage.get(MigratorDocumentStorageKey.self))
-        let exportedDocument = try Document.decode(from: testDirectory + "\(document.fileName).yaml")
+        let exportedDocument = try APIDocument.decode(from: testDirectory + "\(document.fileName).yaml")
         
         XCTAssertEqual(document, exportedDocument)
     }
@@ -140,12 +142,16 @@ final class ApodiniMigratorTests: ApodiniTests {
         
         try app.testable().test(.GET, path) { response in
             XCTAssertEqual(response.status, .ok)
-            XCTAssertNoThrow(try response.bodyStorage.getFullBodyData(decodedAs: Document.self, using: JSONDecoder()))
+            XCTAssertNoThrow(try response.bodyStorage.getFullBodyData(decodedAs: APIDocument.self, using: JSONDecoder()))
         }
     }
     
     func testMigrationGuideCompareFromFile() throws {
-        let emptyDocument = Document()
+        let emptyDocument = APIDocument(serviceInformation: ServiceInformation(
+            version: .default,
+            http: HTTPInformation(hostname: "127.0.0.1"),
+            exporters: RESTExporterConfiguration(encoderConfiguration: .default, decoderConfiguration: .default)
+        ))
         let exportPath = try emptyDocument.write(at: testDirectory.string, fileName: emptyDocument.fileName)
         
         Self.sut = MigratorConfiguration(
@@ -159,13 +165,20 @@ final class ApodiniMigratorTests: ApodiniTests {
         let exported = try MigrationGuide.decode(from: testDirectory + "migration_guide.json")
         
         XCTAssertEqual(stored, exported)
-        
-        let changes = exported.changes
+
+        // TODO fix!
+        print(exported.serviceChanges)
+        print(exported.endpointChanges)
+        print(exported.modelChanges)
+        /*
+        let changes = exported
         XCTAssert(changes.contains { $0.element == .networking(target: .serverPath) })
         XCTAssert(changes.contains { $0.element == .endpoint("multiplyHandler", target: .`self`) })
         XCTAssert(changes.contains { $0.element == .endpoint("blob", target: .`self`) })
         XCTAssert(changes.contains { $0.element == .endpoint("throwingHandler", target: .`self`) })
         XCTAssert(changes.contains { $0.element == .endpoint("text", target: .`self`) })
+        */
+        /*
         
         let addedModelChange = try XCTUnwrap(changes.first { $0.element.isModel } as? AddChange)
         XCTAssertEqual(addedModelChange.elementID, "HTTPMediaType")
@@ -174,7 +187,7 @@ final class ApodiniMigratorTests: ApodiniTests {
             XCTAssertEqual(anyCodable.typed(TypeInformation.self), try TypeInformation(type: HTTPMediaType.self))
         } else {
             XCTFail("Migration guide did not store the added model")
-        }
+        }*/
     }
     
     func testMigrationGuideCompareFromResources() throws {
@@ -205,7 +218,9 @@ final class ApodiniMigratorTests: ApodiniTests {
         try app.testable().test(.GET, endpointPath) { response in
             XCTAssertEqual(response.status, .ok)
             let migrationGuide = try response.bodyStorage.getFullBodyData(decodedAs: MigrationGuide.self, using: JSONDecoder())
-            XCTAssert(migrationGuide.changes.isEmpty)
+            XCTAssert(migrationGuide.serviceChanges.isEmpty)
+            XCTAssert(migrationGuide.modelChanges.isEmpty)
+            XCTAssert(migrationGuide.endpointChanges.isEmpty)
         }
     }
     
@@ -225,7 +240,7 @@ final class ApodiniMigratorTests: ApodiniTests {
             XCTAssertEqual(response.status, .notFound)
         }
         
-        XCTAssertThrowsError(try Document.decode(from: readOnly.asPath))
+        XCTAssertThrowsError(try APIDocument.decode(from: Path(readOnly)))
     }
     
     func testMigratorDocumentCommand() throws {
@@ -242,7 +257,7 @@ final class ApodiniMigratorTests: ApodiniTests {
         XCTAssertEqual(commandType.configuration.commandName, "document")
         
         let document = try XCTUnwrap(app.storage.get(MigratorDocumentStorageKey.self))
-        XCTAssertEqual(document.allModels(), [try TypeInformation(type: HTTPMediaType.self)])
+        XCTAssertEqual(document.models, [try TypeInformation(type: HTTPMediaType.self)])
     }
     
     func testMigratorCompareCommand() throws {
@@ -263,13 +278,16 @@ final class ApodiniMigratorTests: ApodiniTests {
         XCTAssertEqual(commandType.configuration.commandName, "compare")
         
         let document = try XCTUnwrap(app.storage.get(MigratorDocumentStorageKey.self))
-        XCTAssertEqual(document.allModels(), [try TypeInformation(type: HTTPMediaType.self)])
+        XCTAssertEqual(document.models, [try TypeInformation(type: HTTPMediaType.self)])
         
         let migrationGuide = try XCTUnwrap(app.storage.get(MigrationGuideStorageKey.self))
-        XCTAssertEqual(migrationGuide.id, try Document.decode(from: documentPath.asPath).id)
+        XCTAssertEqual(migrationGuide.id, try APIDocument.decode(from: Path(documentPath)).id)
     }
     
     func testMigratorReadCommand() throws {
+        let mg = MigrationGuide.empty(id: UUID())
+        print(mg.yaml)
+
         Self.sut = .init()
         let guidePath = try XCTUnwrap(ResourceLocation.resource(.module, fileName: "empty_migration_guide", format: .yaml).path)
         
@@ -289,7 +307,7 @@ final class ApodiniMigratorTests: ApodiniTests {
         XCTAssertEqual(commandType.configuration.commandName, "read")
         
         let migrationGuide = try XCTUnwrap(app.storage.get(MigrationGuideStorageKey.self))
-        XCTAssertEqual(migrationGuide, try MigrationGuide.decode(from: guidePath.asPath))
+        XCTAssertEqual(migrationGuide, try MigrationGuide.decode(from: Path(guidePath)))
     }
     
     func testCustomHTTPConfig() throws {
@@ -312,8 +330,8 @@ final class ApodiniMigratorTests: ApodiniTests {
         
         try app.testable().test(.GET, "api-spec") { response in
             XCTAssertEqual(response.status, .ok)
-            let document = try response.bodyStorage.getFullBodyData(decodedAs: Document.self, using: JSONDecoder())
-            XCTAssertEqual(document.metaData.versionedServerPath, "http://1.2.3.4:56/789")
+            let document = try response.bodyStorage.getFullBodyData(decodedAs: APIDocument.self, using: JSONDecoder())
+            XCTAssertEqual(document.serviceInformation.http.description, "1.2.3.4:56")
         }
     }
     
@@ -323,18 +341,14 @@ final class ApodiniMigratorTests: ApodiniTests {
         start()
         
         let document = try XCTUnwrap(app.storage.get(MigratorDocumentStorageKey.self))
+
+        let migrator = try RESTMigrator(documentPath: (testDirectory + "\(document.fileName).json").string)
         
-        let migrator = try ApodiniMigrator.Migrator(
-            packageName: "TestPackage",
-            packagePath: testDirectory.string,
-            documentPath: (testDirectory + "\(document.fileName).json").string
-        )
-        
-        XCTAssertNoThrow(try migrator.run())
+        XCTAssertNoThrow(try migrator.run(packageName: "TestPackage", packagePath: testDirectory.string))
         
         let swiftFiles = try testDirectory.recursiveSwiftFiles().map { $0.lastComponent }
         
-        let modelNames = document.allModels().map { $0.typeString + .swift }
+        let modelNames = document.models.map { $0.typeString + .swift }
         for modelName in modelNames {
             XCTAssert(swiftFiles.contains(modelName))
         }

--- a/Tests/ApodiniTests/MigratorTests/ApodiniMigratorTests.swift
+++ b/Tests/ApodiniTests/MigratorTests/ApodiniMigratorTests.swift
@@ -166,28 +166,22 @@ final class ApodiniMigratorTests: ApodiniTests {
         
         XCTAssertEqual(stored, exported)
 
-        // TODO fix!
-        print(exported.serviceChanges)
-        print(exported.endpointChanges)
-        print(exported.modelChanges)
-        /*
-        let changes = exported
-        XCTAssert(changes.contains { $0.element == .networking(target: .serverPath) })
-        XCTAssert(changes.contains { $0.element == .endpoint("multiplyHandler", target: .`self`) })
-        XCTAssert(changes.contains { $0.element == .endpoint("blob", target: .`self`) })
-        XCTAssert(changes.contains { $0.element == .endpoint("throwingHandler", target: .`self`) })
-        XCTAssert(changes.contains { $0.element == .endpoint("text", target: .`self`) })
-        */
-        /*
-        
-        let addedModelChange = try XCTUnwrap(changes.first { $0.element.isModel } as? AddChange)
-        XCTAssertEqual(addedModelChange.elementID, "HTTPMediaType")
-        
-        if case let .element(anyCodable) = addedModelChange.added {
-            XCTAssertEqual(anyCodable.typed(TypeInformation.self), try TypeInformation(type: HTTPMediaType.self))
-        } else {
-            XCTFail("Migration guide did not store the added model")
-        }*/
+        XCTAssert(exported.serviceChanges.contains { change in
+            if change.id == ServiceInformation.deltaIdentifier,
+               case .http = change.modeledUpdateChange?.updated {
+                return true
+            }
+            return false
+        })
+
+        XCTAssert(exported.endpointChanges.contains(where: { $0.id == "MultiplyHandler" && $0.type == .addition }))
+        XCTAssert(exported.endpointChanges.contains(where: { $0.id == "blob" && $0.type == .addition }))
+        XCTAssert(exported.endpointChanges.contains(where: { $0.id == "ThrowingHandler" && $0.type == .addition }))
+        XCTAssert(exported.endpointChanges.contains(where: { $0.id == "Text" && $0.type == .addition }))
+
+        let addedModelChange = try XCTUnwrap(exported.modelChanges.first?.modeledAdditionChange)
+        XCTAssertEqual(addedModelChange.id, "HTTPMediaType")
+        XCTAssertEqual(addedModelChange.added, try TypeInformation(type: HTTPMediaType.self))
     }
     
     func testMigrationGuideCompareFromResources() throws {

--- a/Tests/ApodiniTests/OpenAPITests/OpenAPIComponentsObjectBuilderTests.swift
+++ b/Tests/ApodiniTests/OpenAPITests/OpenAPIComponentsObjectBuilderTests.swift
@@ -274,15 +274,15 @@ final class OpenAPIComponentsObjectBuilderTests: XCTestCase {
         let enums = casino.enums()
         
         XCTAssertEqual(objectTypes.count, 4)
-        XCTAssertEqual(casino.typeName.name, "Casino")
+        XCTAssertEqual(casino.typeName.mangledName, "Casino")
         XCTAssertEqual(casino.typeName.definedIn, "ApodiniTests")
         XCTAssertEqual(casino.property("tables")?.type, .repeated(element: game))
         
-        let unwrappedBadge = try XCTUnwrap(enums.first { $0.typeName.name == "Badge" })
+        let unwrappedBadge = try XCTUnwrap(enums.first { $0.typeName.mangledName == "Badge" })
         XCTAssertEqual(unwrappedBadge.rawValueType, .scalar(.string))
         XCTAssertEqual(unwrappedBadge, badge)
         
-        let unwrappedNumber = try XCTUnwrap(enums.first { $0.typeName.name == "Number" })
+        let unwrappedNumber = try XCTUnwrap(enums.first { $0.typeName.mangledName == "Number" })
         XCTAssertEqual(unwrappedNumber.rawValueType, .scalar(.uint8))
         XCTAssertEqual(unwrappedNumber, number)
         

--- a/Tests/ApodiniTests/Resources/empty_migration_guide.yaml
+++ b/Tests/ApodiniTests/Resources/empty_migration_guide.yaml
@@ -1,6 +1,5 @@
 summary: A summary of what changed between versions
-service-type: REST
-api-spec: Apodini DSL
+document-id: F1D7EDF0-7231-424E-B115-3A8057287807
 from: v_1.0.0
 to: v_1.0.0
 changes: []

--- a/Tests/ApodiniTests/Resources/migrator_document.json
+++ b/Tests/ApodiniTests/Resources/migrator_document.json
@@ -1,7 +1,7 @@
 {
     "id": "24C6C9D9-35A6-4CC4-9AB2-19297A33E8F5",
     "info": {
-        "serverPath": "",
+        "serverPath": "http://127.0.0.1:8080",
         "version": "v_1.0.0",
         "encoderConfiguration": {
             "dateEncodingStrategy": "deferredToDate",


### PR DESCRIPTION


<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Update ApodiniMigration to ApodiniMigrator 0.2.0; bump ApodiniTypeInformation to 0.3.0

## :recycle: Current situation & Problem

Currently Apodini runs with `ApodiniMigrator` `0.1.x` and `ApodiniTypeInformation` `0.2.x`.

## :bulb: Proposed solution

This PR updates the code base and bumps both dependencies to their latest version, ApodiniMigrator to [0.2.0](https://github.com/Apodini/ApodiniMigrator/releases/tag/0.2.0) and ApodiniTypeInformation to [0.3.0](https://github.com/Apodini/ApodiniTypeInformation/releases/tag/0.3.0).

## :gear: Release Notes 
* Updated `ApodiniMigrator` to [0.2.0](https://github.com/Apodini/ApodiniMigrator/releases/tag/0.2.0)
* Updated `ApodiniTypeInformation` to [0.3.0](https://github.com/Apodini/ApodiniTypeInformation/releases/tag/0.3.0)

## :heavy_plus_sign: Additional Information

### Related PRs
-- 

### Testing
--

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
