### PR TITLE
Remove `___` suffixes from implicitly created wrapper proto types

### DIFF
--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        linux: [focal, amazonlinux2, centos8]
+        linux: [focal, amazonlinux2]
         configuration: [debug, release]
     defaults:
       run:

--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -77,6 +77,6 @@ jobs:
       run: |
           swift build -c ${{ matrix.configuration }}
           swift run -c ${{ matrix.configuration }} &
-          sleep 15
+          sleep 60
           sh test.sh
           kill -9 $(lsof -ti:80)

--- a/Sources/ApodiniGRPC/GRPCInterfaceExporter.swift
+++ b/Sources/ApodiniGRPC/GRPCInterfaceExporter.swift
@@ -149,8 +149,11 @@ class GRPCInterfaceExporter: InterfaceExporter {
                 type: .bidirectionalStream,
                 inputType: reflectionInputType,
                 outputType: reflectionOutputType,
-                streamRPCHandlerMaker: { [unowned self] in
-                    ServerReflectionInfoRPCHandler(server: self.server)
+                streamRPCHandlerMaker: { [weak self] in
+                    guard let self = self else {
+                        fatalError("self is nil")
+                    }
+                    return ServerReflectionInfoRPCHandler(server: self.server)
                 }
             )
         )

--- a/Sources/ApodiniGraphQL/GraphQLInterfaceExporter.swift
+++ b/Sources/ApodiniGraphQL/GraphQLInterfaceExporter.swift
@@ -25,7 +25,7 @@ public class GraphQL: Configuration {
         graphQLEndpoint: [HTTPPathComponent] = "/graphql",
         enableGraphiQL: Bool = false,
         graphiQLEndpoint: [HTTPPathComponent] = "/graphiql",
-        enableCustom64BitIntScalars: Bool = false
+        enableCustom64BitIntScalars: Bool = true
     ) {
         precondition(graphQLEndpoint.allSatisfy(\.isConstant), "GraphQL endpoint must be a constant path")
         precondition(graphiQLEndpoint.allSatisfy(\.isConstant), "GraphiQL endpoint must be a constant path")

--- a/Sources/ApodiniGraphQL/Schema.swift
+++ b/Sources/ApodiniGraphQL/Schema.swift
@@ -244,7 +244,7 @@ class GraphQLSchemaBuilder {
         case .scalar(let primitiveType):
             switch primitiveType {
             case .null:
-                fatalError()
+                throw SchemaError.other("Unexpected null type: \(typeInfo)")
             case .bool:
                 return .init(inputAndOutputType: GraphQLBoolean)
             case .float:

--- a/Sources/ApodiniNetworking/ChannelHandlers/UpgradeHandler.swift
+++ b/Sources/ApodiniNetworking/ChannelHandlers/UpgradeHandler.swift
@@ -137,7 +137,9 @@ class HTTPUpgradeHandler: ChannelInboundHandler, ChannelOutboundHandler, Removab
                     }
                     .flatMap { () -> EventLoopFuture<Void> in
                         self.logger.notice("Calling upgrader.upgrade")
-                        return webSocketUpgrader.upgrade(context: context, upgradeRequest: head)
+                        let retval = webSocketUpgrader.upgrade(context: context, upgradeRequest: head)
+                        self.logger.notice("Called upgrader.upgrade. retval: \(retval)")
+                        return retval
                     }
                     .cascadeFailure(to: promise)
             }

--- a/Sources/ApodiniNetworking/HTTP/Request.swift
+++ b/Sources/ApodiniNetworking/HTTP/Request.swift
@@ -67,7 +67,8 @@ public final class HTTPRequest: RequestBasis, Equatable, Hashable, CustomStringC
     
     /// For incoming requests from external clients processed through the HTTP server's router, the route this request matched against.
     /// - Note: This property is `nil` for manually constructed requests
-    internal var route: HTTPRouter.Route?
+    /// - Note: This property is intentionally not a `HTTPRouter.Route`, since that would entail also storing the route's responder, which would introduce the possibility of retain cycles.
+    internal var matchedRoute: (method: HTTPMethod, path: [HTTPPathComponent])?
     
     private var parameters = ParametersStorage()
     
@@ -161,10 +162,10 @@ public final class HTTPRequest: RequestBasis, Equatable, Hashable, CustomStringC
                 ))
             }
         }
