### PR TITLE
Fix NIOExtras dependency

### DIFF
--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -42,23 +42,17 @@ jobs:
           swift --version
     - name: Run ${{ matrix.configuration }} build
       run: swift build -c ${{ matrix.configuration }}
-    - name: Start port 80 TestWebService
-      run: swift run -c ${{ matrix.configuration }} TestWebService &
-      shell: bash
     - name: Test HTTP/1.1
-      run: bash test.sh
+      run: |
+        swift run -c ${{ matrix.configuration }} TestWebService &
+        bash test.sh
+        kill -9 $(lsof -ti:80)
       shell: bash
-    - name: Kill port 80 TestWebService
-      run: kill -9 $(lsof -ti:80)
-      shell: bash
-    - name: Start port 4443 TestWebService
-      run: swift run -c ${{ matrix.configuration }} TestWebService --https-config ./Sources/TestWebService/Resources/localhost.cer.pem,./Sources/TestWebService/Resources/localhost.key.pem --port 4443 &
     - name: Test HTTP/2
-      run: bash testhttp2.sh
-      shell: bash
-    - name: Kill port 4443 TestWebService
-      run: kill -9 $(lsof -ti:4443)
-      shell: bash
+      run: |
+        swift run -c ${{ matrix.configuration }} TestWebService --https-config ./Sources/TestWebService/Resources/localhost.cer.pem,./Sources/TestWebService/Resources/localhost.key.pem --port 4443 &
+        bash testhttp2.sh
+        kill -9 $(lsof -ti:4443)
 
   linux:
     name: Linux ${{ matrix.linux }} ${{ matrix.configuration }}
@@ -92,19 +86,14 @@ jobs:
       run: yum update -y --nobest && yum install -y curl lsof python3
     - name: Run ${{ matrix.configuration }} build
       run: swift build -c ${{ matrix.configuration }}
-    - name: Start port 80 TestWebService & Test
+    - name: Test HTTP/1.1
       run: |
         swift run -c ${{ matrix.configuration }} TestWebService &
         bash test.sh
+        kill -9 $(lsof -ti:80)
       shell: bash
-    - name: Kill port 80 TestWebService
-      run: kill -9 $(lsof -ti:80)
-      shell: bash
-    - name: Start port 4443 TestWebService
-      run: swift run -c ${{ matrix.configuration }} TestWebService --https-config ./Sources/TestWebService/Resources/localhost.cer.pem,./Sources/TestWebService/Resources/localhost.key.pem --port 4443 &
     - name: Test HTTP/2
-      run: bash testhttp2.sh
-      shell: bash
-    - name: Kill port 4443 TestWebService
-      run: kill -9 $(lsof -ti:4443)
-      shell: bash
+      run: |
+        swift run -c ${{ matrix.configuration }} TestWebService --https-config ./Sources/TestWebService/Resources/localhost.cer.pem,./Sources/TestWebService/Resources/localhost.key.pem --port 4443 &
+        bash testhttp2.sh
+        kill -9 $(lsof -ti:4443)

--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -93,9 +93,7 @@ jobs:
       run: swift build -c ${{ matrix.configuration }}
     - name: Start port 80 TestWebService
       run: |
-        nohup swift run -c ${{ matrix.configuration }} TestWebService
-        sleep 30
-        cat nohup.out
+        nohup swift run -c ${{ matrix.configuration }} TestWebService &
     - name: Test HTTP/1.1
       run: bash test.sh
       shell: bash

--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -93,9 +93,9 @@ jobs:
       run: swift build -c ${{ matrix.configuration }}
     - name: Start port 80 TestWebService
       run: |
-        swift run -c ${{ matrix.configuration }} TestWebService > log.txt &
-        sleep 10
-        cat log.txt
+        nohup swift run -c ${{ matrix.configuration }} TestWebService
+        sleep 30
+        cat nohup.out
     - name: Test HTTP/1.1
       run: bash test.sh
       shell: bash

--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -92,7 +92,10 @@ jobs:
     - name: Run ${{ matrix.configuration }} build
       run: swift build -c ${{ matrix.configuration }}
     - name: Start port 80 TestWebService
-      run: swift run -c ${{ matrix.configuration }} TestWebService &
+      run: |
+        swift run -c ${{ matrix.configuration }} TestWebService > log.txt &
+        sleep 10
+        cat log.txt
     - name: Test HTTP/1.1
       run: bash test.sh
       shell: bash

