### PR TITLE
Fix the TestWebService tests

### DIFF
--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -77,6 +77,6 @@ jobs:
       run: |
           swift build -c ${{ matrix.configuration }}
           .build/${{ matrix.configuration }}/TestWebService &
-          sleep 60
+          sleep 10
           sh test.sh
           kill -9 $(lsof -ti:80)

--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Run ${{ matrix.configuration }} build
       run: |
           swift build -c ${{ matrix.configuration }}
-          swift run -c ${{ matrix.configuration }} &
+          .build/${{ matrix.configuration }}/TestWebService &
           sleep 60
           sh test.sh
           kill -9 $(lsof -ti:80)


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Fix the TestWebService tests

## :recycle: Current situation & Problem
The TestWebService tests currently randomly fail, with curl being unable to connect to the started web service.
I'm not actually 100% sure how this is caused, but the issue seems to be that somehow the `swift run` command takes a long time to start the TestWebService, or somehow waits until after curl has already run.

## :bulb: Proposed solution
This PR hopes to fix this by simply launching the TestWebService directly (instead of going through `swift run`).

## :gear: Release Notes 
_n/a_

## :heavy_plus_sign: Additional Information
_n/a_

### Related PRs
_n/a_

### Testing
This change should ideally improve testing.

### Reviewer Nudging
_n/a_

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