-        if let route = route {
+        if let matchedRoute = matchedRoute {
             metadata.append(LoggingMetadataInformation(
                 key: .init("route"),
-                rawValue: .string("\(route.method) \(route.path.httpPathString)")
+                rawValue: .string("\(matchedRoute.method) \(matchedRoute.path.httpPathString)")
             ))
         }
         return metadata
@@ -214,7 +215,7 @@ public final class HTTPRequest: RequestBasis, Equatable, Hashable, CustomStringC
     }
     
     internal func populate(from route: HTTPRouter.Route, withParameters parameters: ParametersStorage) {
-        self.route = route
+        self.matchedRoute = (route.method, route.path)
         self.parameters = parameters
     }
     

--- a/Sources/ApodiniWebSocket/Infrastructure/ConnectionResponsible.swift
+++ b/Sources/ApodiniWebSocket/Infrastructure/ConnectionResponsible.swift
@@ -18,7 +18,7 @@ typealias ContextOpener = (ConnectionResponsible, UUID) -> (ContextResponsible)
 
 
 class ConnectionResponsible: Identifiable {
-    unowned var websocket: WebSocketKit.WebSocket
+    weak var websocket: WebSocketKit.WebSocket?
     let logger: Logger
     let initiatingRequest: HTTPRequest
     private let onClose: (ID) -> Void
@@ -65,7 +65,7 @@ class ConnectionResponsible: Identifiable {
             guard let data = String(data: jsonData, encoding: .utf8) else {
                 throw SerializationError.expectedUTF8
             }
-            self.websocket.send(data)
+            self.websocket!.send(data)
         } catch {
             self.logger.error("Error: \(error)")
         }
@@ -78,14 +78,14 @@ class ConnectionResponsible: Identifiable {
             guard let data = String(data: jsonData, encoding: .utf8) else {
                 throw SerializationError.expectedUTF8
             }
-            self.websocket.send(data)
+            self.websocket!.send(data)
         } catch {
             self.logger.error("Error: \(error)")
         }
     }
     
     func close(_ code: WebSocketErrorCode) {
-        _ = websocket.close(code: code)
+        _ = websocket!.close(code: code)
     }
     
     func destruct(_ context: UUID) {
@@ -95,7 +95,7 @@ class ConnectionResponsible: Identifiable {
             guard let data = String(data: jsonData, encoding: .utf8) else {
                 throw SerializationError.expectedUTF8
             }
-            self.websocket.send(data)
+            self.websocket!.send(data)
         } catch {
             self.logger.error("Error: \(error)")
         }

--- a/Sources/ApodiniWebSocket/Infrastructure/ConnectionResponsible.swift
+++ b/Sources/ApodiniWebSocket/Infrastructure/ConnectionResponsible.swift
@@ -63,6 +63,7 @@ class ConnectionResponsible: Identifiable {
     
     func send<D: Encodable>(_ message: D, in context: UUID) {
         guard let websocket = websocket else {
+            print(Thread.callStackSymbols)
             fatalError("Attempted to write to already-closed web socket")
         }
         let encoder = JSONEncoder()
@@ -79,7 +80,8 @@ class ConnectionResponsible: Identifiable {
     
     func send(_ error: Error, in context: UUID) {
         guard let websocket = websocket else {
-            fatalError("Attempted to write to already-closed web socket")
+            print(Thread.callStackSymbols)
+            fatalError("Attempted to send on already-closed web socket")
         }
         let encoder = JSONEncoder()
         do {
@@ -99,6 +101,7 @@ class ConnectionResponsible: Identifiable {
     
     func destruct(_ context: UUID) {
         guard let websocket = websocket else {
+            print(Thread.callStackSymbols)
             fatalError("Attempted to destruct already-closed web socket")
         }
         let encoder = JSONEncoder()

--- a/Sources/ApodiniWebSocket/Infrastructure/ConnectionResponsible.swift
+++ b/Sources/ApodiniWebSocket/Infrastructure/ConnectionResponsible.swift
@@ -61,10 +61,14 @@ class ConnectionResponsible: Identifiable {
         }
     }
     
+    private func logInvalidOperationOnClosedWebSocketError(_ caller: StaticString = #function) {
+        logger.error("[\(Self.self)]: Attempted to perform '\(caller)' operation on already-closed web socket")
+    }
+    
     func send<D: Encodable>(_ message: D, in context: UUID) {
         guard let websocket = websocket else {
-            print(Thread.callStackSymbols)
-            fatalError("Attempted to write to already-closed web socket")
+            logInvalidOperationOnClosedWebSocketError()
+            return
         }
         let encoder = JSONEncoder()
         do {
@@ -80,8 +84,8 @@ class ConnectionResponsible: Identifiable {
     
     func send(_ error: Error, in context: UUID) {
         guard let websocket = websocket else {
-            print(Thread.callStackSymbols)
-            fatalError("Attempted to send on already-closed web socket")
+            logInvalidOperationOnClosedWebSocketError()
+            return
         }
         let encoder = JSONEncoder()
         do {
@@ -101,8 +105,8 @@ class ConnectionResponsible: Identifiable {
     
     func destruct(_ context: UUID) {
         guard let websocket = websocket else {
-            print(Thread.callStackSymbols)
-            fatalError("Attempted to destruct already-closed web socket")
+            logInvalidOperationOnClosedWebSocketError()
+            return
         }
         let encoder = JSONEncoder()
         do {

--- a/Sources/ApodiniWebSocket/Infrastructure/ContextResponsible.swift
+++ b/Sources/ApodiniWebSocket/Infrastructure/ContextResponsible.swift
@@ -65,7 +65,7 @@ class TypeSafeContextResponsible<I: Input, O: Encodable>: ContextResponsible {
         context: UUID) {
         self.init(
             opener,
-            eventLoop: con.websocket.eventLoop,
+            eventLoop: con.websocket!.eventLoop,
             send: { message in
                 con.send(message, in: context)
             },

--- a/Sources/ApodiniWebSocket/Infrastructure/ContextResponsible.swift
+++ b/Sources/ApodiniWebSocket/Infrastructure/ContextResponsible.swift
@@ -49,20 +49,15 @@ class TypeSafeContextResponsible<I: Input, O: Encodable>: ContextResponsible {
         }
     }
     
-    var input: I
-    
-    let send: (O) -> Void
-    let sendError: (Error) -> Void
-    let destruct: () -> Void
-    let close: (WebSocketErrorCode) -> Void
-    
-    let inputReceiver: Subscribable
+    private var input: I
+    private let inputReceiver: Subscribable
     
     convenience init(
         _ opener: @escaping (AnyAsyncSequence<I>, EventLoop, HTTPRequest) ->
             (default: I, output: AnyAsyncSequence<Message<O>>),
         con: ConnectionResponsible,
-        context: UUID) {
+        context: UUID
+    ) {
         self.init(
             opener,
             eventLoop: con.websocket!.eventLoop,
@@ -129,11 +124,6 @@ class TypeSafeContextResponsible<I: Input, O: Encodable>: ContextResponsible {
                 close((error as? WSClosingError)?.code ?? .unexpectedServerError)
             }
         }
-        
-        self.send = send
-        self.sendError = sendError
-        self.destruct = destruct
-        self.close = close
     }
     
     func receive(_ parameters: [String: Any], _ data: Data) throws {

--- a/Sources/ApodiniWebSocket/Infrastructure/Router.swift
+++ b/Sources/ApodiniWebSocket/Infrastructure/Router.swift
@@ -156,7 +156,7 @@ final class VaporWSRouter: Router {
                 let responsible = ConnectionResponsible(
                     webSocket,
                     initiatingRequest: initiatingRequest,
-                    onClose: { id in
+                    onClose: { [unowned self] id in
                         self.connectionsMutex.lock()
                         self.connections[id] = nil
                         self.connectionsMutex.unlock()

--- a/Sources/ProtobufferCoding/Metadata.swift
+++ b/Sources/ProtobufferCoding/Metadata.swift
@@ -1,0 +1,35 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Apodini
+
+
+/// Handler metadata for explicitly defininga handler's input proto message typename, if necessary.
+public struct HandlerInputProtoMessageName: HandlerMetadataDefinition {
+    public struct Key: OptionalContextKey {
+        public typealias Value = String
+    }
+    public let value: String
+    
+    public init(_ name: String) {
+        self.value = name
+    }
+}
+
+
+/// Handler metadata for explicitly defininga handler's response proto message typename, if necessary.
+public struct HandlerResponseProtoMessageName: HandlerMetadataDefinition {
+    public struct Key: OptionalContextKey {
+        public typealias Value = String
+    }
+    public let value: String
+    
+    public init(_ name: String) {
+        self.value = name
+    }
+}

--- a/Sources/ProtobufferCoding/SchemaManager.swift
+++ b/Sources/ProtobufferCoding/SchemaManager.swift
@@ -629,7 +629,6 @@ public class ProtoSchema {
         precondition(!isFinalized, "Cannot add type to already finalized schema")
         let setMapping = { (dst: inout [ProtoTypename: ProtoType], name: ProtoTypename) in
             if let oldValue = dst[name] {
-//                precondition(oldValue.isEqual(to: protoType, onlyCheckSemanticEquivalence: false))
                 guard oldValue.isEqual(to: protoType, onlyCheckSemanticEquivalence: false) else {
                     throw ProtoValidationError.conflictingMessageTypeNames(oldValue, protoType)
                 }

--- a/Tests/ApodiniDeployTests/ApodiniDeployTestCase.swift
+++ b/Tests/ApodiniDeployTests/ApodiniDeployTestCase.swift
@@ -41,7 +41,7 @@ class ApodiniDeployTestCase: XCTestCase {
     
     
     static var shouldRunDeploymentProviderTests: Bool {
-        #if !Xcode
+        #if os(macOS) && !Xcode
         return true
         #else
         return false

--- a/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
@@ -103,8 +103,8 @@ class GRPCInterfaceExporterTests: XCTApodiniTest {
     
     func testReflection() throws {
         struct AddNumbers: Handler {
-            @Parameter var x: Int
-            @Parameter var y: Int
+            @Parameter var x: Int // swiftlint:disable:this identifier_name
+            @Parameter var y: Int // swiftlint:disable:this identifier_name
             
             func handle() -> Int {
                 x + y
@@ -197,7 +197,6 @@ class GRPCInterfaceExporterTests: XCTApodiniTest {
             }
             """
         ]
-        print(describeServices.output)
         XCTAssert(responseParts.allSatisfy { describeServices.output.contains($0) })
         XCTAssertEqual(describeServices.output.components(separatedBy: " is a service:").count - 1, responseParts.count)
     }

--- a/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
@@ -203,7 +203,7 @@ class GRPCInterfaceExporterTests: XCTApodiniTest {
 }
 
 
-struct EchoHandler<Input: Codable & ResponseTransformable>: Handler {
+private struct EchoHandler<Input: Codable & ResponseTransformable>: Handler {
     @Parameter var value: Input
     func handle() async throws -> some ResponseTransformable {
         value

--- a/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
@@ -448,6 +448,7 @@ extension GRPCInterfaceExporterTests {
     // because it also serves as a proof-of-concept of using `EmbeddedChannel`s for testing the gRPC IE,
     // rather than relying on grpcurl.
     func testResponseHeaders() throws {
+        print(#function, "start")
         struct WebService: Apodini.WebService {
             var content: some Component {
                 Text("Hello World")
@@ -468,12 +469,17 @@ extension GRPCInterfaceExporterTests {
             }
         }
         
+        print(#function, "configure app")
         TestGRPCExporterCollection().configuration.configure(app)
+        print(#function, "create visitor")
         let visitor = SyntaxTreeVisitor(modelBuilder: SemanticModelBuilder(app))
+        print(#function, "accept visitor")
         WebService().accept(visitor)
+        print(#function, "-finishParsing")
         visitor.finishParsing()
         // Intentionally not starting the app here...
         
+        print(#function, "will fetch IE")
         let grpcIE = try XCTUnwrap(app.firstInterfaceExporter(ofType: GRPCInterfaceExporter.self))
         
         let channelCloseExpectation = XCTestExpectation(description: "NIO outbound channel close")
@@ -484,6 +490,7 @@ extension GRPCInterfaceExporterTests {
         // and otherwise behaves the same was as the "normal" gRPC channel pipeline.
         // We also add some intercepting handlers, which allows us to a) check that the data send through the pipeline at certain stages
         // of the message handling process is what we'd expect, and b) detect the end of the connection.
+        print(#function, "create EmbeddedChannel")
         let channel = EmbeddedChannel(handlers: [
             OutboundSinkholeChannelHandler(),
             httpOutInterceptor,
@@ -491,6 +498,7 @@ extension GRPCInterfaceExporterTests {
             messageOutInterceptor,
             GRPCMessageHandler(server: grpcIE.server)
         ])
+        print(#function, "create clientHeaders")
         // The HTTP/2 headers with which the client initiated the connection
         let clientHeaders = HPACKHeaders {
             $0[.methodPseudoHeader] = .POST
@@ -498,18 +506,25 @@ extension GRPCInterfaceExporterTests {
             $0[.pathPseudoHeader] = "/de.lukaskollmer.TestWebService/GetTeam"
             $0[.contentType] = .gRPC(.proto)
         }
+        print(#function, "channel.writeInbound (1)")
         try channel.writeInbound(GRPCMessageHandler.Input.openStream(clientHeaders))
+        print(#function, "channel.writeInbound (2)")
         try channel.writeInbound(GRPCMessageHandler.Input.message(GRPCMessageIn(
             remoteAddress: nil,
             requestHeaders: clientHeaders,
             payload: ByteBuffer()
         )))
+        print(#function, "channel.writeInbound (3)")
         try channel.writeInbound(GRPCMessageHandler.Input.closeStream(reason: .client))
         
+        print(#function, "wait for close expectation")
         wait(for: [channelCloseExpectation], timeout: 5)
+        print(#function, "channel.finish")
         XCTAssert(try channel.finish(acceptAlreadyClosed: true).isClean)
         
+        print(#function, "check 1")
         XCTAssertEqual(messageOutInterceptor.interceptedData.count, 2)
+        print(#function, "check 2")
         XCTAssertEqual(messageOutInterceptor.interceptedData[0].asSingleMessage, GRPCMessageOut.singleMessage(
             headers: HPACKHeaders {
                 $0[.contentType] = .gRPC(.proto)
@@ -517,6 +532,7 @@ extension GRPCInterfaceExporterTests {
             payload: ByteBuffer(bytes: [10, 13, 65, 108, 105, 99, 101, 32, 97, 110, 100, 32, 66, 111, 98]),
             closeStream: true
         ))
+        print(#function, "check 3")
         XCTAssertEqual(messageOutInterceptor.interceptedData[1], .closeStream(trailers: HPACKHeaders()))
     }
 }

--- a/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
@@ -162,8 +162,8 @@ class GRPCInterfaceExporterTests: XCTApodiniTest {
             """
             de.lukaskollmer.TestWebService is a service:
             service TestWebService {
-              rpc GetRoot ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.Text___Response );
-              rpc GetTeam ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.Text___Response );
+              rpc GetRoot ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.TextResponse );
+              rpc GetTeam ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.TextResponse );
             }
             """,
             """
@@ -175,9 +175,9 @@ class GRPCInterfaceExporterTests: XCTApodiniTest {
             """
             de.lukaskollmer.API is a service:
             service API {
-              rpc AddPost ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.Text___Response );
-              rpc DeletePost ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.Text___Response );
-              rpc GetPosts ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.Text___Response );
+              rpc AddPost ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.TextResponse );
+              rpc DeletePost ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.TextResponse );
+              rpc GetPosts ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.TextResponse );
             }
             """
         ]

--- a/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/GRPCTests/GRPCInterfaceExporterTests.swift
@@ -102,6 +102,19 @@ class GRPCInterfaceExporterTests: XCTApodiniTest {
     
     
     func testReflection() throws {
+        struct AddNumbers: Handler {
+            @Parameter var x: Int
+            @Parameter var y: Int
+            
+            func handle() -> Int {
+                x + y
+            }
+            
+            var metadata: AnyHandlerMetadata {
+                HandlerInputProtoMessageName("AdditionInput")
+                HandlerResponseProtoMessageName("AdditionResult")
+            }
+        }
         struct WebService: Apodini.WebService {
             var content: some Component {
                 Text("Hello World")
@@ -119,6 +132,8 @@ class GRPCInterfaceExporterTests: XCTApodiniTest {
                     Text("")
                         .operation(.delete)
                         .endpointName("DeletePost")
+                    AddNumbers()
+                        .endpointName(fixed: "AddNumbers")
                 }.gRPCServiceName("API")
             }
         }
@@ -175,12 +190,14 @@ class GRPCInterfaceExporterTests: XCTApodiniTest {
             """
             de.lukaskollmer.API is a service:
             service API {
+              rpc AddNumbers ( .de.lukaskollmer.AdditionInput ) returns ( .de.lukaskollmer.AdditionResult );
               rpc AddPost ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.TextResponse );
               rpc DeletePost ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.TextResponse );
               rpc GetPosts ( .google.protobuf.Empty ) returns ( .de.lukaskollmer.TextResponse );
             }
             """
         ]
+        print(describeServices.output)
         XCTAssert(responseParts.allSatisfy { describeServices.output.contains($0) })
         XCTAssertEqual(describeServices.output.components(separatedBy: " is a service:").count - 1, responseParts.count)
     }

--- a/Tests/ApodiniTests/GraphQLInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/GraphQLInterfaceExporterTests.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import Foundation
 @testable import Apodini
 @testable import ApodiniGraphQL
 import ApodiniNetworking
@@ -57,7 +58,7 @@ struct Song: Codable, Content, Hashable {
 }
 
 
-enum MusicLibrary {
+private enum MusicLibrary {
     static var albums: [Album] = []
     
     static let initialAlbums: [Album] = [
@@ -96,7 +97,7 @@ enum MusicLibrary {
 }
 
 
-struct FindBandsHandler: Handler {
+private struct FindBandsHandler: Handler {
     @Parameter var genre: Genre
     
     func handle() async throws -> Set<String> {
@@ -107,7 +108,7 @@ struct FindBandsHandler: Handler {
 }
 
 
-struct FetchAlbumsHandler: Handler {
+private struct FetchAlbumsHandler: Handler {
     @Parameter var artist: String?
     @Parameter var genre: Genre?
     @Parameter var title: String?
@@ -135,7 +136,7 @@ struct FetchAlbumsHandler: Handler {
 }
 
 
-struct AddAlbumHandler: Handler {
+private struct AddAlbumHandler: Handler {
     @Parameter var title: String
     @Parameter var artist: String
     @Parameter var genres: [Genre]
@@ -149,7 +150,65 @@ struct AddAlbumHandler: Handler {
 }
 
 
-struct TestWebService: WebService {
+struct EchoHandlerResult<T: Codable & Equatable>: Codable, Apodini.Content, Equatable {
+    let string: String
+    let listOfStrings: [String]
+    let listOfInts: [Int]
+    let bool: Bool
+    let url: URL
+    let uuid: UUID
+    let uint32: UInt32
+    let uint64: UInt64
+    let int32: Int32
+    let int64: Int64
+    let float: Float
+    let double: Double
+    let date: Date
+    let data: Data
+    let custom: T
+}
+
+
+private struct EchoHandler<T: Codable & Equatable>: Handler {
+    @Parameter var string: String
+    @Parameter var listOfStrings: [String]
+    @Parameter var listOfInts: [Int]
+    @Parameter var bool: Bool
+    @Parameter var url: URL
+    @Parameter var uuid: UUID
+    @Parameter var uint32: UInt32
+    @Parameter var uint64: UInt64
+    @Parameter var int32: Int32
+    @Parameter var int64: Int64
+    @Parameter var float: Float
+    @Parameter var double: Double
+    @Parameter var date: Date
+    @Parameter var data: Data
+    @Parameter var custom: T
+    
+    func handle() -> EchoHandlerResult<T> {
+        EchoHandlerResult(
+            string: string,
+            listOfStrings: listOfStrings,
+            listOfInts: listOfInts,
+            bool: bool,
+            url: url,
+            uuid: uuid,
+            uint32: uint32,
+            uint64: uint64,
+            int32: int32,
+            int64: int64,
+            float: float,
+            double: double,
+            date: date,
+            data: data,
+            custom: custom
+        )
+    }
+}
+
+
+private struct TestWebService: WebService {
     var content: some Component {
         Text("Hello, there")
             .endpointName("root")
@@ -162,6 +221,8 @@ struct TestWebService: WebService {
         AddAlbumHandler()
             .operation(.create)
             .endpointName("addAlbum")
+        EchoHandler<Album>()
+            .endpointName("echo")
     }
 }
 
@@ -176,7 +237,7 @@ struct WrappedGraphQLResponse<T: Decodable>: Decodable {
 class GraphQLInterfaceExporterTests: XCTApodiniTest {
     struct TestGraphQLExporterCollection: ConfigurationCollection {
         var configuration: Configuration {
-            GraphQL(graphQLEndpoint: "/graphql", enableGraphiQL: false)
+            GraphQL(graphQLEndpoint: "/graphql", enableGraphiQL: false, enableCustom64BitIntScalars: true)
         }
     }
     
@@ -262,7 +323,82 @@ class GraphQLInterfaceExporterTests: XCTApodiniTest {
     }
     
     
-    func _testAlbumsQuery( // swiftlint:disable:this identifier_name
+    func testCustomScalarTypes() throws {
+        let input = """
+            query {
+                echo(
+                    string: "Hello, World!",
+                    listOfStrings: ["Hello", "World"],
+                    listOfInts: [-2, -1, 0, 1, 2],
+                    bool: true,
+                    url: "https://in.tum.de",
+                    uuid: "3B68EBD7-057D-4477-8C6D-C03FDC541D2F",
+                    uint32: 4294967292,
+                    uint64: 427792345092,
+                    int32: -2147483648,
+                    int64: -3254582894236989,
+                    float: -3.2145698142,
+                    double: 3.14159265359,
+                    date: "2022-02-01T19:17:58Z",
+                    data: "SGVsbG8sIFdvcmxkCg==",
+                    custom: { title: "Mirror Reaper", artist: "Bell Witch", genres: [doomMetal, funeralDoom], songs: [{ title: "Mirror Reaper" }] }
+                ) {
+                    string,
+                    listOfStrings,
+                    listOfInts,
+                    bool,
+                    url,
+                    uuid,
+                    uint32,
+                    uint64,
+                    int32,
+                    int64,
+                    float,
+                    double,
+                    date,
+                    data,
+                    custom { title, artist, genres, songs { title } }
+                }
+            }
+            """
+        try app.testable().test(
+            .POST,
+            "/graphql",
+            headers: HTTPHeaders { $0[.contentType] = .graphQL },
+            body: ByteBuffer(string: input)
+        ) { res in
+            XCTAssertEqual(res.status, .ok)
+            struct Response: Codable, Equatable {
+                let echo: EchoHandlerResult<Album>
+            }
+            let decoder = JSONDecoder()
+            decoder.dataDecodingStrategy = .base64
+            decoder.dateDecodingStrategy = .iso8601
+            let response = try res.bodyStorage.getFullBodyData(decodedAs: WrappedGraphQLResponse<Response>.self, using: decoder).data.echo
+            XCTAssertEqual(response, .init(
+                string: "Hello, World!",
+                listOfStrings: ["Hello", "World"],
+                listOfInts: [-2, -1, 0, 1, 2],
+                bool: true,
+                url: URL(string: "https://in.tum.de")!,
+                uuid: UUID(uuidString: "3B68EBD7-057D-4477-8C6D-C03FDC541D2F")!,
+                uint32: 4294967292,
+                uint64: 427792345092,
+                int32: -2147483648,
+                int64: -3254582894236989,
+                float: -3.2145698142,
+                double: 3.14159265359,
+                date: ISO8601DateFormatter().date(from: "2022-02-01T19:17:58Z")!,
+                data: Data(base64Encoded: "SGVsbG8sIFdvcmxkCg==")!,
+                custom: .init(title: "Mirror Reaper", artist: "Bell Witch", genres: [.doomMetal, .funeralDoom], songs: [
+                    .init(title: "Mirror Reaper")
+                ])
+            ))
+        }
+    }
+    
+    
+    private func _testAlbumsQuery(
         parameters: [String: String],
         variables: [String: (type: String, value: Map)] = [:],
         expectedResponse: [AlbumQueryResponse]

--- a/Tests/ApodiniTests/WebSocketInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/WebSocketInterfaceExporterTests.swift
@@ -297,17 +297,24 @@ class WebSocketInterfaceExporterTests: XCTApodiniTest {
         let errorForwardingExporter = ErrorForwardingInterfaceExporter {
             forwardedError = $0
         }
+        print("register exporter")
         app.registerExporter(exporter: errorForwardingExporter)
 
         let testCollection = TestWebSocketExporterCollection()
+        print("configure app")
         testCollection.configuration.configure(app)
 
+        print("create STV")
         let visitor = SyntaxTreeVisitor(modelBuilder: SemanticModelBuilder(app))
+        print("accept STV")
         testService.accept(visitor)
+        print("finish parsing")
         visitor.finishParsing()
 
+        print("start app")
         try app.start()
 
+        print("create client")
         let client = StatelessClient(on: app.eventLoopGroup.next())
 
         let userId = "1234"
@@ -317,7 +324,9 @@ class WebSocketInterfaceExporterTests: XCTApodiniTest {
             let userId: String
         }
 
+        print("client.resolve")
         XCTAssertThrowsError(try client.resolve(one: InvalidUserHandlerInput(userId: userId), on: "user.:userId:").wait() as User)
+        print("check")
         let forwardedApodiniError = try XCTUnwrap(forwardedError as? ApodiniError)
         XCTAssertEqual(forwardedApodiniError.option(for: .errorType), .badInput)
     }

--- a/Tests/ApodiniTests/WebSocketInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/WebSocketInterfaceExporterTests.swift
@@ -353,7 +353,7 @@ class WebSocketInterfaceExporterTests: XCTApodiniTest {
             true.asInputForThrowingHandler,
             false.asInputForThrowingHandler,
             on: "throwing.none"
-        ).wait()
+        ).wait() // swiftlint:disable:this multiline_function_chains
         _ = output
         let forwardedApodiniError = try XCTUnwrap(forwardedError as? ApodiniError)
         XCTAssertEqual(forwardedApodiniError.option(for: .errorType), .other)

--- a/Tests/ApodiniTests/WebSocketInterfaceExporterTests.swift
+++ b/Tests/ApodiniTests/WebSocketInterfaceExporterTests.swift
@@ -297,36 +297,27 @@ class WebSocketInterfaceExporterTests: XCTApodiniTest {
         let errorForwardingExporter = ErrorForwardingInterfaceExporter {
             forwardedError = $0
         }
-        print("register exporter")
         app.registerExporter(exporter: errorForwardingExporter)
-
+        
         let testCollection = TestWebSocketExporterCollection()
-        print("configure app")
         testCollection.configuration.configure(app)
-
-        print("create STV")
+        
         let visitor = SyntaxTreeVisitor(modelBuilder: SemanticModelBuilder(app))
-        print("accept STV")
         testService.accept(visitor)
-        print("finish parsing")
         visitor.finishParsing()
-
-        print("start app")
+        
         try app.start()
-
-        print("create client")
+        
         let client = StatelessClient(on: app.eventLoopGroup.next())
-
+        
         let userId = "1234"
-
+        
         // without name parameter
         struct InvalidUserHandlerInput: Encodable {
             let userId: String
         }
-
-        print("client.resolve")
+        
         XCTAssertThrowsError(try client.resolve(one: InvalidUserHandlerInput(userId: userId), on: "user.:userId:").wait() as User)
-        print("check")
         let forwardedApodiniError = try XCTUnwrap(forwardedError as? ApodiniError)
         XCTAssertEqual(forwardedApodiniError.option(for: .errorType), .badInput)
     }


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Remove `___` suffixes from implicitly created wrapper proto types

## :recycle: Current situation & Problem
The gRPC interface exporter sometimes needs to generate proto message types for things like collecting handler inputs or wrapping handler response values.
These types currently were created using a `{HandlerName}___{Suffix}` pattern, with the suffix being for example `Input`.
The initial reason for this was to avoid conflicts with user-defined types that may have the same name.


## :bulb: Proposed solution
We remove the underscores, and instead have a proper check for such name clashes. They can be avoided by setting, via the handler's metadata, an explicit typename to be used by the gRPC interface exporter. Such metadata definitions are available for both input and output wrapper types.
Alternatively, this issue of conflicting type names can also be avoided by changing the name of the not-auto-generated type, e.g. by directly changing its name within the Swift type system, or via a conformance to the `ProtoTypeWithCustomProtoName` protocol. (This isn't something new, but an existing solution to this problem.)


## :gear: Release Notes 
- gRPC Interface Exporter:
  - Changed protobuffer message typename generation to no longer use `___` underscores for auto-generated wrapper types.
  - Added `HandlerInputProtoMessageName` and `HandlerResponseProtoMessageName` metadata definitions for explicitly specifying the typenames of a `Handler`'s implicitly generated input and/or output proto message types.
- GraphQL Interface Exporter:
  - Added custom scalar types for commonly-used Swift types such as `Date`, `URL`, or `Data`
    - `Date` objects are represented as ISO8601-encoded strings
    - `URL` objects are represented as strings containing the full and absolute URL
    - `Data` objects are represented as base-64 encoded strings
  - Added custom scalar types for Swift's integer types with > 32 bits
    - the `Int64` scalar type maps to Swift's `Int` and `Int64` types
    - the `UInt64` scalar type maps to Swift's `UInt` and `UInt64` types
    - (we're assuming that Apodini is running on a 64-bit system here, which should be fine since the probability of someone running Apodini on an old Apple Watch is rather low...)
    - There is a flag to disable these custom 64-bit Int scalars, which will cause the GraphQL interface exporter to throw an error instead. (This option is exposed via the `enableCustom64BitIntScalars` flag in the `GraphQL` configuration type)


## :heavy_plus_sign: Additional Information
n/a

### Related PRs
n/a


### Testing
The existing gRPC tests have been adjusted to contain a handler with the new metadata options set, thus testing that the user-defined options, if specified, are picked up correctly.


### Reviewer Nudging
*Where should the reviewer start, where is a good entry point?*
The code.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