--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -92,12 +92,10 @@ jobs:
       run: yum update -y --nobest && yum install -y curl lsof python3
     - name: Run ${{ matrix.configuration }} build
       run: swift build -c ${{ matrix.configuration }}
-    - name: Start port 80 TestWebService
+    - name: Start port 80 TestWebService & Test
       run: |
         swift run -c ${{ matrix.configuration }} TestWebService &
-      shell: bash
-    - name: Test HTTP/1.1
-      run: bash test.sh
+        bash test.sh
       shell: bash
     - name: Kill port 80 TestWebService
       run: kill -9 $(lsof -ti:80)

--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -44,6 +44,7 @@ jobs:
       run: swift build -c ${{ matrix.configuration }}
     - name: Start port 80 TestWebService
       run: swift run -c ${{ matrix.configuration }} TestWebService &
+      shell: bash
     - name: Test HTTP/1.1
       run: bash test.sh
       shell: bash
@@ -93,7 +94,8 @@ jobs:
       run: swift build -c ${{ matrix.configuration }}
     - name: Start port 80 TestWebService
       run: |
-        nohup swift run -c ${{ matrix.configuration }} TestWebService &
+        swift run -c ${{ matrix.configuration }} TestWebService &
+      shell: bash
     - name: Test HTTP/1.1
       run: bash test.sh
       shell: bash

--- a/.github/workflows/run-test-web-service.yml
+++ b/.github/workflows/run-test-web-service.yml
@@ -42,24 +42,23 @@ jobs:
           swift --version
     - name: Run ${{ matrix.configuration }} build
       run: swift build -c ${{ matrix.configuration }}
+    - name: Start port 80 TestWebService
+      run: swift run -c ${{ matrix.configuration }} TestWebService &
     - name: Test HTTP/1.1
-      run: |
-          exec 3< <(swift run -c ${{ matrix.configuration }} TestWebService)
-          sed '/info org.apodini.application : Server starting on/q' <&3 ; cat <&3 &
-          bash test.sh
+      run: bash test.sh
       shell: bash
     - name: Kill port 80 TestWebService
       run: kill -9 $(lsof -ti:80)
       shell: bash
+    - name: Start port 4443 TestWebService
+      run: swift run -c ${{ matrix.configuration }} TestWebService --https-config ./Sources/TestWebService/Resources/localhost.cer.pem,./Sources/TestWebService/Resources/localhost.key.pem --port 4443 &
     - name: Test HTTP/2
-      run: |
-          exec 3< <(swift run -c ${{ matrix.configuration }} TestWebService --https-config ./Sources/TestWebService/Resources/localhost.cer.pem,./Sources/TestWebService/Resources/localhost.key.pem --port 4443)
-          sed '/info org.apodini.application : Server starting on/q' <&3 ; cat <&3 &
-          bash testhttp2.sh
+      run: bash testhttp2.sh
       shell: bash
     - name: Kill port 4443 TestWebService
       run: kill -9 $(lsof -ti:4443)
       shell: bash
+
   linux:
     name: Linux ${{ matrix.linux }} ${{ matrix.configuration }}
     container:
@@ -92,20 +91,18 @@ jobs:
       run: yum update -y --nobest && yum install -y curl lsof python3
     - name: Run ${{ matrix.configuration }} build
       run: swift build -c ${{ matrix.configuration }}
+    - name: Start port 80 TestWebService
+      run: swift run -c ${{ matrix.configuration }} TestWebService &
     - name: Test HTTP/1.1
-      run: |
-          exec 3< <(swift run -c ${{ matrix.configuration }} TestWebService)
-          sed '/info org.apodini.application : Server starting on/q' <&3 ; cat <&3 &
-          bash test.sh
+      run: bash test.sh
       shell: bash
     - name: Kill port 80 TestWebService
       run: kill -9 $(lsof -ti:80)
       shell: bash
+    - name: Start port 4443 TestWebService
+      run: swift run -c ${{ matrix.configuration }} TestWebService --https-config ./Sources/TestWebService/Resources/localhost.cer.pem,./Sources/TestWebService/Resources/localhost.key.pem --port 4443 &
     - name: Test HTTP/2
