### PR TITLE
Fix some ProtobufferCoding bugs

### DIFF
--- a/Sources/ApodiniGRPC/ProtoPrinter.swift
+++ b/Sources/ApodiniGRPC/ProtoPrinter.swift
@@ -176,8 +176,12 @@ struct ProtoPrinter {
         case .LABEL_REPEATED:
             write("repeated ")
         case .LABEL_REQUIRED:
-            precondition(self.fileDescriptor!.syntax == "proto2")
+            precondition(self.fileDescriptor?.syntax == ProtoSyntax.proto2.rawValue)
             write("required ")
+        }
+        
+        if self.fileDescriptor?.syntax == ProtoSyntax.proto3.rawValue && descriptor.proto3Optional {
+            write("optional ")
         }
         
         switch descriptor.type {

--- a/Sources/ProtobufferCoding/Decoding/Decoder.swift
+++ b/Sources/ProtobufferCoding/Decoding/Decoder.swift
@@ -51,7 +51,7 @@ public struct ProtobufferDecoder {
         }
         let decoder = _ProtobufferDecoder(codingPath: [], buffer: buffer)
         let keyedDecoder = try decoder.container(keyedBy: FixedCodingKey.self)
-        return try keyedDecoder.decode(T.self, forKey: .init(intValue: fieldInfo.fieldNumber))
+        return try keyedDecoder.decode(T.self, forKey: .init(intValue: fieldInfo.fieldNumber, stringValue: fieldInfo.name))
     }
 }
 

--- a/Sources/ProtobufferCoding/Decoding/KeyedDecodingContainer.swift
+++ b/Sources/ProtobufferCoding/Decoding/KeyedDecodingContainer.swift
@@ -194,7 +194,11 @@ struct ProtobufferDecoderKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingCo
     func getFieldInfoAndBytes(forKey key: Key, atOffset keyOffset: Int?) throws -> (fieldInfo: ProtobufFieldInfo, fieldBytes: ByteBuffer) {
         let fieldNumber = key.getProtoFieldNumber()
         guard fieldNumber > 0 else {
-            fatalError("Invalid field number: \(fieldNumber)")
+            throw DecodingError.keyNotFound(key, .init(
+                codingPath: self.codingPath.appending(key),
+                debugDescription: "CodingKey \(key) has an invalid proto field number \(fieldNumber), must be > 0.",
+                underlyingError: nil
+            ))
         }
         let fieldInfo: ProtobufFieldInfo?
         if let keyOffset = keyOffset {
@@ -203,7 +207,11 @@ struct ProtobufferDecoderKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingCo
             fieldInfo = fields.getLast(forFieldNumber: fieldNumber)
         }
         guard let fieldInfo = fieldInfo else {
-            fatalError("Unable to get field info")
+            throw DecodingError.keyNotFound(key, .init(
+                codingPath: self.codingPath.appending(key),
+                debugDescription: "Unable to find corresponding proto message field",
+                underlyingError: nil
+            ))
         }
         return (fieldInfo, buffer.getSlice(at: fieldInfo.keyOffset, length: fieldInfo.fieldLength)!)
     }

--- a/Sources/ProtobufferCoding/Helpers.swift
+++ b/Sources/ProtobufferCoding/Helpers.swift
@@ -8,20 +8,36 @@
 
 import Foundation
 
-/// A helper type conforming to `CodingKey` that does not support string-based coding keys,
+/// A helper type conforming to `CodingKey` that does not necessarily support string-based coding keys,
 /// and will always return the same `intValue`.
 struct FixedCodingKey: CodingKey {
-    /// Guaranteed to be non-nil, but has to be nullable to satisfy the `CodingKey` protocol
-    let intValue: Int?
+    private let _intValue: Int
+    private let _stringValue: String?
     
     init(intValue: Int) {
-        self.intValue = intValue
+        self._intValue = intValue
+        self._stringValue = nil
+    }
+    
+    init(intValue: Int, stringValue: String) {
+        self._intValue = intValue
+        self._stringValue = stringValue
     }
     
     init?(stringValue: String) {
         fatalError("Not supported. Provide an integer")
     }
-    var stringValue: String {
-        fatalError("Not supported")
+    
+    /// Guaranteed to be non-nil, but has to be nullable to satisfy the `CodingKey` protocol
+    var intValue: Int? { _intValue }
+    /// Has to be non-nil to satisfy the `CodingKey` protocol. Will crash if there is no underlying string value.
+    var stringValue: String { _stringValue! }
+    
+    var description: String {
+        "\(Self.self)(intValue: \(_intValue), stringValue: \(_stringValue))"
+    }
+    
+    var debugDescription: String {
+        description
     }
 }


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Fix some ProtobufferCoding bugs

## :recycle: Current situation & Problem
The ProtobufferCoding target currently contains some bugs, for example #424 and #425.

## :bulb: Proposed solution
We should fix the bugs

## :gear: Release Notes 
- ApodiniGRPC:
  - Fix issue where the generated proto schema files would mark optional fields as such only for proto2 types, but not proto3 types
  - Fix issue where attempting to decode a non-existent field would, in some circumstances, result in a crash, thus shutting down the entire web service. Now throws an error instead.
  - Fix issue where Apodini constructing an ApodiniError object with an error message containing (via string interpolation) another error object, which happens to be a `DecodingError` object with a `CodingKey` property where this `CodingKey` is a `FixedCodingKey`, would result in the `DecodingError`'s `debugDescription` property getting called, which in turn would try to produce a string description for the contained `FixedCodingKey`, which would go through `CodingKey`'s conformance to `DebugStringConvertible`, where the default implementation for `debugDescription` would try to access the `FixedCodingKey`'s `stringValue` property, which we had replaced with a `fatalError`, would result in a crash.
  - Improved quality of errors thrown when attempting to decoding non-existent fields, by also including the field's name in the error message (instead of just the field number)


## :heavy_plus_sign: Additional Information
n/a

### Related PRs
- Fixes #424
- Fixes #425 

### Testing
n/a

### Reviewer Nudging
n/a

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
