### PR TITLE
Improve Parameter Handling

### DIFF
--- a/Sources/Apodini/Semantic Model Builder/Model/EndpointParameter.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/EndpointParameter.swift
@@ -188,15 +188,18 @@ public struct EndpointParameter<Type: Codable>: _AnyEndpointParameter, Identifia
         let httpOption = options.option(for: PropertyOptionKey.http)
         switch httpOption {
         case .path:
-            precondition(Type.self is LosslessStringConvertible.Type, "Invalid explicit option .path for '\(description)'. Option is only available for wrapped properties conforming to \(LosslessStringConvertible.self).")
+            //precondition(Type.self is LosslessStringConvertible.Type, "Invalid explicit option .path for '\(description)'. Option is only available for wrapped properties conforming to \(LosslessStringConvertible.self).")
+//            precondition(Self.isValidPathOrQueryParamType, "Invalid option .path for \(description): Parameter type \(T.self) must ")
+            Self.assertIsValidLightweightParamType(forParameterMode: .path, description: description)
             parameterType = .path
         case .query:
-            precondition(Type.self is LosslessStringConvertible.Type, "Invalid explicit option .query for '\(description)'. Option is only available for wrapped properties conforming to \(LosslessStringConvertible.self).")
+//            precondition(Type.self is LosslessStringConvertible.Type, "Invalid explicit option .query for '\(description)'. Option is only available for wrapped properties conforming to \(LosslessStringConvertible.self).")
+            Self.assertIsValidLightweightParamType(forParameterMode: .query, description: description)
             parameterType = .lightweight
         case .body:
             parameterType = .content
         default:
-            parameterType = Type.self is LosslessStringConvertible.Type ? .lightweight : .content
+            parameterType = Self.isValidLightweightParamType ? .lightweight : .content
         }
     }
 
@@ -214,6 +217,16 @@ public struct EndpointParameter<Type: Codable>: _AnyEndpointParameter, Identifia
 
     func exportParameter<I: InterfaceExporter>(on exporter: I) -> I.ParameterExportOutput {
         exporter.exportParameter(self)
+    }
+    
+    private static var isValidLightweightParamType: Bool {
+        Type.self is LosslessStringConvertible.Type || Type.self == Foundation.Date.self
+    }
+    
+    private static func assertIsValidLightweightParamType(forParameterMode parameterMode: HTTPParameterMode, description: String) {
+        if !isValidLightweightParamType {
+            fatalError("Invalid option .\(parameterMode) for \(description): Parameter type \(Type.self) must conform to \(LosslessStringConvertible.self), or be \(Foundation.Date.self).")
+        }
     }
 }
 