-      run: |
-          exec 3< <(swift run -c ${{ matrix.configuration }} TestWebService --https-config ./Sources/TestWebService/Resources/localhost.cer.pem,./Sources/TestWebService/Resources/localhost.key.pem --port 4443)
-          sed '/info org.apodini.application : Server starting on/q' <&3 ; cat <&3 &
-          bash testhttp2.sh
+      run: bash testhttp2.sh
       shell: bash
     - name: Kill port 4443 TestWebService
       run: kill -9 $(lsof -ti:4443)

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/Apodini/ApodiniDocumentExport.git",
       "state" : {
         "revision" : "7de65b4c81929b56eadad190b11f02cf42ff9afe",
-        "version" : "0.1.0"
+        "version" : "0.1.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "794dc9d42720af97cedd395e8cd2add9173ffd9a",
-        "version" : "1.11.1"
+        "revision" : "fc510a39cff61b849bf5cdff17eb2bd6d0777b49",
+        "version" : "1.11.5"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent-kit.git",
       "state" : {
-        "revision" : "c49398ff06fc293a6a6f897bba4adf43544c7d0a",
-        "version" : "1.33.0"
+        "revision" : "38670d2eefcba27530272946d627ac8d4e45f017",
+        "version" : "1.35.1"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GraphQLSwift/GraphQL",
       "state" : {
-        "revision" : "283cc4de56b994a00b2724328221b7a1bc846ddc",
-        "version" : "2.2.1"
+        "revision" : "17b96ed859072fca79dd562da2a79e1bc752756f",
+        "version" : "2.4.1"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
-        "revision" : "d772b688d718c2eb29f99b535fc4d92ebba031c5",
-        "version" : "1.8.1"
+        "revision" : "d114c5ec34015bab663b3b7afaa7d6197656e47e",
+        "version" : "1.9.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/jwt-kit.git",
       "state" : {
-        "revision" : "aa7d9cd805b10c1ca17dfc53062ffbc695469cf4",
-        "version" : "4.6.1"
+        "revision" : "87ce13a1df913ba4d51cf00606df7ef24d455571",
+        "version" : "4.7.0"
       }
     },
     {
@@ -230,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sql-kit.git",
       "state" : {
-        "revision" : "89b0a0a5f110e77272fb5a775064a31bfc1f155c",
-        "version" : "3.18.0"
+        "revision" : "3c5413a229bc2abc962dab17ea66d25e448ad344",
+        "version" : "3.21.0"
       }
     },
     {
@@ -277,6 +277,15 @@
       "state" : {
         "revision" : "83b23d940471b313427da226196661856f6ba3e0",
         "version" : "0.4.4"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+        "version" : "1.0.2"
       }
     },
     {
@@ -347,8 +356,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-        "version" : "1.4.2"
+        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
+        "version" : "1.4.4"
       }
     },
     {
@@ -383,8 +392,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "124119f0bb12384cef35aa041d7c3a686108722d",
-        "version" : "2.40.0"
+        "revision" : "b4e0a274f7f34210e97e2f2c50ab02a10b549250",
+        "version" : "2.41.1"
       }
     },
     {
@@ -392,8 +401,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "a75e92bde3683241c15df3dd905b7a6dcac4d551",
-        "version" : "1.12.1"
+        "revision" : "5334d949febb396a4e2e5235e9fbcd9c3c014bb3",
+        "version" : "1.13.0"
       }
     },
     {
@@ -401,8 +410,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "108ac15087ea9b79abb6f6742699cf31de0e8772",
-        "version" : "1.22.0"
+        "revision" : "f9ab1c94c80d568efd762d2a638f25162691d766",
+        "version" : "1.22.1"
       }
     },
     {
@@ -410,8 +419,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "fd5f38b0039148e76c2e863a2fc868cc39bb451b",
-        "version" : "2.20.1"
+        "revision" : "a6f9a034e5903024c6bac4ce2c56b157688d844f",
+        "version" : "2.22.0"
       }
     },
     {
@@ -419,8 +428,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "2cb54f91ddafc90832c5fa247faf5798d0a7c204",
-        "version" : "1.13.0"
+        "revision" : "4e02d9cf35cabfb538c96613272fb027dd0c8692",
+        "version" : "1.13.1"
       }
     },
     {
@@ -437,8 +446,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "e1499bc69b9040b29184f7f2996f7bab467c1639",
-        "version" : "1.19.0"
+        "revision" : "b8230909dedc640294d7324d37f4c91ad3dcf177",
+        "version" : "1.20.1"
       }
     },
     {
@@ -446,8 +455,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/websocket-kit.git",
       "state" : {
-        "revision" : "d8230eae70650652661f360f322db0cc22955b2f",
-        "version" : "2.5.0"
+        "revision" : "2d9d2188a08eef4a869d368daab21b3c08510991",
+        "version" : "2.6.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -133,7 +133,10 @@ let package = Package(
         .package(url: "https://github.com/Apodini/ApodiniDocumentExport.git", .upToNextMinor(from: "0.1.0")),
         
         // Apodini Audit
-        .package(url: "https://github.com/pvieito/PythonKit.git", from: "0.2.2")
+        .package(url: "https://github.com/pvieito/PythonKit.git", from: "0.2.2"),
+
+        // XCTApodiniNetworking
+        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0")
     ],
     targets: [
         .target(name: "CApodiniUtils"),
@@ -488,7 +491,8 @@ let package = Package(
                 .target(name: "XCTUtils"),
                 .target(name: "Apodini"),
                 .target(name: "ApodiniNetworking"),
-                .product(name: "AsyncHTTPClient", package: "async-http-client")
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "NIOExtras", package: "swift-nio-extras")
             ]
         ),
 

