### PR TITLE
Fix Schedule GitHub Action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: MIT
 #
 
-name: Push
+name: Build and Test
 
 on:
   push:

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -28,10 +28,8 @@ jobs:
     - name: Update Swift Packages Test Web Service
       run: swift package update
       working-directory: ./TestWebService
-    - name: Test Git Setup
-      run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git status
+    - name: Add Safe Directory
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -29,7 +29,9 @@ jobs:
       run: swift package update
       working-directory: ./TestWebService
     - name: Test Git Setup
-      run: git status
+      run: |
+          git config --global --add safe.directory /__w/Apodini/Apodini
+          git status
     - uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -28,6 +28,11 @@ jobs:
     - name: Update Swift Packages Test Web Service
       run: swift package update
       working-directory: ./TestWebService
+    - name: Test Git Setup
+      run: |
+        ls -la
+        git status
+        git remote
     - uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -29,10 +29,7 @@ jobs:
       run: swift package update
       working-directory: ./TestWebService
     - name: Test Git Setup
-      run: |
-        ls -la
-        git status
-        git remote
+      run: git status
     - uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -30,7 +30,7 @@ jobs:
       working-directory: ./TestWebService
     - name: Test Git Setup
       run: |
-          git config --global --add safe.directory /__w/Apodini/Apodini
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git status
     - uses: peter-evans/create-pull-request@v4
       with:

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -20,7 +20,7 @@ jobs:
       image: swift:focal
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check Swift version
       run: swift --version
     - name: Update Swift Packages

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Update Swift Packages Test Web Service
       run: swift package update
       working-directory: ./TestWebService
-    - uses: peter-evans/create-pull-request@v3
+    - uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
         commit-message: Update dependencies


### PR DESCRIPTION
# Fix Schedule GitHub Action

## :recycle: Current situation & Problem
The GitHub Action to run a Swift Package Manager update fails at the moment: https://github.com/Apodini/Apodini/actions/runs/2217337880

## :bulb: Proposed solution
This PR updates the GitHub Action to work again. The issue is related to the [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/) and adds the GitHub Workspace as a safe directory before the create PR GitHub Action is called. 

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
