### PR TITLE
Refine the Hostname and Port Configuration Selection Logic

### DIFF
--- a/Sources/Apodini/Configurations/HTTPConfiguration.swift
+++ b/Sources/Apodini/Configurations/HTTPConfiguration.swift
@@ -75,7 +75,7 @@ public final class HTTPConfiguration: Configuration {
             self.bindAddress = .interface(Defaults.bindAddress, port: defaultPort)
         }
         
-        // We use the port from the bindAddress as the default port for the hostname, taking presicence over the defailt HTTP port
+        // We use the port from the bindAddress as the default port for the hostname, taking precedence over the default HTTP port.
         if case let .interface(_, port) = self.bindAddress {
             defaultPort = port ?? defaultPort
         }

--- a/Sources/Apodini/Configurations/HTTPConfiguration.swift
+++ b/Sources/Apodini/Configurations/HTTPConfiguration.swift
@@ -74,6 +74,11 @@ public final class HTTPConfiguration: Configuration {
         default:
             self.bindAddress = .interface(Defaults.bindAddress, port: defaultPort)
         }
+        
+        // We use the port from the bindAddress as the default port for the hostname, taking presicence over the defailt HTTP port
+        if case let .interface(_, port) = self.bindAddress {
+            defaultPort = port ?? defaultPort
+        }
 
         if let hostname = hostname {
             switch (hostname.address, hostname.port) {

--- a/Sources/ApodiniMigration/ApodiniMigratorInterfaceExporter.swift
+++ b/Sources/ApodiniMigration/ApodiniMigratorInterfaceExporter.swift
@@ -105,21 +105,13 @@ final class ApodiniMigratorInterfaceExporter: InterfaceExporter, LifecycleHandle
         }
         self.webService = nil
 
-        let httpAddress: String
-        let httpPort: Int?
-        if case let .interface(address, port) = app.httpConfiguration.bindAddress {
-            httpAddress = address
-            httpPort = port
-        } else {
-            httpAddress = app.httpConfiguration.hostname.address
-            httpPort = app.httpConfiguration.hostname.port
-        }
+        let httpAddress = app.httpConfiguration.hostname.address
+        let httpPort = app.httpConfiguration.hostname.port ?? (app.httpConfiguration.tlsConfiguration == nil ? HTTPConfiguration.Defaults.httpPort : HTTPConfiguration.Defaults.httpsPort)
 
         let http = HTTPInformation(
             protocol: app.httpConfiguration.tlsConfiguration != nil ? .https : .http,
             hostname: httpAddress,
             port: httpPort
-                ?? (app.httpConfiguration.tlsConfiguration == nil ? HTTPConfiguration.Defaults.httpPort : HTTPConfiguration.Defaults.httpsPort)
         )
 
         let serviceInformation = ServiceInformation(


### PR DESCRIPTION
# Refine the Hostname and Port Configuration Selection Logic

## :recycle: Current situation & Problem

The Apodini Migrator currently uses the bind address as the hostname for the API document and, therefore, the client library generation. This is, e.g., a problem when a developer uses a web service in a docker container (requires the docker IP address or wildcard 0.0.0.0) or does not provide a bind address that is not the wildcard address (0.0.0.0) the Apodini Migrator uses this bind address which is not usable for outside connections.

In addition, the port number specified by the bind address does not take prescience over the default HTTP port if there is no explicit port defined by the hostname.


## :bulb: Proposed solution

The Apodini HTTP Configuration offers the hostname configuration for this exact purpose. We should use this configuration. This PR proposes to change the hostname port assignment by using the bind address port before the default port if provided by the developer. 

## :gear: Release Notes 

- Changes the behavior that the bind address port does take prescience over the default HTTP port if there is no explicit port defined by the hostname. 
- The Apodini Migrator uses the hostname for the hostname in the API document instead of the bind address.

### Related PRs
A problem occurred in https://github.com/Apodini/ApodiniMigratorExample/pull/3 lead to the detection of this problem.

### Testing
Added an additional unit test.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