--- a/Sources/Apodini/Semantic Model Builder/Model/EndpointParameter.swift
+++ b/Sources/Apodini/Semantic Model Builder/Model/EndpointParameter.swift
@@ -188,12 +188,9 @@ public struct EndpointParameter<Type: Codable>: _AnyEndpointParameter, Identifia
         let httpOption = options.option(for: PropertyOptionKey.http)
         switch httpOption {
         case .path:
-            //precondition(Type.self is LosslessStringConvertible.Type, "Invalid explicit option .path for '\(description)'. Option is only available for wrapped properties conforming to \(LosslessStringConvertible.self).")
-//            precondition(Self.isValidPathOrQueryParamType, "Invalid option .path for \(description): Parameter type \(T.self) must ")
             Self.assertIsValidLightweightParamType(forParameterMode: .path, description: description)
             parameterType = .path
         case .query:
-//            precondition(Type.self is LosslessStringConvertible.Type, "Invalid explicit option .query for '\(description)'. Option is only available for wrapped properties conforming to \(LosslessStringConvertible.self).")
             Self.assertIsValidLightweightParamType(forParameterMode: .query, description: description)
             parameterType = .lightweight
         case .body:

--- a/Sources/ApodiniHTTP/Configuration.swift
+++ b/Sources/ApodiniHTTP/Configuration.swift
@@ -20,7 +20,7 @@ extension HTTP {
         public let encoder: AnyEncoder
         /// The `AnyDecoder` to be used for decoding requests
         public let decoder: AnyDecoder
-        /// How `Date` objects passed as query or path parameters should be decoded.
+        /// How `Date` objects passed as query or path parameters should be decoded
         public let urlParamDateDecodingStrategy: DateDecodingStrategy
         /// Indicates whether the HTTP route is interpreted case-sensitivly
         public let caseInsensitiveRouting: Bool

--- a/Sources/ApodiniHTTP/Configuration.swift
+++ b/Sources/ApodiniHTTP/Configuration.swift
@@ -10,6 +10,7 @@ import Foundation
 import Apodini
 import ApodiniExtension
 import ApodiniHTTPProtocol
+import ApodiniNetworking
 
 
 extension HTTP {
@@ -19,6 +20,8 @@ extension HTTP {
         public let encoder: AnyEncoder
         /// The `AnyDecoder` to be used for decoding requests
         public let decoder: AnyDecoder
+        /// How `Date` objects passed as query or path parameters should be decoded.
+        public let urlParamDateDecodingStrategy: DateDecodingStrategy
         /// Indicates whether the HTTP route is interpreted case-sensitivly
         public let caseInsensitiveRouting: Bool
         /// Configures the root path for the HTTP endpoints
@@ -33,11 +36,13 @@ extension HTTP {
         public init(
             encoder: AnyEncoder = HTTP.defaultEncoder,
             decoder: AnyDecoder = HTTP.defaultDecoder,
+            urlParamDateDecodingStrategy: DateDecodingStrategy = .default,
             caseInsensitiveRouting: Bool = false,
             rootPath: RootPath? = nil
         ) {
             self.encoder = encoder
             self.decoder = decoder
+            self.urlParamDateDecodingStrategy = urlParamDateDecodingStrategy
             self.caseInsensitiveRouting = caseInsensitiveRouting
             self.rootPath = rootPath
         }

--- a/Sources/ApodiniNetworking/HTTP/Request.swift
+++ b/Sources/ApodiniNetworking/HTTP/Request.swift
@@ -173,11 +173,15 @@ public final class HTTPRequest: RequestBasis, Equatable, Hashable, CustomStringC
     /// Read a query param value, decoded to the specified type.
     /// - Note: This function adopts Apodini's requirement that only types conforming to the `LosslessStringConvertible` protocol may be used as query parameters.
     ///         It may work with other types, but that's really just by accident.
-    public func getQueryParam<T: Decodable>(for key: String, as _: T.Type = T.self) throws -> T? {
+    public func getQueryParam<T: Decodable>(
+        for key: String,
+        as _: T.Type = T.self,
+        dateDecodingStrategy: DateDecodingStrategy = .default
+    ) throws -> T? {
         guard case Optional<String?>.some(.some(let rawValue)) = url.queryItems[key] else { // swiftlint:disable:this syntactic_sugar
             return nil
         }
-        return try URLQueryParameterValueDecoder().decode(T.self, from: rawValue)
+        return try URLQueryParameterValueDecoder(dateDecodingStrategy: dateDecodingStrategy).decode(T.self, from: rawValue)
     }
     
     /// Returns the raw (i.e. stringly typed) value of the specified non-query parameter
@@ -187,7 +191,11 @@ public final class HTTPRequest: RequestBasis, Equatable, Hashable, CustomStringC
     }
     
     /// Returns the value of the specified non-query parameter, decoded using the specified type
-    public func getParameter<T: Decodable>(_ name: String, as _: T.Type = T.self) throws -> T? {
+    public func getParameter<T: Decodable>(
+        _ name: String,
+        as _: T.Type = T.self,
+        dateDecodingStrategy: DateDecodingStrategy = .default
+    ) throws -> T? {
         guard let rawValue = getParameterRawValue(name) else {
             return nil
         }
@@ -196,7 +204,7 @@ public final class HTTPRequest: RequestBasis, Equatable, Hashable, CustomStringC
             return rawValue as! T?
         }
         do {
-            return try URLQueryParameterValueDecoder().decode(T.self, from: rawValue)
+            return try URLQueryParameterValueDecoder(dateDecodingStrategy: dateDecodingStrategy).decode(T.self, from: rawValue)
         } catch {
             throw ApodiniNetworkingError(message: "Error decoding parameter '\(name)'", underlying: error)
         }

--- a/Sources/ApodiniNetworking/URLQueryParamDecoder.swift
+++ b/Sources/ApodiniNetworking/URLQueryParamDecoder.swift
@@ -42,7 +42,7 @@ public enum DateDecodingStrategy {
     /// Decodes `Date` objects using a custom closure.
     case custom((String) throws -> Date)
     
-    /// The "default" date decoding strategy, which interprets dates as UNIX timestamps.
+    /// The "default" date decoding strategy, which interprets dates as UNIX timestamps
     /// This static variable exists to ensure that different methods and types can use a common uniform "default" date decoding strategy.
     public static let `default` = Self.secondsSince1970
     

--- a/Sources/ApodiniNetworking/URLQueryParamDecoder.swift
+++ b/Sources/ApodiniNetworking/URLQueryParamDecoder.swift
@@ -80,8 +80,11 @@ struct URLQueryParameterValueDecoder {
     }
     
     func decode<T: Decodable>(_: T.Type, from rawValue: String) throws -> T {
+        if T.self == Date.self {
+            return try dateDecodingStrategy.decodeDate(from: rawValue) as! T
+        }
         let decoder = _Decoder(rawValue: rawValue, dateDecodingStrategy: self.dateDecodingStrategy)
-        return try decoder.singleValueContainer().decode(T.self)
+        return try T(from: decoder)
     }
 }
 

--- a/Sources/ApodiniNetworking/URLQueryParamDecoder.swift
+++ b/Sources/ApodiniNetworking/URLQueryParamDecoder.swift
@@ -37,7 +37,7 @@ public enum DateDecodingStrategy {
     case iso8601
     /// Decodes `Date` objects from a UNIX timestamp
     case secondsSince1970
-    /// Decodes `Date` objects from a timestamp relative to Foundation's reference date of 00:00:00 UTC on 1 January 2001.
+    /// Decodes `Date` objects from a timestamp relative to Foundation's reference date of 00:00:00 UTC on 1 January 2001
     case secondsSinceReferenceDate
     /// Decodes `Date` objects using a custom closure.
     case custom((String) throws -> Date)

--- a/Sources/ApodiniREST/RESTEndpointHandler.swift
+++ b/Sources/ApodiniREST/RESTEndpointHandler.swift
@@ -37,8 +37,8 @@ struct RESTEndpointHandler<H: Handler>: HTTPResponder {
         self.exporter = exporter
         
         self.strategy = ParameterTypeSpecific(
-            lightweight: LightweightStrategy(),
-            path: PathStrategy(useNameAsIdentifier: false),
+            lightweight: LightweightStrategy(dateDecodingStrategy: exporterConfiguration.urlParamDateDecodingStrategy),
+            path: PathStrategy(useNameAsIdentifier: false, dateDecodingStrategy: exporterConfiguration.urlParamDateDecodingStrategy),
             content: AllIdentityStrategy(exporterConfiguration.decoder).transformedToHTTPRequestBasedStrategy()
         ).applied(to: endpoint)
         

--- a/Sources/ApodiniREST/RESTExporterConfiguration.swift
+++ b/Sources/ApodiniREST/RESTExporterConfiguration.swift
@@ -19,6 +19,8 @@ extension REST {
         public let encoder: AnyEncoder
         /// The to be used `AnyDecoder` for decoding requests to the `RESTInterfaceExporter`
         public let decoder: AnyDecoder
+        /// How `Date` objects passed as query or path parameters should be decoded.
+        public let urlParamDateDecodingStrategy: DateDecodingStrategy
         /// Indicates whether the HTTP route is interpreted case-sensitivly
         public let caseInsensitiveRouting: Bool
         /// Configures if the current web service version should be used as a prefix for all HTTP paths
@@ -30,12 +32,16 @@ extension REST {
         ///    - encoder: The to be used `AnyEncoder`, defaults to a `JSONEncoder`
         ///    - decoder: The to be used `AnyDecoder`, defaults to a `JSONDecoder`
         ///    - caseInsensitiveRouting: Indicates whether the HTTP route is interpreted case-sensitivly
-        public init(encoder: AnyEncoder = REST.defaultEncoder,
-                    decoder: AnyDecoder = REST.defaultDecoder,
-                    caseInsensitiveRouting: Bool = false,
-                    rootPath: RootPath? = nil) {
+        public init(
+            encoder: AnyEncoder = REST.defaultEncoder,
+            decoder: AnyDecoder = REST.defaultDecoder,
+            urlParamDateDecodingStrategy: DateDecodingStrategy = .default,
+            caseInsensitiveRouting: Bool = false,
+            rootPath: RootPath? = nil
+        ) {
             self.encoder = encoder
             self.decoder = decoder
+            self.urlParamDateDecodingStrategy = urlParamDateDecodingStrategy
             self.caseInsensitiveRouting = caseInsensitiveRouting
             self.rootPath = rootPath
         }

--- a/Sources/ApodiniREST/RESTExporterConfiguration.swift
+++ b/Sources/ApodiniREST/RESTExporterConfiguration.swift
@@ -19,7 +19,7 @@ extension REST {
         public let encoder: AnyEncoder
         /// The to be used `AnyDecoder` for decoding requests to the `RESTInterfaceExporter`
         public let decoder: AnyDecoder
-        /// How `Date` objects passed as query or path parameters should be decoded.
+        /// How `Date` objects passed as query or path parameters should be decoded
         public let urlParamDateDecodingStrategy: DateDecodingStrategy
         /// Indicates whether the HTTP route is interpreted case-sensitivly
         public let caseInsensitiveRouting: Bool

--- a/Sources/ApodiniREST/RESTInterfaceExporter.swift
+++ b/Sources/ApodiniREST/RESTInterfaceExporter.swift
@@ -40,12 +40,14 @@ public final class REST: Configuration {
     public init(
         encoder: AnyEncoder = defaultEncoder,
         decoder: AnyDecoder = defaultDecoder,
+        urlParamDateDecodingStrategy: DateDecodingStrategy = .default,
         caseInsensitiveRouting: Bool = false,
         rootPath: RootPath? = nil
     ) {
         self.configuration = REST.ExporterConfiguration(
             encoder: encoder,
             decoder: decoder,
+            urlParamDateDecodingStrategy: urlParamDateDecodingStrategy,
             caseInsensitiveRouting: caseInsensitiveRouting,
             rootPath: rootPath
         )
@@ -75,11 +77,18 @@ extension REST {
     public convenience init(
         encoder: JSONEncoder = defaultEncoder as! JSONEncoder,
         decoder: JSONDecoder = defaultDecoder as! JSONDecoder,
+        urlParamDateDecodingStrategy: DateDecodingStrategy = .default,
         caseInsensitiveRouting: Bool = false,
         rootPath: RootPath? = nil,
         @RESTDependentStaticConfigurationBuilder staticConfigurations: () -> [RESTDependentStaticConfiguration] = { [] }
     ) {
-        self.init(encoder: encoder, decoder: decoder, caseInsensitiveRouting: caseInsensitiveRouting, rootPath: rootPath)
+        self.init(
+            encoder: encoder,
+            decoder: decoder,
+            urlParamDateDecodingStrategy: urlParamDateDecodingStrategy,
+            caseInsensitiveRouting: caseInsensitiveRouting,
+            rootPath: rootPath
+        )
         self.staticConfigurations = staticConfigurations()
     }
 }

--- a/Sources/XCTApodini/Mocks/MockConnectionContext.swift
+++ b/Sources/XCTApodini/Mocks/MockConnectionContext.swift
@@ -128,7 +128,7 @@ extension RESTInterfaceExporter: EndpointDecodingStrategyProvider {
     public var strategy: AnyEndpointDecodingStrategy<HTTPRequest> {
         ParameterTypeSpecific(
             lightweight: LightweightStrategy(),
-            path: PathStrategy(useNameAsIdentifier: false),
+            path: PathStrategy(useNameAsIdentifier: false, dateDecodingStrategy: .default),
             content: AllIdentityStrategy(exporterConfiguration.decoder).transformedToHTTPRequestBasedStrategy()
         ).typeErased
     }


### PR DESCRIPTION
# Improve Parameter Handling

## :recycle: Current situation & Problem
Because Date doesn't conform to LosslessStringConvertible (for good reasons, btw), date objects cannot be used as path or query parameters in HTTP/REST endpoints. It is possible to work around this, by adding a dummy extension Date: LosslessStringConvertible conformance somewhere in the web service, but that still produces invalid parameter values: All Date query parameters are interpreted as the amount of seconds passed since Foundation's reference date of 00:00:00 UTC on 1 January 2001.

## :bulb: Proposed solution
We allow `Date` objects as lightweight parameters (despite the fact that they don't conform to `LosslessStringConvertible`, and without adding such a conformance), and expose configuration options (with reasonable default values) to Interface Exporters (and interface exporter configurations), in order to allow Handlers to use `Date` objects as lightweight parameters.

## :gear: Release Notes 
- Added support for `Date` objects as path or query parameters in the HTTP and REST interface exporters

## :heavy_plus_sign: Additional Information
I decided to set the default date decoding strategy to `secondsSince 1970`, since that seems like a more reasonable default than using Foundation's reference date.

### Related PRs
n/a

### Testing
There are tests included to check that the date decoding works properly.

### Reviewer Nudging
There really isn't too much code, so this should be straightforward, basically I just added a `dateDecodingStrategy` parameter to all functions/types between the REST/HTTP IEs and ApodiniNetworking's `HTTPRequest` class.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).


Fixes #415 