### PR TITLE
Fix the AWS Lambda Deployment Provider

### DIFF
--- a/Sources/AWSLambdaDeploymentProvider/Commands/DeployWebServiceCommand.swift
+++ b/Sources/AWSLambdaDeploymentProvider/Commands/DeployWebServiceCommand.swift
@@ -162,7 +162,7 @@ struct LambdaDeploymentProviderImpl: DeploymentProvider {
                 let data = try Data(contentsOf: tmpDirUrl.appendingPathComponent("WebServiceStructure.json", isDirectory: false), options: [])
                 return try JSONDecoder().decode(LambdaDeployedSystem.self, from: data)
             } else {
-                return try retrieveDeployedSystem(usingDockerImage: dockerImageName)
+                return try retrieveDeployedSystem(usingDockerImage: dockerImageName, awsApiGatewayApiId: awsApiGatewayApiId)
             }
         }()
         Context.logger.notice("Successfully generated web service structure")
@@ -254,7 +254,7 @@ struct LambdaDeploymentProviderImpl: DeploymentProvider {
         try task.launchSyncAndAssertSuccess()
     }
     
-    private func retrieveDeployedSystem(usingDockerImage dockerImageName: String) throws -> LambdaDeployedSystem {
+    private func retrieveDeployedSystem(usingDockerImage dockerImageName: String, awsApiGatewayApiId: String) throws -> LambdaDeployedSystem {
         let filename = "WebServiceStructure.json"
         let filePath = ".build/\(tmpDirName)/\(filename)"
         try runInDocker(


### PR DESCRIPTION
# Fix the AWS Lambda Deployment Provider

## :recycle: Current situation & Problem
The API Gateway was not correctly passed to the web service when extracting the web service structure.

## :bulb: Proposed solution
We use the unwrapped version of the API Gateway ID.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
