### PR TITLE
Add XCTApodiniNetworking product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,8 @@ let package = Package(
 
         // Test Utils
         .library(name: "XCTApodini", targets: ["XCTApodini"]),
-        .library(name: "XCTApodiniObserve", targets: ["XCTApodiniObserve"])
+        .library(name: "XCTApodiniObserve", targets: ["XCTApodiniObserve"]),
+        .library(name: "XCTApodiniNetworking", targets: ["XCTApodiniNetworking"])
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.16.0"),


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# *Name of the PR*

## :recycle: Current situation & Problem

[comment]: # "
*Describe the current situation (if possible with and exemplary (or real) code snippet and/or where this is used)*
*Please link any open issue that is addressed with this PR*
"
Currently, other packages cannot use the XCTApodiniNetworking module to test endpoints

## :bulb: Proposed solution

[comment]: # "
*Describe the solution and how this affects the project and internal structure*
"
This PR adds XCTApodiniNetworking as a product in the Apodini package

## :gear: Release Notes 

[comment]: # "
*Add a short summary of the feature as well as possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented if it appends or changes the public interface.*
"
- Adds XCTApodiniNetworking product

## :heavy_plus_sign: Additional Information

[comment]: # "
*Provide some additional information if possible*
"
This change is necessary to test the endpoint in the ApodiniSustainability package but may be relevant to other packages in the future.

### Related PRs

[comment]: # "
*Reference the related PRs*
"
—

### Testing

[comment]: # "
*Are there tests included? If yes, which situations are tested and which corner cases are missing?*
"
—

### Reviewer Nudging

[comment]: # "
*Where should the reviewer start, where is a good entry point?*
"
Take a look at [ApdoniMigratorTests](https://github.com/Apodini/Apodini/blob/develop/Tests/ApodiniTests/MigratorTests/ApodiniMigratorTests.swift) to see example use

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
