### PR TITLE
Swift 5.6 Compatibility

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,11 +15,9 @@ on:
 jobs:
   build_and_test:
     name: Build and Test
-    uses: Apodini/.github/.github/workflows/build-and-test.yml@v1
+    uses: Apodini/.github/.github/workflows/build-and-test.yml@main
     with:
       packagename: Apodini
-      testdocc: false
-      supportsmacos11: false
       aptgetdependencies: libsqlite3-dev
       yumdependencies: sqlite-devel
       installgrpcurl: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build_and_test:
     name: Build and Test
-    uses: Apodini/.github/.github/workflows/build-and-test.yml@main
+    uses: Apodini/.github/.github/workflows/build-and-test.yml@v1
     with:
       packagename: Apodini
       aptgetdependencies: libsqlite3-dev

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,11 +17,9 @@ on:
 jobs:
   build_and_test:
     name: Build and Test
-    uses: Apodini/.github/.github/workflows/build-and-test.yml@v1
+    uses: Apodini/.github/.github/workflows/build-and-test.yml@main
     with:
       packagename: Apodini
-      testdocc: false
-      supportsmacos11: false
       aptgetdependencies: libsqlite3-dev
       yumdependencies: sqlite-devel
       installgrpcurl: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build_and_test:
     name: Build and Test
-    uses: Apodini/.github/.github/workflows/build-and-test.yml@main
+    uses: Apodini/.github/.github/workflows/build-and-test.yml@v1
     with:
       packagename: Apodini
       aptgetdependencies: libsqlite3-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ on:
 jobs:
   docs:
     name: Generate Docs
-    uses: Apodini/.github/.github/workflows/docs.yml@v1
+    uses: Apodini/.github/.github/workflows/docs.yml@main
     with:
-      packagename: Apodini
+      targetname: Apodini
   docker-build-and-push:
     name: Docker Build and Push
     uses: Apodini/.github/.github/workflows/docker-build-and-push.yml@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   docs:
     name: Generate Docs
-    uses: Apodini/.github/.github/workflows/docs.yml@main
+    uses: Apodini/.github/.github/workflows/docs.yml@feature/docc
     with:
       targetname: Apodini
   docker-build-and-push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   docs:
     name: Generate Docs
-    uses: Apodini/.github/.github/workflows/docs.yml@feature/docc
+    uses: Apodini/.github/.github/workflows/docs.yml@v1
     with:
       targetname: Apodini
   docker-build-and-push:

--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   macos:
     name: macOS ${{ matrix.configuration }}
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "cbf533073d9a5edfb16c266d14151f69137ba7c9",
-          "version": "1.8.2"
+          "revision": "7a4dfe026f6ee0f8ad741b58df74c60af296365d",
+          "version": "1.9.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-kit.git",
         "state": {
           "branch": null,
-          "revision": "d5273e8d050c51dd7e1d3a4dab08fe32ec9ffffa",
-          "version": "1.20.0"
+          "revision": "3c06388997a1ee72e97bcd752aff47d5b64722f5",
+          "version": "1.23.2"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/grpc/grpc-swift.git",
         "state": {
           "branch": null,
-          "revision": "5cc08ebf77e68598bfe4c793927d0f2838598607",
-          "version": "1.6.1"
+          "revision": "593fe0fe931f7e838969243cd137be48e8055b1d",
+          "version": "1.7.3"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/adam-fowler/jmespath.swift.git",
         "state": {
           "branch": null,
-          "revision": "4a166ea71f0d9e9cc3523fc3dee516080a4c36a0",
-          "version": "1.0.0"
+          "revision": "4513d319c4aaa6c3b2ac18e1e6566a803515ad91",
+          "version": "1.0.2"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/vapor/jwt-kit.git",
         "state": {
           "branch": null,
-          "revision": "1822bb0abf0a31a4b5078ec19061c548835253b5",
-          "version": "4.3.0"
+          "revision": "5f9c44d4c196cc06c3fc601f279169f121d6f62d",
+          "version": "4.4.0"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/soto-project/soto-core.git",
         "state": {
           "branch": null,
-          "revision": "a216ea49b9ff2480ccbc5880b1aa648032433798",
-          "version": "5.9.2"
+          "revision": "3079d17f2576cff5f2a3f68865629af455c673d1",
+          "version": "5.9.3"
         }
       },
       {
@@ -204,8 +204,8 @@
         "repositoryURL": "https://github.com/soto-project/soto-s3-file-transfer",
         "state": {
           "branch": null,
-          "revision": "6a35d736753d46f5dc76712855428de412967d94",
-          "version": "0.4.0"
+          "revision": "74899d6e9b95cfb9543993ece6aa56796cf6ba80",
+          "version": "0.4.2"
         }
       },
       {
@@ -303,8 +303,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "a8911e0fadc25aef1071d582355bd1037a176060",
-          "version": "2.0.4"
+          "revision": "067254c79435de759aeef4a6a03e43d087d61312",
+          "version": "2.0.5"
         }
       },
       {
@@ -332,6 +332,15 @@
           "branch": null,
           "revision": "9a2884a37f39e08ebd225627c400feae9c6ea8df",
           "version": "0.1.1"
+        }
+      },
+      {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin.git",
+        "state": {
+          "branch": null,
+          "revision": "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+          "version": "1.0.0"
         }
       },
       {
@@ -375,8 +384,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "51c3fc2e4a0fcdf4a25089b288dd65b73df1b0ef",
-          "version": "2.37.0"
+          "revision": "d6e3762e0a5f7ede652559f53623baf11006e17c",
+          "version": "2.39.0"
         }
       },
       {
@@ -393,8 +402,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "6e94a7be32891d1b303a3fcfde8b5bf64d162e74",
-          "version": "1.19.1"
+          "revision": "50c25c132b140e62b45e90b5a76f13ded02c8a46",
+          "version": "1.20.1"
         }
       },
       {
@@ -402,8 +411,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "52a486ff6de9bc3e26bf634c5413c41c5fa89ca5",
-          "version": "2.17.2"
+          "revision": "b5260a31c2a72a89fa684f5efb3054d8725a2316",
+          "version": "2.18.0"
         }
       },
       {
@@ -429,8 +438,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "7e2c5f3cbbeea68e004915e3a8961e20bd11d824",
-          "version": "1.18.0"
+          "revision": "e1499bc69b9040b29184f7f2996f7bab467c1639",
+          "version": "1.19.0"
         }
       },
       {
@@ -438,8 +447,8 @@
         "repositoryURL": "https://github.com/vapor/websocket-kit.git",
         "state": {
           "branch": null,
-          "revision": "ff8fbce837ef01a93d49c6fb49a72be0f150dac7",
-          "version": "2.3.0"
+          "revision": "e32033ad3c68ebec1b761bc961be7bd56bad02f8",
+          "version": "2.3.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -64,6 +64,7 @@ let package = Package(
         .library(name: "XCTApodiniNetworking", targets: ["XCTApodiniNetworking"])
     ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.16.0"),
         .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.1.0"),
         // Used by the `NotificationCenter` to send push notifications to `APNS`

--- a/Sources/Apodini/Components/Handler/Handler.swift
+++ b/Sources/Apodini/Components/Handler/Handler.swift
@@ -8,16 +8,22 @@
 
 import NIO
 
+
 /// A `Handler` is a `Component` which defines an endpoint and can handle requests.
 public protocol Handler: AnyHandlerMetadataBlock, Component {
     /// The type that is returned from the `handle()` method when the component handles a request. The return type of the `handle` method is encoded into the response send out to the client.
     associatedtype Response: ResponseTransformable
-
+    
+#if compiler(>=5.6)
+    typealias Metadata = any AnyHandlerMetadata
+#else
     typealias Metadata = AnyHandlerMetadata
-
+#endif
+    
     /// A function that is called when a request reaches the `Handler`
     func handle() async throws -> Response
 }
+
 
 // MARK: Metadata DSL
 public extension Handler {
@@ -26,6 +32,7 @@ public extension Handler {
         Empty()
     }
 }
+
 
 extension Handler {
     /// By default, `Handler`s don't provide any further content

--- a/Sources/Apodini/WebService.swift
+++ b/Sources/Apodini/WebService.swift
@@ -13,11 +13,16 @@ import ArgumentParser
 
 /// Each Apodini program consists of a `WebService`component that is used to describe the Web API of the Web Service
 public protocol WebService: AnyWebServiceMetadataBlock, Component, ConfigurationCollection, ParsableCommand {
+#if compiler(>=5.6)
+    typealias Metadata = any AnyWebServiceMetadata
+#else
     typealias Metadata = AnyWebServiceMetadata
+#endif
     
     /// An empty initializer used to create an Apodini `WebService`
     init()
 }
+
 
 // MARK: Metadata DSL
 public extension WebService {
@@ -26,6 +31,7 @@ public extension WebService {
         Empty()
     }
 }
+
 
 extension WebService {
     /// Overrides  the `main()` method of `ParsableCommand` from the Swift ArgumentParser


### PR DESCRIPTION
# Swift 5.6 compatibility

## :recycle: Current situation & Problem
Apodini does not support Swift 5.6 (see also #430)

## :bulb: Proposed solution
We add support for Swift 5.6

## :gear: Release Notes 
- Added support for Swift 5.6, Fixes #430.

### Reviewer Nudging
Would be nice if someone with more Swift 5.6 knowledge than I have could give some feedback on whether this is the correct approach.