--- a/TestWebService/Package.resolved
+++ b/TestWebService/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/Apodini/ApodiniDocumentExport.git",
       "state" : {
         "revision" : "7de65b4c81929b56eadad190b11f02cf42ff9afe",
-        "version" : "0.1.0"
+        "version" : "0.1.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "794dc9d42720af97cedd395e8cd2add9173ffd9a",
-        "version" : "1.11.1"
+        "revision" : "fc510a39cff61b849bf5cdff17eb2bd6d0777b49",
+        "version" : "1.11.5"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent-kit.git",
       "state" : {
-        "revision" : "f5ae02083656d1218cc32ad10c0608c040b4d22c",
-        "version" : "1.30.0"
+        "revision" : "38670d2eefcba27530272946d627ac8d4e45f017",
+        "version" : "1.35.1"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GraphQLSwift/GraphQL",
       "state" : {
-        "revision" : "283cc4de56b994a00b2724328221b7a1bc846ddc",
-        "version" : "2.2.1"
+        "revision" : "17b96ed859072fca79dd562da2a79e1bc752756f",
+        "version" : "2.4.1"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
-        "revision" : "d772b688d718c2eb29f99b535fc4d92ebba031c5",
-        "version" : "1.8.1"
+        "revision" : "d114c5ec34015bab663b3b7afaa7d6197656e47e",
+        "version" : "1.9.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/jwt-kit.git",
       "state" : {
-        "revision" : "718e94f917a4c053758e5bb50c28553561a6ef91",
-        "version" : "4.6.0"
+        "revision" : "87ce13a1df913ba4d51cf00606df7ef24d455571",
+        "version" : "4.7.0"
       }
     },
     {
@@ -230,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sql-kit.git",
       "state" : {
-        "revision" : "89b0a0a5f110e77272fb5a775064a31bfc1f155c",
-        "version" : "3.18.0"
+        "revision" : "3c5413a229bc2abc962dab17ea66d25e448ad344",
+        "version" : "3.21.0"
       }
     },
     {
@@ -277,6 +277,15 @@
       "state" : {
         "revision" : "83b23d940471b313427da226196661856f6ba3e0",
         "version" : "0.4.4"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+        "version" : "1.0.2"
       }
     },
     {
@@ -338,8 +347,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-        "version" : "1.4.2"
+        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
+        "version" : "1.4.4"
       }
     },
     {
@@ -365,8 +374,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "124119f0bb12384cef35aa041d7c3a686108722d",
-        "version" : "2.40.0"
+        "revision" : "b4e0a274f7f34210e97e2f2c50ab02a10b549250",
+        "version" : "2.41.1"
       }
     },
     {
@@ -374,8 +383,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "a75e92bde3683241c15df3dd905b7a6dcac4d551",
-        "version" : "1.12.1"
+        "revision" : "5334d949febb396a4e2e5235e9fbcd9c3c014bb3",
+        "version" : "1.13.0"
       }
     },
     {
@@ -383,8 +392,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "108ac15087ea9b79abb6f6742699cf31de0e8772",
-        "version" : "1.22.0"
+        "revision" : "f9ab1c94c80d568efd762d2a638f25162691d766",
+        "version" : "1.22.1"
       }
     },
     {
@@ -392,8 +401,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "42436a25ff32c390465567f5c089a9a8ce8d7baf",
-        "version" : "2.20.0"
+        "revision" : "a6f9a034e5903024c6bac4ce2c56b157688d844f",
+        "version" : "2.22.0"
       }
     },
     {
@@ -401,8 +410,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "2cb54f91ddafc90832c5fa247faf5798d0a7c204",
-        "version" : "1.13.0"
+        "revision" : "4e02d9cf35cabfb538c96613272fb027dd0c8692",
+        "version" : "1.13.1"
       }
     },
     {
@@ -419,8 +428,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "e1499bc69b9040b29184f7f2996f7bab467c1639",
-        "version" : "1.19.0"
+        "revision" : "b8230909dedc640294d7324d37f4c91ad3dcf177",
+        "version" : "1.20.1"
       }
     },
     {
@@ -428,8 +437,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/websocket-kit.git",
       "state" : {
-        "revision" : "d8230eae70650652661f360f322db0cc22955b2f",
-        "version" : "2.5.0"
+        "revision" : "2d9d2188a08eef4a869d368daab21b3c08510991",
+        "version" : "2.6.1"
       }
     },
     {

--- a/TestWebService/test.sh
+++ b/TestWebService/test.sh
@@ -8,5 +8,19 @@
 #
 
 set -e
-curl --fail http://localhost/
-curl --fail http://localhost/http
+INTERVAL=5
+TRIES=10
+
+# Send requests every 5 seconds
+COUNTER=0
+while [ $COUNTER != $TRIES ]
+do
+    sleep $INTERVAL
+    echo "Trying..."
+    curl --fail http://localhost/ &&
+    curl --fail http://localhost/http &&
+    exit 0
+    COUNTER=$[$COUNTER + 1]
+done
+
+exit 1

--- a/TestWebService/test.sh
+++ b/TestWebService/test.sh
@@ -9,7 +9,7 @@
 
 set -e
 INTERVAL=5
-TRIES=10
+TRIES=20
 
 # Send requests every 5 seconds
 COUNTER=0

--- a/TestWebService/testhttp2.sh
+++ b/TestWebService/testhttp2.sh
@@ -8,4 +8,18 @@
 #
 
 set -e
-curl --fail --insecure --request GET --data-binary "@teststreamingrequest" -H "Content-Type: application/data" --http2-prior-knowledge --output response https://localhost:4443/http/countdown
+INTERVAL=5
+TRIES=10
+
+# Send requests every 5 seconds
+COUNTER=0
+while [ $COUNTER != $TRIES ]
+do
+    sleep $INTERVAL
+    echo "Trying..."
+    curl --fail --insecure --request GET --data-binary "@teststreamingrequest" -H "Content-Type: application/data" --http2-prior-knowledge --output response https://localhost:4443/http/countdown &&
+    exit 0
+    COUNTER=$[$COUNTER + 1]
+done
+
+exit 1

--- a/TestWebService/testhttp2.sh
+++ b/TestWebService/testhttp2.sh
@@ -9,7 +9,7 @@
 
 set -e
 INTERVAL=5
-TRIES=10
+TRIES=20
 
 # Send requests every 5 seconds
 COUNTER=0

--- a/Tests/ApodiniObserveTests/ApodiniLoggerTests.swift
+++ b/Tests/ApodiniObserveTests/ApodiniLoggerTests.swift
@@ -324,7 +324,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #file)
+            XCTAssertEqual(logMessage.file, #filePath)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.requestResponseHandler1Line)
 
@@ -425,7 +425,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world!")
             XCTAssertEqual(logMessage.level, .debug)
-            XCTAssertEqual(logMessage.file, #file)
+            XCTAssertEqual(logMessage.file, #filePath)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.requestResponseHandler2Line)
 
@@ -520,7 +520,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #file)
+            XCTAssertEqual(logMessage.file, #filePath)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.requestResponseHandler3Line)
 
@@ -552,7 +552,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #file)
+            XCTAssertEqual(logMessage.file, #filePath)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.requestResponseHandler4Line)
 
@@ -616,7 +616,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #file)
+            XCTAssertEqual(logMessage.file, #filePath)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.requestResponseHandler5Line)
 
@@ -682,7 +682,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(firstLogMessage.message, "Hello world - Countdown!")
             XCTAssertEqual(firstLogMessage.level, .info)
-            XCTAssertEqual(firstLogMessage.file, #file)
+            XCTAssertEqual(firstLogMessage.file, #filePath)
             XCTAssertEqual(firstLogMessage.function, "handle()")
             XCTAssertEqual(firstLogMessage.line, Self.serverSideStreamingHandlerStreamingLine)
 
@@ -769,7 +769,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(eleventhLogMessage.message, "Hello world - Launch!")
             XCTAssertEqual(eleventhLogMessage.level, .info)
-            XCTAssertEqual(eleventhLogMessage.file, #file)
+            XCTAssertEqual(eleventhLogMessage.file, #filePath)
             XCTAssertEqual(eleventhLogMessage.function, "handle()")
             XCTAssertEqual(eleventhLogMessage.line, Self.serverSideStreamingHandlerFinalLine)
 
@@ -900,7 +900,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world - Streaming!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #file)
+            XCTAssertEqual(logMessage.file, #filePath)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.clientSideStreamingHandlerStreamingLine)
 
@@ -1128,7 +1128,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world - Streaming!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #file)
+            XCTAssertEqual(logMessage.file, #filePath)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.bidirectionalStreamingHandlerStreamingLine)
 

--- a/Tests/ApodiniObserveTests/ApodiniLoggerTests.swift
+++ b/Tests/ApodiniObserveTests/ApodiniLoggerTests.swift
@@ -324,7 +324,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #filePath)
+            XCTAssertEqual(logMessage.file, #fileID)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.requestResponseHandler1Line)
 
@@ -425,7 +425,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world!")
             XCTAssertEqual(logMessage.level, .debug)
-            XCTAssertEqual(logMessage.file, #filePath)
+            XCTAssertEqual(logMessage.file, #fileID)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.requestResponseHandler2Line)
 
@@ -520,7 +520,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #filePath)
+            XCTAssertEqual(logMessage.file, #fileID)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.requestResponseHandler3Line)
 
@@ -552,7 +552,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #filePath)
+            XCTAssertEqual(logMessage.file, #fileID)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.requestResponseHandler4Line)
 
@@ -616,7 +616,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #filePath)
+            XCTAssertEqual(logMessage.file, #fileID)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.requestResponseHandler5Line)
 
@@ -682,7 +682,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(firstLogMessage.message, "Hello world - Countdown!")
             XCTAssertEqual(firstLogMessage.level, .info)
-            XCTAssertEqual(firstLogMessage.file, #filePath)
+            XCTAssertEqual(firstLogMessage.file, #fileID)
             XCTAssertEqual(firstLogMessage.function, "handle()")
             XCTAssertEqual(firstLogMessage.line, Self.serverSideStreamingHandlerStreamingLine)
 
@@ -769,7 +769,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(eleventhLogMessage.message, "Hello world - Launch!")
             XCTAssertEqual(eleventhLogMessage.level, .info)
-            XCTAssertEqual(eleventhLogMessage.file, #filePath)
+            XCTAssertEqual(eleventhLogMessage.file, #fileID)
             XCTAssertEqual(eleventhLogMessage.function, "handle()")
             XCTAssertEqual(eleventhLogMessage.line, Self.serverSideStreamingHandlerFinalLine)
 
@@ -900,7 +900,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world - Streaming!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #filePath)
+            XCTAssertEqual(logMessage.file, #fileID)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.clientSideStreamingHandlerStreamingLine)
 
@@ -1128,7 +1128,7 @@ class ApodiniLoggerTests: XCTestCase {
             // Assert log message, level etc.
             XCTAssertEqual(logMessage.message, "Hello world - Streaming!")
             XCTAssertEqual(logMessage.level, .info)
-            XCTAssertEqual(logMessage.file, #filePath)
+            XCTAssertEqual(logMessage.file, #fileID)
             XCTAssertEqual(logMessage.function, "handle()")
             XCTAssertEqual(logMessage.line, Self.bidirectionalStreamingHandlerStreamingLine)
 


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

The ApodiniAuditLinguaWebService builds failed as NIOExtras wasn't avaliable from the XCTApodiniNetworking target. I am not sure why the builds were working normally here. Anyways, this should fix the error.